### PR TITLE
Add an option to disable LDAPS Certificate verification

### DIFF
--- a/src/CommonLib/LDAPConfig.cs
+++ b/src/CommonLib/LDAPConfig.cs
@@ -10,6 +10,7 @@ namespace SharpHoundCommonLib
         public int Port { get; set; } = 0;
         public bool SSL { get; set; } = false;
         public bool DisableSigning { get; set; } = false;
+        public bool DisableCertVerification { get; set; } = false;
         public AuthType AuthType { get; set; } = AuthType.Kerberos;
 
         public int GetPort()

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -1238,6 +1238,9 @@ namespace SharpHoundCommonLib
             if (_ldapConfig.SSL)
                 connection.SessionOptions.SecureSocketLayer = true;
             
+            if (_ldapConfig.DisableCertVerification)
+                connection.SessionOptions.VerifyServerCertificate = (ldapConnection, certificate) => true;
+
             connection.AuthType = authType;
 
             if (!skipCache)


### PR DESCRIPTION
By default, DotNet (which SharpHound uses) perform strong verification of LDAPS TLS certificates. 
This is unlike `bloodhound-python` which [does not verify SSL](https://github.com/cannatag/ldap3/blob/master/ldap3/core/tls.py#L73) on its queries. 

DotNet TLS verification [is notoriously tricky](https://stackoverflow.com/questions/58165262/net-program-does-not-get-validated-server-certificate), and [sometimes fail](https://stackoverflow.com/questions/28761249/x509certificate2-verify-returns-false-always) even trough the certificate is perfectly valid (For instance, because the CRL cannot be reached or because TLS 1.3 can't be used..). This can be a problem when running bloodhound in LDAPS-only environments.

This PR add an option to disable verification of the TLS certificate when doing LDAPS queries

(Related to https://github.com/BloodHoundAD/SharpHound/pull/24)