### PR TITLE
Update LAPS schema

### DIFF
--- a/src/CommonLib/LDAPProperties.cs
+++ b/src/CommonLib/LDAPProperties.cs
@@ -34,7 +34,8 @@
         public const string OperatingSystem = "operatingsystem";
         public const string ServicePack = "operatingsystemservicepack";
         public const string DNSHostName = "dnshostname";
-        public const string LAPSExpirationTime = "ms-mcs-admpwdexpirationtime";
+        public const string LAPSExpirationTime = "mslaps-passwordexpirationtime";
+        public const string LegacyLAPSExpirationTime = "ms-mcs-admpwdexpirationtime";
         public const string Members = "member";
         public const string SecurityDescriptor = "ntsecuritydescriptor";
         public const string SecurityIdentifier = "securityidentifier";

--- a/src/CommonLib/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/SearchResultEntryWrapper.cs
@@ -247,7 +247,7 @@ namespace SharpHoundCommonLib
 
         public bool HasLAPS()
         {
-            return GetProperty(LDAPProperties.LAPSExpirationTime) != null;
+            return GetProperty(LDAPProperties.LAPSExpirationTime) != null || GetProperty(LDAPProperties.LegacyLAPSExpirationTime) != null;
         }
 
         public SearchResultEntry GetEntry()


### PR DESCRIPTION
## Description
In April 2023, MS released their new iteration of LAPS which included a refactor of the LAPS attributes on Computer objects. Currently SharpHound looks for the `ms-acs-admpwdexpirationtime` which is now know as `msLAPS-PasswordExpirationTime`. Therefore this PR is to add that LDAP property and change HasLAPS() logic to return true if the computer object possesses either of this attributes.

## Motivation and Context
Testing CE in a lab with LAPS configured was not returning any objects with haslaps = True

## How Has This Been Tested?
This has not been tested, however this is a (hopefully) simple change which will not break anything.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes include a database migration.
