### PR TITLE
Exclude MSAs when searching for Computers affected by GPOs

### DIFF
--- a/src/CommonLib/LDAPQueries/LDAPFilter.cs
+++ b/src/CommonLib/LDAPQueries/LDAPFilter.cs
@@ -144,6 +144,8 @@ namespace SharpHoundCommonLib.LDAPQueries
 
         /// <summary>
         ///     Add a filter that will include Computer objects
+        ///
+        ///     Note that gMSAs and sMSAs have this samaccounttype as well
         /// </summary>
         /// <param name="conditions"></param>
         /// <returns></returns>
@@ -161,6 +163,17 @@ namespace SharpHoundCommonLib.LDAPQueries
         public LDAPFilter AddSchemaID(params string[] conditions)
         {
             _filterParts.Add(BuildString("(schemaidguid=*)", conditions));
+            return this;
+        }
+
+        /// <summary>
+        ///     Add a filter that will include Computer objects but exclude gMSA and sMSA objects
+        /// </summary>
+        /// <param name="conditions"></param>
+        /// <returns></returns>
+        public LDAPFilter AddComputersNoMSAs(params string[] conditions)
+        {
+            _filterParts.Add(BuildString("(&(samaccounttype=805306369)(!(objectclass=msDS-GroupManagedServiceAccount))(!(objectclass=msDS-ManagedServiceAccount)))", conditions));
             return this;
         }
 

--- a/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
@@ -71,7 +71,7 @@ namespace SharpHoundCommonLib.Processors
             // Its cheaper to fetch the affected computers from LDAP first and then process the GPLinks 
             var options = new LDAPQueryOptions
             {
-                Filter = new LDAPFilter().AddComputers().GetFilter(),
+                Filter = new LDAPFilter().AddComputersNoMSAs().GetFilter(),
                 Scope = SearchScope.Subtree,
                 Properties = CommonProperties.ObjectSID,
                 AdsPath = distinguishedName

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -144,14 +144,13 @@ namespace CommonLibTest
             mockSearchResultEntry.Setup(x => x.GetSid()).Returns("teapot");
             var mockSearchResults = new List<ISearchResultEntry>();
             mockSearchResults.Add(mockSearchResultEntry.Object);
-            mockLDAPUtils.Setup(x => x.QueryLDAP(
-                    new LDAPQueryOptions
-                    {
-                        Filter = "(samaccounttype=805306369)",
-                        Scope = SearchScope.Subtree,
-                        Properties = CommonProperties.ObjectSID,
-                        AdsPath = null
-                    }))
+            mockLDAPUtils.Setup(x => x.QueryLDAP(new LDAPQueryOptions
+                {
+                    Filter = "(&(samaccounttype=805306369)(!(objectclass=msDS-GroupManagedServiceAccount))(!(objectclass=msDS-ManagedServiceAccount)))",
+                    Scope = SearchScope.Subtree,
+                    Properties = CommonProperties.ObjectSID,
+                    AdsPath = null
+                }))
                 .Returns(mockSearchResults.ToArray());
 
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);


### PR DESCRIPTION
gMSAs and sMSAs have the same samaccounttype as Computers. So they have to be filtered out in certain cases.

Solves the bug described here: https://github.com/BloodHoundAD/BloodHound/issues/644

This is only relevant for FOSS SharpHound as privileges granted through GPOs are not considered in BHE.