### PR TITLE
Fix BUG #70

### DIFF
--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -243,8 +243,7 @@ namespace SharpHoundCommonLib.Processors
                 //Cool ACE courtesy of @rookuu. Allows a principal to add itself to a group and no one else
                 if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
                     !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
-                    !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                    aceType == ACEGuids.WriteMember)
+                    !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group)
                     yield return new ACE
                     {
                         PrincipalType = resolvedPrincipal.ObjectType,


### PR DESCRIPTION
## Description
See BUG #70 

## Motivation and Context
Properly make the "AddSelf" edge

## How Has This Been Tested?
Tested on a OU that has the AddSelf edge is created if you grant "Add/remove self as member" only, but if you select "All validated writes", then the edge is not created.

## Types of changes
The self ACL does not require the ACL for WriteMember.
