### PR TITLE
test: improve aclprocessor test coverage

### DIFF
--- a/src/CommonLib/ILDAPUtils.cs
+++ b/src/CommonLib/ILDAPUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Security.AccessControl;
 using System.DirectoryServices.ActiveDirectory;
 using System.DirectoryServices.Protocols;
 using System.Threading;
@@ -87,5 +88,9 @@ namespace SharpHoundCommonLib
             string[] props, string domainName = null, bool includeAcl = false, bool showDeleted = false, string adsPath = null, bool globalCatalog = false, bool skipCache = false);
 
         Forest GetForest(string domainName = null);
+
+        ActiveDirectorySecurityDescriptor MakeSecurityDescriptor();
     }
+
+
 }

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -6,6 +6,7 @@ using System.DirectoryServices.Protocols;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
 using System.Threading;
@@ -15,6 +16,7 @@ using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
+using ActiveDirectorySecurity = System.DirectoryServices.ActiveDirectorySecurity;
 using Domain = System.DirectoryServices.ActiveDirectory.Domain;
 
 namespace SharpHoundCommonLib
@@ -1118,5 +1120,11 @@ namespace SharpHoundCommonLib
 
             return domainName.ToUpper();
         }
+
+        public ActiveDirectorySecurityDescriptor MakeSecurityDescriptor()
+        {
+            return new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+        }   
     }
+
 }

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -297,11 +297,11 @@ namespace SharpHoundCommonLib.Processors
             var rawAllowedToAct = entry.GetByteProperty("msDS-AllowedToActOnBehalfOfOtherIdentity");
             if (rawAllowedToAct != null)
             {
-                var sd = new ActiveDirectorySecurity();
+                var sd = _utils.MakeSecurityDescriptor();
                 sd.SetSecurityDescriptorBinaryForm(rawAllowedToAct, AccessControlSections.Access);
-                foreach (ActiveDirectoryAccessRule rule in sd.GetAccessRules(true, true, typeof(SecurityIdentifier)))
+                foreach (ActiveDirectoryRuleDescriptor rule in sd.GetAccessRules(true, true, typeof(SecurityIdentifier)))
                 {
-                    var res = _utils.ResolveIDAndType(rule.IdentityReference.Value, domain);
+                    var res = _utils.ResolveIDAndType(rule.IdentityReference(), domain);
                     allowedToActPrincipals.Add(res);
                 }
             }

--- a/src/CommonLib/SecurityDescriptor.cs
+++ b/src/CommonLib/SecurityDescriptor.cs
@@ -1,0 +1,105 @@
+using SharpHoundCommonLib.Processors;
+using System;
+using System.Collections.Generic;
+using System.DirectoryServices;
+using System.Security.AccessControl;
+using AccessControlSections = System.Security.AccessControl.AccessControlSections;
+
+namespace SharpHoundCommonLib
+{
+
+    public class ActiveDirectoryRuleDescriptor
+    {
+        private ActiveDirectoryAccessRule _inner;
+
+        public ActiveDirectoryRuleDescriptor(ActiveDirectoryAccessRule inner) => _inner = inner;
+
+        public virtual AccessControlType AccessControlType()
+        {
+            return _inner.AccessControlType;
+        }
+
+        public virtual string IdentityReference()
+        {
+            return _inner.IdentityReference.Value;
+        }
+
+        public virtual bool IsInherited()
+        {
+            return _inner.IsInherited;
+        }
+
+        public virtual bool IsAceInheritedFrom(string guid)
+        {
+            //Check if the ace is inherited
+            var isInherited = _inner.IsInherited;
+
+            //The inheritedobjecttype needs to match the guid of the object type being enumerated or the guid for All
+            var inheritedType = _inner.InheritedObjectType.ToString();
+            isInherited = isInherited && (inheritedType == ACEGuids.AllGuid || inheritedType == guid);
+
+            //Special case for Exchange
+            //If the ACE is not Inherited and is not an inherit-only ace, then it's set by exchange for reasons
+            if (!isInherited && (_inner.PropagationFlags & PropagationFlags.InheritOnly) != PropagationFlags.InheritOnly &&
+                !_inner.IsInherited)
+            {
+                isInherited = true;
+            }
+
+            return isInherited;
+        }
+
+        public virtual ActiveDirectoryRights ActiveDirectoryRights()
+        {
+            return _inner.ActiveDirectoryRights;
+        }
+
+        public virtual Guid ObjectType()
+        {
+            return _inner.ObjectType;
+        }
+    }
+
+    public class ActiveDirectorySecurityDescriptor
+    {
+
+        private ActiveDirectorySecurity _sd;
+
+        public ActiveDirectorySecurityDescriptor(ActiveDirectorySecurity sd)
+        {
+            _sd = sd;
+        }
+
+        public virtual bool AreAccessRulesProtected()
+        {
+            return _sd.AreAccessRulesProtected;
+        }
+
+        public virtual List<ActiveDirectoryRuleDescriptor> GetAccessRules(bool includeExplicit, bool includeInherited, Type targetType) {
+
+            var result = new List<ActiveDirectoryRuleDescriptor>();
+            foreach (ActiveDirectoryAccessRule ace in _sd.GetAccessRules(includeExplicit, includeInherited, targetType))
+            {
+                result.Add(new ActiveDirectoryRuleDescriptor(ace));
+            }
+
+            return result;
+        }
+
+        public virtual void SetSecurityDescriptorBinaryForm(byte[] binaryForm)
+        {
+            _sd.SetSecurityDescriptorBinaryForm(binaryForm);
+        }
+
+        public virtual void SetSecurityDescriptorBinaryForm(byte[] binaryForm, AccessControlSections type)
+        {
+            _sd.SetSecurityDescriptorBinaryForm(binaryForm, type);
+        }
+
+        public virtual string GetOwner(Type targetType)
+        {
+            return _sd.GetOwner(targetType).Value;
+        }
+        
+    }
+}

--- a/test/unit/Facades/FacadeHelpers.cs
+++ b/test/unit/Facades/FacadeHelpers.cs
@@ -7,16 +7,19 @@ namespace CommonLibTest.Facades
     {
         const BindingFlags nonPublicInstance = BindingFlags.NonPublic | BindingFlags.Instance;
         const BindingFlags publicInstance = BindingFlags.Public | BindingFlags.Instance;
-        
+
         internal static T GetUninitializedObject<T>()
         {
-            return (T) FormatterServices.GetUninitializedObject(typeof(T));
+            return (T)FormatterServices.GetUninitializedObject(typeof(T));
         }
-        
+
         internal static void SetProperty<T1, T2>(T1 obj, string propertyName, T2 propertyValue)
         {
             var set = typeof(T1).GetField(propertyName, nonPublicInstance);
-            set.SetValue(obj, propertyValue);
+            if (set != null)
+            {
+                set.SetValue(obj, propertyValue);
+            }
         }
     }
 }

--- a/test/unit/Facades/MockLDAPUtils.cs
+++ b/test/unit/Facades/MockLDAPUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.AccessControl;
 using System.DirectoryServices.ActiveDirectory;
 using System.DirectoryServices.Protocols;
 using System.Threading;
@@ -7,6 +8,7 @@ using System.Threading.Tasks;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
+using Moq;
 
 namespace CommonLibTest.Facades
 {
@@ -973,6 +975,12 @@ namespace CommonLibTest.Facades
         public Forest GetForest(string domainName = null)
         {
             return _forest;
+        }
+
+        public ActiveDirectorySecurityDescriptor MakeSecurityDescriptor()
+        {
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>();
+            return mockSecurityDescriptor.Object;
         }
     }
 }


### PR DESCRIPTION
- Created wrapper classes to improve testability
- Added factory method to ILdapUtils to return security descriptor wrapper
- Boosted ACLProcessor coverage to ~92%