### PR TITLE
Support exceptions in QueryLDAP methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,11 +131,7 @@ tags
 # Visual Studio Code
 ################
 
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode
 *.code-workspace
 
 # Local History for Visual Studio Code

--- a/src/CommonLib/Exceptions/SharpHoundCommonException.cs
+++ b/src/CommonLib/Exceptions/SharpHoundCommonException.cs
@@ -1,10 +1,11 @@
 using System;
 
-namespace SharpHoundCommonLib.Exceptions;
-
-public class SharpHoundCommonException : Exception
+namespace SharpHoundCommonLib.Exceptions
 {
-    public SharpHoundCommonException() { }
-    public SharpHoundCommonException(string message) : base(message) { }
-    public SharpHoundCommonException(string message, Exception inner) : base(message, inner) { }
+    public class SharpHoundCommonException : Exception
+    {
+        public SharpHoundCommonException() { }
+        public SharpHoundCommonException(string message) : base(message) { }
+        public SharpHoundCommonException(string message, Exception inner) : base(message, inner) { }
+    }
 }

--- a/src/CommonLib/Exceptions/SharpHoundCommonException.cs
+++ b/src/CommonLib/Exceptions/SharpHoundCommonException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SharpHoundCommonLib.Exceptions;
+
+public class SharpHoundCommonException : Exception
+{
+    public SharpHoundCommonException() { }
+    public SharpHoundCommonException(string message) : base(message) { }
+    public SharpHoundCommonException(string message, Exception inner) : base(message, inner) { }
+}

--- a/src/CommonLib/Exceptions/SharpHoundCommonException.cs
+++ b/src/CommonLib/Exceptions/SharpHoundCommonException.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace SharpHoundCommonLib.Exceptions
 {
-    public class SharpHoundCommonException : Exception
+    public class LDAPQueryException : Exception
     {
-        public SharpHoundCommonException() { }
-        public SharpHoundCommonException(string message) : base(message) { }
-        public SharpHoundCommonException(string message, Exception inner) : base(message, inner) { }
+        public LDAPQueryException() { }
+        public LDAPQueryException(string message) : base(message) { }
+        public LDAPQueryException(string message, Exception inner) : base(message, inner) { }
     }
 }

--- a/src/CommonLib/ILDAPUtils.cs
+++ b/src/CommonLib/ILDAPUtils.cs
@@ -24,6 +24,7 @@ namespace SharpHoundCommonLib
         public string AdsPath;
         public bool GlobalCatalog;
         public bool SkipCache;
+        public bool ThrowException;
     }
 
     public interface ILDAPUtils
@@ -98,10 +99,12 @@ namespace SharpHoundCommonLib
         ///     Skip the connection cache and force a new connection. You must dispose of this connection
         ///     yourself.
         /// </param>
+        /// <param name="throwException">Throw exceptions rather than logging the errors directly</param>
         /// <returns>All LDAP search results matching the specified parameters</returns>
         IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope,
             string[] props, CancellationToken cancellationToken, string domainName = null, bool includeAcl = false,
-            bool showDeleted = false, string adsPath = null, bool globalCatalog = false, bool skipCache = false);
+            bool showDeleted = false, string adsPath = null, bool globalCatalog = false, bool skipCache = false,
+            bool throwException = false);
 
         /// <summary>
         ///     Performs an LDAP query using the parameters specified by the user.
@@ -118,10 +121,11 @@ namespace SharpHoundCommonLib
         ///     Skip the connection cache and force a new connection. You must dispose of this connection
         ///     yourself.
         /// </param>
+        /// <param name="throwException">Throw exceptions rather than logging the errors directly</param>
         /// <returns>All LDAP search results matching the specified parameters</returns>
         IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope,
             string[] props, string domainName = null, bool includeAcl = false, bool showDeleted = false,
-            string adsPath = null, bool globalCatalog = false, bool skipCache = false);
+            string adsPath = null, bool globalCatalog = false, bool skipCache = false, bool throwException = false);
 
         Forest GetForest(string domainName = null);
 

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -648,8 +648,8 @@ namespace SharpHoundCommonLib
         ///     Skip the connection cache and force a new connection. You must dispose of this connection
         ///     yourself.
         /// </param>
-        /// <returns>Tuple of LdapConnection, SearchRequest, PageResultRequestControl and SharpHoundCommonException</returns>
-        public Tuple<LdapConnection, SearchRequest, PageResultRequestControl, SharpHoundCommonException> SetupLDAPQueryFilter(string ldapFilter,
+        /// <returns>Tuple of LdapConnection, SearchRequest, PageResultRequestControl and LDAPQueryException</returns>
+        public Tuple<LdapConnection, SearchRequest, PageResultRequestControl, LDAPQueryException> SetupLDAPQueryFilter(string ldapFilter,
             SearchScope scope, string[] props, bool includeAcl = false, string domainName = null, bool showDeleted = false,
             string adsPath = null, bool globalCatalog = false, bool skipCache = false)
         {
@@ -668,16 +668,16 @@ namespace SharpHoundCommonLib
             {
                 var errorString = String.Format("Exception getting LDAP connection for {0} and domain {1}", ldapFilter,
                     domainName ?? "Default Domain");
-                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, SharpHoundCommonException>(
-                    null, null, null, new SharpHoundCommonException(errorString, e));
+                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, LDAPQueryException>(
+                    null, null, null, new LDAPQueryException(errorString, e));
             }
 
             if (conn == null)
             {
                 var errorString = String.Format("LDAP connection is null for filter {0} and domain {1}", ldapFilter,
                     domainName ?? "Default Domain");
-                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, SharpHoundCommonException>(
-                    null, null, null, new SharpHoundCommonException(errorString));
+                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, LDAPQueryException>(
+                    null, null, null, new LDAPQueryException(errorString));
             }
 
             var request = CreateSearchRequest(ldapFilter, scope, props, domainName, adsPath, showDeleted);
@@ -686,8 +686,8 @@ namespace SharpHoundCommonLib
             {
                 var errorString = String.Format("Search request is null for filter {0} and domain {1}", ldapFilter,
                     domainName ?? "Default Domain");
-                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, SharpHoundCommonException>(
-                    null, null, null, new SharpHoundCommonException(errorString));
+                return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, LDAPQueryException>(
+                    null, null, null, new LDAPQueryException(errorString));
             }
 
             var pageControl = new PageResultRequestControl(500);
@@ -699,7 +699,7 @@ namespace SharpHoundCommonLib
                     SecurityMasks = SecurityMasks.Dacl | SecurityMasks.Owner
                 });
 
-            return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, SharpHoundCommonException>(conn, request, pageControl, null);
+            return Tuple.Create<LdapConnection, SearchRequest, PageResultRequestControl, LDAPQueryException>(conn, request, pageControl, null);
         }
 
         /// <summary>
@@ -742,8 +742,8 @@ namespace SharpHoundCommonLib
         /// </param>
         /// <param name="throwException">Throw exceptions rather than logging the errors directly</param>
         /// <returns>All LDAP search results matching the specified parameters</returns>
-        /// <exception cref="SharpHoundCommonException">
-        ///     Thrown when an error occurs during LDAP query
+        /// <exception cref="LDAPQueryException">
+        ///     Thrown when an error occurs during LDAP query (only when throwException = true)
         /// </exception>
         public IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope,
             string[] props, CancellationToken cancellationToken, string domainName = null, bool includeAcl = false,
@@ -762,7 +762,7 @@ namespace SharpHoundCommonLib
             {
                 if (throwException)
                 {
-                    throw new SharpHoundCommonException("Failed to setup LDAP Query Filter", error);
+                    throw new LDAPQueryException("Failed to setup LDAP Query Filter", error);
                 }
                 else
                 {
@@ -790,7 +790,7 @@ namespace SharpHoundCommonLib
                     if (le.ErrorCode != 82)
                         if (throwException)
                         {
-                            throw new SharpHoundCommonException(String.Format(
+                            throw new LDAPQueryException(String.Format(
                                 "LDAP Exception in Loop: {0}. {1}. {2}. Filter: {3}. Domain: {4}.",
                                 le.ErrorCode, le.ServerErrorMessage, le.Message, ldapFilter, domainName), le);
                         }
@@ -807,7 +807,7 @@ namespace SharpHoundCommonLib
                 {
                     if (throwException)
                     {
-                        throw new SharpHoundCommonException(String.Format("Exception in LDAP loop for {0} and {1}",
+                        throw new LDAPQueryException(String.Format("Exception in LDAP loop for {0} and {1}",
                             ldapFilter, domainName));
                     }
                     else
@@ -856,8 +856,8 @@ namespace SharpHoundCommonLib
         /// </param>
         /// <param name="throwException">Throw exceptions rather than logging the errors directly</param>
         /// <returns>All LDAP search results matching the specified parameters</returns>
-        /// <exception cref="SharpHoundCommonException">
-        ///     Thrown when an error occurs during LDAP query
+        /// <exception cref="LDAPQueryException">
+        ///     Thrown when an error occurs during LDAP query (only when throwException = true)
         /// </exception>
         public IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope,
             string[] props, string domainName = null, bool includeAcl = false, bool showDeleted = false,
@@ -875,7 +875,7 @@ namespace SharpHoundCommonLib
             {
                 if (throwException)
                 {
-                    throw new SharpHoundCommonException("Failed to setup LDAP Query Filter", error);
+                    throw new LDAPQueryException("Failed to setup LDAP Query Filter", error);
                 }
                 else
                 {
@@ -901,7 +901,7 @@ namespace SharpHoundCommonLib
                     if (le.ErrorCode != 82)
                         if (throwException)
                         {
-                            throw new SharpHoundCommonException(String.Format(
+                            throw new LDAPQueryException(String.Format(
                                 "LDAP Exception in Loop: {0}. {1}. {2}. Filter: {3}. Domain: {4}",
                                 le.ErrorCode, le.ServerErrorMessage, le.Message, ldapFilter, domainName), le);
                         }
@@ -917,7 +917,7 @@ namespace SharpHoundCommonLib
                 {
                     if (throwException)
                     {
-                        throw new SharpHoundCommonException(String.Format(
+                        throw new LDAPQueryException(String.Format(
                             "Exception in LDAP loop for {0} and {1}", ldapFilter, domainName ?? "Default Domain"), e);
                     }
                     else

--- a/test/unit/ContainerProcessorTest.cs
+++ b/test/unit/ContainerProcessorTest.cs
@@ -100,7 +100,7 @@ namespace CommonLibTest
 
             mock.Setup(x => x.QueryLDAP(It.IsAny<string>(), It.IsAny<SearchScope>(), It.IsAny<string[]>(),
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>(),
-                It.IsAny<bool>())).Returns(searchResults);
+                It.IsAny<bool>(), It.IsAny<bool>())).Returns(searchResults);
 
             var processor = new ContainerProcessor(mock.Object);
             var test = processor.GetContainerChildObjects(_testGpLinkString).ToArray();

--- a/test/unit/DomainTrustProcessorTest.cs
+++ b/test/unit/DomainTrustProcessorTest.cs
@@ -39,7 +39,7 @@ namespace CommonLibTest
 
             mockUtils.Setup(x => x.QueryLDAP(It.IsAny<string>(), It.IsAny<SearchScope>(), It.IsAny<string[]>(),
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>(),
-                It.IsAny<bool>())).Returns(searchResults);
+                It.IsAny<bool>(), It.IsAny<bool>())).Returns(searchResults);
             var processor = new DomainTrustProcessor(mockUtils.Object);
             var test = processor.EnumerateDomainTrusts("testlab.local").ToArray();
             Assert.Single(test);
@@ -96,7 +96,7 @@ namespace CommonLibTest
 
             mockUtils.Setup(x => x.QueryLDAP(It.IsAny<string>(), It.IsAny<SearchScope>(), It.IsAny<string[]>(),
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>(),
-                It.IsAny<bool>())).Returns(searchResults);
+                It.IsAny<bool>(), It.IsAny<bool>())).Returns(searchResults);
             var processor = new DomainTrustProcessor(mockUtils.Object);
             var test = processor.EnumerateDomainTrusts("testlab.local");
             Assert.Empty(test);

--- a/test/unit/Facades/MockLDAPUtils.cs
+++ b/test/unit/Facades/MockLDAPUtils.cs
@@ -40,10 +40,10 @@ namespace CommonLibTest.Facades
             name = name.ToLower();
             return name switch
             {
-                "dfm" => new[] {"S-1-5-21-3130019616-2776909439-2417379446-1105"},
+                "dfm" => new[] { "S-1-5-21-3130019616-2776909439-2417379446-1105" },
                 "administrator" => new[]
                     {"S-1-5-21-3130019616-2776909439-2417379446-500", "S-1-5-21-3084884204-958224920-2707782874-500"},
-                "admin" => new[] {"S-1-5-21-3130019616-2776909439-2417379446-2116"},
+                "admin" => new[] { "S-1-5-21-3130019616-2776909439-2417379446-2116" },
                 _ => Array.Empty<string>()
             };
         }
@@ -1023,7 +1023,7 @@ namespace CommonLibTest.Facades
         public virtual IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope, string[] props,
             CancellationToken cancellationToken,
             string domainName = null, bool includeAcl = false, bool showDeleted = false, string adsPath = null,
-            bool globalCatalog = false, bool skipCache = false)
+            bool globalCatalog = false, bool skipCache = false, bool throwException = false)
         {
             throw new NotImplementedException();
         }
@@ -1031,7 +1031,7 @@ namespace CommonLibTest.Facades
         public virtual IEnumerable<ISearchResultEntry> QueryLDAP(string ldapFilter, SearchScope scope, string[] props,
             string domainName = null,
             bool includeAcl = false, bool showDeleted = false, string adsPath = null, bool globalCatalog = false,
-            bool skipCache = false)
+            bool skipCache = false, bool throwException = false)
         {
             throw new NotImplementedException();
         }
@@ -1049,7 +1049,7 @@ namespace CommonLibTest.Facades
 
         private Group GetBaseEnterpriseDC()
         {
-            var g = new Group {ObjectIdentifier = "TESTLAB.LOCAL-S-1-5-9".ToUpper()};
+            var g = new Group { ObjectIdentifier = "TESTLAB.LOCAL-S-1-5-9".ToUpper() };
             g.Properties.Add("name", "ENTERPRISE DOMAIN CONTROLLERS@TESTLAB.LOCAL".ToUpper());
             return g;
         }

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -122,6 +122,7 @@ namespace CommonLibTest
                 It.IsAny<bool>(),
                 It.IsAny<string>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>()
             )).Returns(new List<ISearchResultEntry>());
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
@@ -144,12 +145,12 @@ namespace CommonLibTest
             var mockSearchResults = new List<ISearchResultEntry>();
             mockSearchResults.Add(mockSearchResultEntry.Object);
             mockLDAPUtils.Setup(x => x.QueryLDAP(new LDAPQueryOptions
-                {
-                    Filter = "(samaccounttype=805306369)",
-                    Scope = SearchScope.Subtree,
-                    Properties = CommonProperties.ObjectSID,
-                    AdsPath = null
-                }))
+            {
+                Filter = "(samaccounttype=805306369)",
+                Scope = SearchScope.Subtree,
+                Properties = CommonProperties.ObjectSID,
+                AdsPath = null
+            }))
                 .Returns(mockSearchResults.ToArray());
 
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -144,13 +144,14 @@ namespace CommonLibTest
             mockSearchResultEntry.Setup(x => x.GetSid()).Returns("teapot");
             var mockSearchResults = new List<ISearchResultEntry>();
             mockSearchResults.Add(mockSearchResultEntry.Object);
-            mockLDAPUtils.Setup(x => x.QueryLDAP(new LDAPQueryOptions
-            {
-                Filter = "(samaccounttype=805306369)",
-                Scope = SearchScope.Subtree,
-                Properties = CommonProperties.ObjectSID,
-                AdsPath = null
-            }))
+            mockLDAPUtils.Setup(x => x.QueryLDAP(
+                new LDAPQueryOptions
+                {
+                    Filter = "(samaccounttype=805306369)",
+                    Scope = SearchScope.Subtree,
+                    Properties = CommonProperties.ObjectSID,
+                    AdsPath = null
+                }))
                 .Returns(mockSearchResults.ToArray());
 
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -117,7 +117,7 @@ namespace CommonLibTest
                 ThrowException = true
             };
 
-            Assert.Throws<SharpHoundCommonException>(
+            Assert.Throws<LDAPQueryException>(
                 () =>
                 {
                     foreach (var sre in _utils.QueryLDAP(null, new SearchScope(), null, new CancellationToken(), null, false, false, null, false, false, true))
@@ -126,7 +126,7 @@ namespace CommonLibTest
                     };
                 });
 
-            Assert.Throws<SharpHoundCommonException>(
+            Assert.Throws<LDAPQueryException>(
                 () =>
                 {
                     foreach (var sre in _utils.QueryLDAP(options))

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -3,6 +3,9 @@ using CommonLibTest.Facades;
 using Moq;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
+using SharpHoundCommonLib.Exceptions;
+using System.DirectoryServices.Protocols;
+using System.Threading;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -104,6 +107,64 @@ namespace CommonLibTest
             Assert.True(result);
             Assert.Equal(Label.Group, typedPrincipal.ObjectType);
             Assert.Equal($"{_testDomainName}-S-1-5-32-544", typedPrincipal.ObjectIdentifier);
+        }
+
+        [Fact]
+        public void QueryLDAP_With_Exception()
+        {
+            var options = new LDAPQueryOptions
+            {
+                ThrowException = true
+            };
+
+            Assert.Throws<SharpHoundCommonException>(
+                () =>
+                {
+                    foreach (var sre in _utils.QueryLDAP(null, new SearchScope(), null, new CancellationToken(), null, false, false, null, false, false, true))
+                    {
+                        // We shouldn't reach this anyway, and all we care about is if exceptions are bubbling
+                    };
+                });
+
+            Assert.Throws<SharpHoundCommonException>(
+                () =>
+                {
+                    foreach (var sre in _utils.QueryLDAP(options))
+                    {
+                        // We shouldn't reach this anyway, and all we care about is if exceptions are bubbling
+                    };
+                });
+        }
+
+        [Fact]
+        public void QueryLDAP_Without_Exception()
+        {
+            Exception exception;
+
+            var options = new LDAPQueryOptions
+            {
+                ThrowException = false
+            };
+
+            exception = Record.Exception(
+                () =>
+                {
+                    foreach (var sre in _utils.QueryLDAP(null, new SearchScope(), null, new CancellationToken()))
+                    {
+                        // We shouldn't reach this anyway, and all we care about is if exceptions are bubbling
+                    };
+                });
+            Assert.Null(exception);
+
+            exception = Record.Exception(
+                () =>
+                {
+                    foreach (var sre in _utils.QueryLDAP(options))
+                    {
+                        // We shouldn't reach this anyway, and all we care about is if exceptions are bubbling
+                    };
+                });
+            Assert.Null(exception);
         }
 
         #endregion


### PR DESCRIPTION
This pull request adds support for throwing exceptions in all `QueryLDAP()` methods. Because this is only a "sometimes applicable" feature for tracing exact problems, it adds an optional flag at the end of the method calls called `throwException`. The default behavior remains the same and will log errors exactly as before. However, when `throwException` is enabled, any code that pumps the iterator will need to catch exceptions.

Exceptions are of a new type `SharpHoundCommonException` and will contain the details that would typically be logged in normal operation. This will allow for calling code to examine exceptions and then make informed decisions on how to proceed. In the default configuration, a warning will be logged on any failure, but no additional results will be returned.

This pull request includes a basic test to ensure that both states of the flag work correctly (throwing an exception or not) and that they work with the "options" variant of `QueryLDAP`.