### PR TITLE
fix: set Base as default label

### DIFF
--- a/src/CommonLib/Enums/Labels.cs
+++ b/src/CommonLib/Enums/Labels.cs
@@ -2,6 +2,7 @@
 {
     public enum Label
     {
+        Base = 0,
         User,
         Computer,
         Group,
@@ -10,7 +11,6 @@
         GPO,
         Domain,
         OU,
-        Container,
-        Base
+        Container
     }
 }

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -329,7 +329,7 @@ namespace CommonLibTest
             Assert.NotNull(tp);
             Assert.Equal(new TypedPrincipal(), tp);
             Assert.NotNull(str);
-            Assert.Equal("Action: Add, Target: RestrictedMemberOf, TargetSid: , TargetType: User, TargetRid: None",
+            Assert.Equal("Action: Add, Target: RestrictedMemberOf, TargetSid: , TargetType: Base, TargetRid: None",
                 str);
         }
     }


### PR DESCRIPTION
If an object is deleted, we will stop resolution of the object before the ObjectType is determined. The ObjectType will in this case be the default (first) Label value, User. This resulted in the 'Deleted Objects' container (which is marked as deleted) being resolved to a (deleted) User.

I have changed the the default Label to Base.