### PR TITLE
DumpSMSAPassword: collection and resolving of msds-hostserviceaccount

### DIFF
--- a/src/CommonLib/LDAPProperties.cs
+++ b/src/CommonLib/LDAPProperties.cs
@@ -46,5 +46,6 @@
         public const string UnicodePassword = "unicodepwd";
         public const string MsSFU30Password = "msSFU30Password";
         public const string ScriptPath = "scriptpath";
+        public const string HostServiceAccount = "msds-hostserviceaccount";
     }
 }

--- a/src/CommonLib/LDAPQueries/CommonProperties.cs
+++ b/src/CommonLib/LDAPQueries/CommonProperties.cs
@@ -39,7 +39,7 @@
             "operatingsystemservicepack", "serviceprincipalname", "displayname", "mail", "title",
             "homedirectory", "description", "admincount", "userpassword", "gpcfilesyspath", "objectclass",
             "msds-behavior-version", "objectguid", "name", "gpoptions", "msds-allowedToDelegateTo",
-            "msDS-AllowedToActOnBehalfOfOtherIdentity", "whenCreated"
+            "msDS-AllowedToActOnBehalfOfOtherIdentity", "whenCreated", "msds-hostserviceaccount"
         };
 
         public static readonly string[] ContainerProps =

--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -11,7 +11,7 @@ namespace SharpHoundCommonLib.OutputTypes
         public TypedPrincipal[] AllowedToDelegate { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] AllowedToAct { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] HasSIDHistory { get; set; } = Array.Empty<TypedPrincipal>();
-        public string[] SMSA { get; set; } = Array.Empty<string>();
+        public TypedPrincipal[] DumpSMSAPassword { get; set; } = Array.Empty<TypedPrincipal>();
         public SessionAPIResult Sessions { get; set; } = new();
         public SessionAPIResult PrivilegedSessions { get; set; } = new();
         public SessionAPIResult RegistrySessions { get; set; } = new();

--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -11,6 +11,7 @@ namespace SharpHoundCommonLib.OutputTypes
         public TypedPrincipal[] AllowedToDelegate { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] AllowedToAct { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] HasSIDHistory { get; set; } = Array.Empty<TypedPrincipal>();
+        public string[] SMSA { get; set; } = Array.Empty<string>();
         public SessionAPIResult Sessions { get; set; } = new();
         public SessionAPIResult PrivilegedSessions { get; set; } = new();
         public SessionAPIResult RegistrySessions { get; set; } = new();

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -377,16 +377,16 @@ namespace SharpHoundCommonLib.Processors
             props.Add("sidhistory", sidHistoryList.ToArray());
 
             var hsa = entry.GetArrayProperty(LDAPProperties.HostServiceAccount);
-            var smsaPrincipals = new List<string>();
+            var smsaPrincipals = new List<TypedPrincipal>();
             foreach (var dn in hsa)
             {
                 var resolvedPrincipal = _utils.ResolveDistinguishedName(dn);
 
                 if (resolvedPrincipal != null)
-                    smsaPrincipals.Add(resolvedPrincipal.ObjectIdentifier);
+                    smsaPrincipals.Add(resolvedPrincipal);
             }
 
-            compProps.SMSA = smsaPrincipals.ToArray();
+            compProps.DumpSMSAPassword = smsaPrincipals.ToArray();
 
             compProps.Props = props;
 
@@ -506,6 +506,6 @@ namespace SharpHoundCommonLib.Processors
         public TypedPrincipal[] AllowedToDelegate { get; set; }
         public TypedPrincipal[] AllowedToAct { get; set; }
         public TypedPrincipal[] SidHistory { get; set; }
-        public string[] SMSA { get; set; }
+        public TypedPrincipal[] DumpSMSAPassword { get; set; }
     }
 }

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -376,6 +376,18 @@ namespace SharpHoundCommonLib.Processors
 
             props.Add("sidhistory", sidHistoryList.ToArray());
 
+            var hsa = entry.GetArrayProperty(LDAPProperties.HostServiceAccount);
+            var smsaPrincipals = new List<string>();
+            foreach (var dn in hsa)
+            {
+                var resolvedPrincipal = _utils.ResolveDistinguishedName(dn);
+
+                if (resolvedPrincipal != null)
+                    smsaPrincipals.Add(resolvedPrincipal.ObjectIdentifier);
+            }
+
+            compProps.SMSA = smsaPrincipals.ToArray();
+
             compProps.Props = props;
 
             return compProps;
@@ -494,5 +506,6 @@ namespace SharpHoundCommonLib.Processors
         public TypedPrincipal[] AllowedToDelegate { get; set; }
         public TypedPrincipal[] AllowedToAct { get; set; }
         public TypedPrincipal[] SidHistory { get; set; }
+        public string[] SMSA { get; set; }
     }
 }

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -378,12 +378,15 @@ namespace SharpHoundCommonLib.Processors
 
             var hsa = entry.GetArrayProperty(LDAPProperties.HostServiceAccount);
             var smsaPrincipals = new List<TypedPrincipal>();
-            foreach (var dn in hsa)
+            if (hsa != null)
             {
-                var resolvedPrincipal = _utils.ResolveDistinguishedName(dn);
+                foreach (var dn in hsa)
+                {
+                    var resolvedPrincipal = _utils.ResolveDistinguishedName(dn);
 
-                if (resolvedPrincipal != null)
-                    smsaPrincipals.Add(resolvedPrincipal);
+                    if (resolvedPrincipal != null)
+                        smsaPrincipals.Add(resolvedPrincipal);
+                }
             }
 
             compProps.DumpSMSAPassword = smsaPrincipals.ToArray();

--- a/test/unit/LDAPPropertyTests.cs
+++ b/test/unit/LDAPPropertyTests.cs
@@ -531,6 +531,76 @@ namespace CommonLibTest
             Assert.Empty(props["sidhistory"] as string[]);
         }
 
+        [Fact]
+        public async Task LDAPPropertyProcessor_ReadComputerProperties_TestDumpSMSAPassword()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dWIN10,OU\u003dTestOU,DC\u003dtestlab,DC\u003dlocal",
+                new Dictionary<string, object>
+                {
+                    {"description", "Test"},
+                    {"useraccountcontrol", 0x1001000.ToString()},
+                    {"lastlogon", "132673011142753043"},
+                    {"lastlogontimestamp", "132670318095676525"},
+                    {"operatingsystem", "Windows 10 Enterprise"},
+                    {"operatingsystemservicepack", "1607"},
+                    {"admincount", "c"},
+                    {
+                        "sidhistory", new[]
+                        {
+                            Helpers.B64ToBytes("AQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQUQQAAA==")
+                        }
+                    },
+                    {
+                        "msds-allowedtodelegateto", new[]
+                        {
+                            "ldap/PRIMARY.testlab.local/testlab.local",
+                            "ldap/PRIMARY.testlab.local",
+                            "ldap/PRIMARY"
+                        }
+                    },
+                    {"pwdlastset", "132131667346106691"},
+                    {
+                        "serviceprincipalname", new[]
+                        {
+                            "WSMAN/WIN10",
+                            "WSMAN/WIN10.testlab.local",
+                            "RestrictedKrbHost/WIN10",
+                            "HOST/WIN10",
+                            "RestrictedKrbHost/WIN10.testlab.local",
+                            "HOST/WIN10.testlab.local"
+                        }
+                    },
+                    {
+                        "msds-hostserviceaccount", new[]
+                        {
+                            "CN=dfm,CN=Users,DC=testlab,DC=local",
+                            "CN=krbtgt,CN=Users,DC=testlab,DC=local"
+                        }
+                    }
+                }, "S-1-5-21-3130019616-2776909439-2417379446-1101", Label.Computer);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var test = await processor.ReadComputerProperties(mock);
+
+            var expected = new TypedPrincipal[]
+            {
+                new()
+                {
+                    ObjectIdentifier = "S-1-5-21-3130019616-2776909439-2417379446-1105",
+                    ObjectType = Label.User
+                },
+                new()
+                {
+                    ObjectIdentifier = "S-1-5-21-3130019616-2776909439-2417379446-502",
+                    ObjectType = Label.User
+                }
+            };
+
+            var testDumpSMSAPassword = test.DumpSMSAPassword;
+            Assert.Equal(2, testDumpSMSAPassword.Length);
+            Assert.Equal(expected, testDumpSMSAPassword);
+
+        }
         //TODO: Add coverage for ParseAllProperties
     }
 }


### PR DESCRIPTION
Collection of the attribute `msds-hostserviceaccount` on computer objects when reading properties. It is not added to the list of properties that are shown on the UI when viewing an object since it is only collected in order to build edges. The distinguished names contained in the attribute are resolved, and only object identifiers are returned to avoid bloating with unnecessary data.

For more info, see https://github.com/BloodHoundAD/BloodHound/issues/624.