### PR TITLE
Fix for null sid values when resolving hosts to a sid

### DIFF
--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -468,7 +468,8 @@ namespace SharpHoundCommonLib
                     //Append the $ to indicate this is a computer
                     tempName = $"{tempName}$".ToUpper();
                     var principal = ResolveAccountName(tempName, tempDomain);
-                    if (principal != null)
+                    sid = principal?.ObjectIdentifier;
+                    if (sid != null)
                     {
                         _hostResolutionMap.TryAdd(strippedHost, sid);
                         return sid;


### PR DESCRIPTION
SharpHound does not populate session information due to a null value being assigned as the SID in some cases. This appears to be due to one step in the ResolveHostToSid function where the ObjectIdentifier from the returned TypedPrincipal object is not assigned to the sid variable before being stored in the _hostResolutionMap dictionary. This fix should match the previous behaviour observed in SharpHound3.