### PR TITLE
Update PortScanner.cs

### DIFF
--- a/src/CommonLib/Processors/PortScanner.cs
+++ b/src/CommonLib/Processors/PortScanner.cs
@@ -27,7 +27,7 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="port"></param>
         /// <param name="timeout">Timeout in milliseconds</param>
         /// <returns>True if port is open, otherwise false</returns>
-        public virtual async Task<bool> CheckPort(string hostname, int port = 445, int timeout = 500)
+        public virtual async Task<bool> CheckPort(string hostname, int port = 445, int timeout = 2000)
         {
             var key = new PingCacheKey
             {


### PR DESCRIPTION
change default value from 1/2 second to 2 seconds.
Fixes https://github.com/BloodHoundAD/BloodHound/issues/548
