### PR TITLE
Add AddAllowedToAct logic based on User Account Restrictions property set

### DIFF
--- a/src/CommonLib/EdgeNames.cs
+++ b/src/CommonLib/EdgeNames.cs
@@ -19,5 +19,6 @@
         public const string WriteSPN = "WriteSPN";
         public const string AddKeyCredentialLink = "AddKeyCredentialLink";
         public const string SQLAdmin = "SQLAdmin";
+        public const string WriteAccountRestrictions = "WriteAccountRestrictions";
     }
 }

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -10,5 +10,6 @@
         public const string WriteAllowedToAct = "3f78c3e5-f79a-46bd-a0b8-9d18116ddc79";
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";
+        public const string UserAccountRestrictions = "4c164200-20c0-11d0-a768-00aa006e0529";
     }
 }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -349,7 +349,7 @@ namespace SharpHoundCommonLib.Processors
                             IsInherited = inherited,
                             RightName = EdgeNames.WriteSPN
                         };
-                    else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
+                    else if (objectType == Label.Computer && (aceType == ACEGuids.WriteAllowedToAct || aceType == ACEGuids.UserAccountRestrictions) && !resolvedPrincipal.ObjectIdentifier.EndsWith("-512"))
                         yield return new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -349,13 +349,21 @@ namespace SharpHoundCommonLib.Processors
                             IsInherited = inherited,
                             RightName = EdgeNames.WriteSPN
                         };
-                    else if (objectType == Label.Computer && (aceType == ACEGuids.WriteAllowedToAct || aceType == ACEGuids.UserAccountRestrictions) && !resolvedPrincipal.ObjectIdentifier.EndsWith("-512"))
+                    else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
                         yield return new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,
                             IsInherited = inherited,
                             RightName = EdgeNames.AddAllowedToAct
+                        };
+                    else if (objectType == Label.Computer && aceType == ACEGuids.UserAccountRestrictions && !resolvedPrincipal.ObjectIdentifier.EndsWith("-512"))
+                        yield return new ACE
+                        {
+                            PrincipalType = resolvedPrincipal.ObjectType,
+                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                            IsInherited = inherited,
+                            RightName = EdgeNames.WriteAccountRestrictions
                         };
                     else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
                         yield return new ACE


### PR DESCRIPTION
This property set contains the `msDS-AllowedToActOnBehalfOfOtherIdentity` property so if you have write privs on this set you can configure RBCD.

Will add a link to a blog soon with more context.