### PR TITLE
Publish packages to sleet repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Publish NuGet
         run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_TOKEN }} --skip-duplicate
         
+      - name: Publish to SpecterOps Packages
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        run: |
+          dotnet tool install -g sleet
+          sleet push *.nupkg --skip-existing
+        
   ghpages:
     name: ghpages
     needs: nuget

--- a/sleet.json
+++ b/sleet.json
@@ -1,0 +1,11 @@
+{
+  "sources": [
+    {
+      "name": "feed",
+      "type": "s3",
+      "path": "https://s3.amazonaws.com/bloodhound-ad",
+      "region": "us-east-1",
+      "bucketName": "bloodhound-ad"
+    }
+  ]
+}


### PR DESCRIPTION
## Description
Nuget is currently blocking our ability to publish packages due to virus scanning, and github packages requires auth. This is an alternative solution which self-hosts the nupkg files for consumption

## Motivation and Context
See above

## How Has This Been Tested?
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes include a database migration.
