### PR TITLE
Added option to do Session Enumeration as local Admin User

### DIFF
--- a/src/CommonLib/Impersonate.cs
+++ b/src/CommonLib/Impersonate.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using System.Xml.Linq;
+
+namespace Impersonate
+{
+    public enum LogonType
+    {
+        LOGON32_LOGON_INTERACTIVE = 2,
+        LOGON32_LOGON_NETWORK = 3,
+        LOGON32_LOGON_BATCH = 4,
+        LOGON32_LOGON_SERVICE = 5,
+        LOGON32_LOGON_UNLOCK = 7,
+        LOGON32_LOGON_NETWORK_CLEARTEXT = 8, // Win2K or higher
+        LOGON32_LOGON_NEW_CREDENTIALS = 9 // Win2K or higher
+    };
+
+    public enum LogonProvider
+    {
+        LOGON32_PROVIDER_DEFAULT = 0,
+        LOGON32_PROVIDER_WINNT35 = 1,
+        LOGON32_PROVIDER_WINNT40 = 2,
+        LOGON32_PROVIDER_WINNT50 = 3
+    };
+
+    public enum ImpersonationLevel
+    {
+        SecurityAnonymous = 0,
+        SecurityIdentification = 1,
+        SecurityImpersonation = 2,
+        SecurityDelegation = 3
+    }
+
+    class Win32NativeMethods
+    {
+        [DllImport("advapi32.dll", SetLastError = true)]
+        public static extern int LogonUser(string lpszUserName,
+             string lpszDomain,
+             string lpszPassword,
+             int dwLogonType,
+             int dwLogonProvider,
+             ref IntPtr phToken);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int DuplicateToken(IntPtr hToken,
+              int impersonationLevel,
+              ref IntPtr hNewToken);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern bool RevertToSelf();
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        public static extern bool CloseHandle(IntPtr handle);
+    }
+
+    /// <summary>
+    /// Allows code to be executed under the security context of a specified user account.
+    /// </summary>
+    /// <remarks> 
+    ///
+    /// Implements IDispose, so can be used via a using-directive or method calls;
+    ///  ...
+    ///
+    ///  var imp = new Impersonator( "myUsername", "myDomainname", "myPassword" );
+    ///  imp.UndoImpersonation();
+    ///
+    ///  ...
+    ///
+    ///   var imp = new Impersonator();
+    ///  imp.Impersonate("myUsername", "myDomainname", "myPassword");
+    ///  imp.UndoImpersonation();
+    ///
+    ///  ...
+    ///
+    ///  using ( new Impersonator( "myUsername", "myDomainname", "myPassword" ) )
+    ///  {
+    ///   ...
+    ///   1
+    ///   ...
+    ///  }
+    ///
+    ///  ...
+    /// </remarks>
+    public class Impersonator : IDisposable
+    {
+        private WindowsImpersonationContext _wic;
+ 
+  /// <summary>
+  /// Begins impersonation with the given credentials, Logon type and Logon provider.
+  /// </summary>
+  ///<param name = "userName" > Name of the user.</param>
+  ///<param name = "domainName" > Name of the domain.</param>
+  ///<param name = "password" > The password. <see cref = "System.String" /></ param >
+  ///< param name="logonType">Type of the logon.</param>
+  ///<param name = "logonProvider" > The logon provider. <see cref = "Mit.Sharepoint.WebParts.EventLogQuery.Network.LogonProvider" /></ param >
+     public Impersonator(string userName, string domainName, string password, LogonType logonType, LogonProvider logonProvider)
+        {
+            Impersonate(userName, domainName, password, logonType, logonProvider);
+        }
+ 
+  /// <summary>
+  /// Begins impersonation with the given credentials.
+  /// </summary>
+  ///<param name = "userName" > Name of the user.</param>
+  ///<param name = "domainName" > Name of the domain.</param>
+  ///<param name = "password" > The password. <see cref = "System.String" /></ param >
+     public Impersonator(string userName, string domainName, string password)
+        {
+            Impersonate(userName, domainName, password, LogonType.LOGON32_LOGON_INTERACTIVE, LogonProvider.LOGON32_PROVIDER_DEFAULT);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Impersonator"/> class.
+        /// </summary>
+        public Impersonator()
+        { }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            UndoImpersonation();
+        }
+ 
+  /// <summary>
+  /// Impersonates the specified user account.
+  /// </summary>
+  ///<param name = "userName" > Name of the user.</param>
+  ///<param name = "domainName" > Name of the domain.</param>
+  ///<param name = "password" > The password. <see cref = "System.String" /></ param >
+     public void Impersonate(string userName, string domainName, string password)
+        {
+            Impersonate(userName, domainName, password, LogonType.LOGON32_LOGON_INTERACTIVE, LogonProvider.LOGON32_PROVIDER_DEFAULT);
+        }
+ 
+  /// <summary>
+  /// Impersonates the specified user account.
+  /// </summary>
+  ///<param name = "userName" > Name of the user.</param>
+  ///<param name = "domainName" > Name of the domain.</param>
+  ///<param name = "password" > The password. <see cref = "System.String" /></ param >
+  ///< param name="logonType">Type of the logon.</param>
+  ///<param name = "logonProvider" > The logon provider. <see cref = "Mit.Sharepoint.WebParts.EventLogQuery.Network.LogonProvider" /></ param >
+     public void Impersonate(string userName, string domainName, string password, LogonType logonType, LogonProvider logonProvider)
+        {
+            UndoImpersonation();
+
+            IntPtr logonToken = IntPtr.Zero;
+            IntPtr logonTokenDuplicate = IntPtr.Zero;
+            try
+            {
+                // revert to the application pool identity, saving the identity of the current requestor
+                _wic = WindowsIdentity.Impersonate(IntPtr.Zero);
+
+                // do logon & impersonate
+                if (Win32NativeMethods.LogonUser(userName,
+                    domainName,
+                    password,
+                    (int)logonType,
+                    (int)logonProvider,
+                    ref logonToken) != 0)
+                {
+                    if (Win32NativeMethods.DuplicateToken(logonToken, (int)ImpersonationLevel.SecurityImpersonation, ref logonTokenDuplicate) != 0)
+                    {
+                        var wi = new WindowsIdentity(logonTokenDuplicate);
+                        wi.Impersonate(); // discard the returned identity context (which is the context of the application pool)
+                    }
+                    else
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+                else
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+            finally
+            {
+                if (logonToken != IntPtr.Zero)
+                    Win32NativeMethods.CloseHandle(logonToken);
+
+                if (logonTokenDuplicate != IntPtr.Zero)
+                    Win32NativeMethods.CloseHandle(logonTokenDuplicate);
+            }
+        }
+
+        /// <summary>
+        /// Stops impersonation.
+        /// </summary>
+        private void UndoImpersonation()
+        {
+            // restore saved requestor identity
+            if (_wic != null)
+                _wic.Undo();
+            _wic = null;
+        }
+    }
+}

--- a/src/CommonLib/Impersonate.cs
+++ b/src/CommonLib/Impersonate.cs
@@ -1,4 +1,5 @@
-﻿using System;
+//credit to Phillip Allan-Harding (Twitter @phillipharding) for this library.
+using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Principal;

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -131,15 +131,26 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="computerSamAccountName"></param>
         /// <param name="computerSid"></param>
         /// <returns></returns>
-        public SessionAPIResult ReadUserSessionsPrivileged(string computerName,
-            string computerSamAccountName, string computerSid)
+        public SessionAPIResult ReadUserSessionsPrivileged(string computerName, string computerSamAccountName, string computerSid, string username, string password)
         {
             var ret = new SessionAPIResult();
             NativeMethods.WKSTA_USER_INFO_1[] apiResult;
+            Console.WriteLine("Setting local Username and Password");
+            string username = "Admin";
+            string password = "Password";
+
+            // Create a new WindowsIdentity object for the specified user
+            var newIdentity = new WindowsIdentity(username, password);
+            Console.WriteLine(newIdentity);
 
             try
             {
-                apiResult = _nativeMethods.CallNetWkstaUserEnum(computerName).ToArray();
+                // Impersonate the new identity
+                Console.WriteLine("Now impersonating local User");
+                using (var impersonatedContext = newIdentity.Impersonate())
+                {
+                    apiResult = _nativeMethods.CallNetWkstaUserEnum(computerName).ToArray();
+                }
             }
             catch (APIException e)
             {
@@ -147,7 +158,7 @@ namespace SharpHoundCommonLib.Processors
                 ret.Collected = false;
                 ret.FailureReason = e.Status;
                 return ret;
-            }
+            
 
             ret.Collected = true;
 

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -152,6 +152,7 @@ namespace SharpHoundCommonLib.Processors
 
             try
             {
+                //Proudly brought to you by @eversinc33 and LuemmelSec
                 // If we are authenticating using a local admin, we need to impersonate for this
                 // TODO: refactor to avoid code reusage
                 if (_doLocalAdminSessionEnum)

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -28,8 +28,7 @@ namespace SharpHoundCommonLib.Processors
         private readonly string _localAdminUsername;
         private readonly string _localAdminPassword;
 
-        public ComputerSessionProcessor(ILDAPUtils utils, bool doLocalAdminSessionEnum = false, string localAdminUsername = null, string localAdminPassword = null, string currentUserName = null,
-            NativeMethods nativeMethods = null, ILogger log = null)
+        public ComputerSessionProcessor(ILDAPUtils utils, string currentUserName = null, NativeMethods nativeMethods = null, ILogger log = null, bool doLocalAdminSessionEnum = false, string localAdminUsername = null, string localAdminPassword = null)
         {
             _utils = utils;
             _nativeMethods = nativeMethods ?? new NativeMethods();

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -171,7 +171,6 @@ namespace SharpHoundCommonLib.Processors
 
             try
             {
-                //Proudly brought to you by @eversinc33 and LuemmelSec
                 // If we are authenticating using a local admin, we need to impersonate for this
                 if (_doLocalAdminSessionEnum)
                 {


### PR DESCRIPTION
This is the needed PR to SharpHoundCommon that allows to set an option to do session enumeration with a dedicated local (admin) user.
Credits to @eversinc33 how helped me a lot with this.

The situation with more recent pentests and red-team engagements is most likely that you see higher numbers of Windows Server 2016 + as well as Windows 10 1607 +. So the privileged session enumeration via NetWkstaUserEnum needs to be with a user that has local admin rights. Once gaining a foothold or in an assumed breach scenario we will most likely do not have these rights.
But, and that is very common, we do local priv esc on the client, fetch the local admin's credentials, and it happens to be some lame password that is reused accross a large scope of systems - worst case even servers. Same applies to once we get a server's local admin password, and this one is reused.

SharpHound was not able to do this, because it would run the session checks in the context of  the user that runs the collector.
What we did was to add 3 new flags:

-DoLocalAdminSessionEnum
-LocalAdminUsername
-LocalAdminPassword

We added a new library (Impersonate.cs ) that allows us to impersonate another remote local user in the current user's context via the LOGON32_PROVIDER_WINNT50 option from the advapi32.dll. 
That allows us to wrap the session enumeration stuff inside an impersonated user's context and overcome the limitations mentioned above.
Credits to @phillipharding for this library.

Everything else is done as the running user, so no impact on the rest of what SharpHound is doing.

I created a POC video demonsrating how it works:
https://www.youtube.com/watch?v=mMpNs3MXISM

BloodHound documentation was extended accordingly as well as the SharpHound project itself. Accordings PRs were opened.

https://github.com/BloodHoundAD/SharpHound/pull/40
https://github.com/BloodHoundAD/BloodHound/pull/646