### PR TITLE
chore: improve test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ## Build
 
-``` powershell
+```powershell
 dotnet build
 ```
 
@@ -17,31 +17,30 @@ dotnet build
 This project is configured to generate test coverage every time tests are run and produces a HTML report at
 [./docfx/coverage/report](./docfx/coverage/report).
 
-
-``` powershell
+```powershell
 dotnet test
 ```
 
 ## Documentation
 
-Documentation is generated into Html from Markdown using [docfx](https://https://dotnet.github.io/docfx/).
+Documentation is generated into HTML from Markdown using [docfx](https://dotnet.github.io/docfx/).
 
 To build the docs:
 
-``` powershell
+```powershell
 dotnet build docfx
 ```
 
 To preview the docs:
 
-``` powershell
+```powershell
 dotnet build docfx
 dotnet build docfx -t:Serve
 ```
 
 To preview the docs with test coverage:
 
-``` powershell
+```powershell
 dotnet test
 dotnet build docfx
 dotnet build docfx -t:Serve

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -413,7 +413,7 @@ namespace SharpHoundCommonLib.Processors
 
             return props;
         }
-        public Dictionary<string, object> ReadNTAuthStoreProperties(ISearchResultEntry entry)
+        public static Dictionary<string, object> ReadNTAuthStoreProperties(ISearchResultEntry entry)
         {
             var ntAuthStoreProps = new NTAuthStoreProperties
             {

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -413,10 +413,14 @@ namespace SharpHoundCommonLib.Processors
 
             return props;
         }
-        public static Dictionary<string, object> ReadNTAuthStoreProperties(ISearchResultEntry entry)
+        public Dictionary<string, object> ReadNTAuthStoreProperties(ISearchResultEntry entry)
         {
-            var props = GetCommonProps(entry);
-            return props;
+            var ntAuthStoreProps = new NTAuthStoreProperties
+            {
+                Props = GetCommonProps(entry)
+            };
+
+            return ntAuthStoreProps.Props;
         }
 
         public static Dictionary<string, object> ReadCertTemplateProperties(ISearchResultEntry entry)
@@ -637,5 +641,11 @@ namespace SharpHoundCommonLib.Processors
         public TypedPrincipal[] AllowedToAct { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] SidHistory { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] DumpSMSAPassword { get; set; } = Array.Empty<TypedPrincipal>();
+    }
+
+    public class NTAuthStoreProperties
+    {
+        public Dictionary<string, object> Props { get; set; } = new();
+        public TypedPrincipal[] CertThumbprints { get; set; } = Array.Empty<TypedPrincipal>();
     }
 }

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -55,7 +55,7 @@ namespace CommonLibTest
         public void ACLProcessor_IsACLProtected_NullNTSD_ReturnsFalse()
         {
             var processor = new ACLProcessor(new MockLDAPUtils(), true);
-            var result = processor.IsACLProtected((byte[]) null);
+            var result = processor.IsACLProtected((byte[])null);
             Assert.False(result);
         }
 
@@ -206,7 +206,7 @@ namespace CommonLibTest
             var collection = new List<ActiveDirectoryRuleDescriptor>();
 
             mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-            mockRule.Setup(x => x.IdentityReference()).Returns((string) null);
+            mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
             collection.Add(mockRule.Object);
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
@@ -267,7 +267,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object, true);
@@ -287,7 +287,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object, true);
@@ -309,7 +309,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object, true);
@@ -332,7 +332,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object, true);
@@ -351,12 +351,12 @@ namespace CommonLibTest
             var collection = new List<ActiveDirectoryRuleDescriptor>();
             mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
             mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-            mockRule.Setup(x => x.IdentityReference()).Returns((string) null);
+            mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
             collection.Add(mockRule.Object);
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object, true);
@@ -386,7 +386,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -417,7 +417,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -454,7 +454,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -491,7 +491,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -528,7 +528,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -550,7 +550,6 @@ namespace CommonLibTest
         {
             var expectedPrincipalType = Label.Group;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var expectedRightName = EdgeNames.AddSelf;
 
             var mockLDAPUtils = new Mock<ILDAPUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
@@ -565,7 +564,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -597,7 +596,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -634,7 +633,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -671,7 +670,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -709,7 +708,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -741,7 +740,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -778,7 +777,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -815,7 +814,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -847,7 +846,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -889,7 +888,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -921,7 +920,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -958,7 +957,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));
@@ -997,7 +996,7 @@ namespace CommonLibTest
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string) null);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType));

--- a/test/unit/Facades/MockSearchResultEntry.cs
+++ b/test/unit/Facades/MockSearchResultEntry.cs
@@ -37,22 +37,40 @@ namespace CommonLibTest.Facades
 
         public byte[] GetByteProperty(string propertyName)
         {
+            //returning something not null specifically for these properties for the parseAllProperties tests
+            if (propertyName == "badpasswordtime" || propertyName == "domainsid") return new byte[] { 0x20 };
             return _properties[propertyName] as byte[];
         }
 
         public string[] GetArrayProperty(string propertyName)
         {
-            return _properties[propertyName] as string[];
+            if (!_properties.Contains(propertyName))
+                return Array.Empty<string>();
+
+            var value = _properties[propertyName];
+            Type valueType = value.GetType();
+
+            if (valueType.IsArray)
+                return value as string[];
+            else
+                return new string[1] { (value ?? "").ToString() };
         }
 
         public byte[][] GetByteArrayProperty(string propertyName)
         {
-            return _properties[propertyName] as byte[][];
+
+            if (!_properties.Contains(propertyName))
+                return Array.Empty<byte[]>();
+
+            var byteArray = new byte[] { 0x20 };
+            var byteArrayArray = new byte[][] { byteArray };
+
+            return byteArrayArray;
         }
 
         public bool GetIntProperty(string propertyName, out int value)
         {
-            value = _properties[propertyName] is int ? (int) _properties[propertyName] : 0;
+            value = _properties[propertyName] is int ? (int)_properties[propertyName] : 0;
             return true;
         }
 
@@ -88,12 +106,16 @@ namespace CommonLibTest.Facades
 
         public int PropCount(string prop)
         {
-            throw new NotImplementedException();
+            var count = 0;
+
+            foreach (var property in _properties) count++;
+
+            return count;
         }
 
         public IEnumerable<string> PropertyNames()
         {
-            throw new NotImplementedException();
+            foreach (var property in _properties.Keys) yield return property.ToString().ToLower();
         }
 
         public bool IsMSA()

--- a/test/unit/Facades/MockSearchResultEntry.cs
+++ b/test/unit/Facades/MockSearchResultEntry.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
 
@@ -37,8 +38,14 @@ namespace CommonLibTest.Facades
 
         public byte[] GetByteProperty(string propertyName)
         {
-            //returning something not null specifically for these properties for the parseAllProperties tests
-            if (propertyName == "badpasswordtime" || propertyName == "domainsid") return new byte[] { 0x20 };
+            if (!_properties.Contains(propertyName))
+                return null;
+
+            if (_properties[propertyName] is string prop)
+            {
+                return Encoding.ASCII.GetBytes(prop);
+            }
+
             return _properties[propertyName] as byte[];
         }
 
@@ -48,24 +55,19 @@ namespace CommonLibTest.Facades
                 return Array.Empty<string>();
 
             var value = _properties[propertyName];
-            Type valueType = value.GetType();
-
-            if (valueType.IsArray)
+            if (value.IsArray())
                 return value as string[];
-            else
-                return new string[1] { (value ?? "").ToString() };
+            
+            return new [] { (value ?? "").ToString() };
         }
 
         public byte[][] GetByteArrayProperty(string propertyName)
         {
-
             if (!_properties.Contains(propertyName))
                 return Array.Empty<byte[]>();
-
-            var byteArray = new byte[] { 0x20 };
-            var byteArrayArray = new byte[][] { byteArray };
-
-            return byteArrayArray;
+            
+            var property = _properties[propertyName] as byte[][];
+            return property;
         }
 
         public bool GetIntProperty(string propertyName, out int value)
@@ -106,11 +108,14 @@ namespace CommonLibTest.Facades
 
         public int PropCount(string prop)
         {
-            var count = 0;
+            var property = _properties[prop];
+            if (property.IsArray())
+            {
+                var cast = property as string[];
+                return cast?.Length ?? 0;
+            }
 
-            foreach (var property in _properties) count++;
-
-            return count;
+            return 1;
         }
 
         public IEnumerable<string> PropertyNames()

--- a/test/unit/Helpers.cs
+++ b/test/unit/Helpers.cs
@@ -33,6 +33,14 @@ namespace CommonLibTest
                 results.Add(item);
             return results.ToArray();
         }
+
+        internal static bool IsArray(this object obj)
+        {
+            var valueType = obj?.GetType();
+            if (valueType == null)
+                return false;
+            return valueType.IsArray;
+        }
     }
 
     public sealed class WindowsOnlyFact : FactAttribute

--- a/test/unit/LDAPPropertyTests.cs
+++ b/test/unit/LDAPPropertyTests.cs
@@ -617,9 +617,8 @@ namespace CommonLibTest
                     {"whencreated", 1683986131},
                 }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
 
-            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
-            var props = processor.ReadNTAuthStoreProperties(mock);
-            var keys = props.Keys;
+            var test = LDAPPropertyProcessor.ReadNTAuthStoreProperties(mock);
+            var keys = test.Keys;
 
             Assert.Contains("description", keys);
             Assert.Contains("whencreated", keys);

--- a/test/unit/LDAPPropertyTests.cs
+++ b/test/unit/LDAPPropertyTests.cs
@@ -120,7 +120,7 @@ namespace CommonLibTest
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
-            Assert.True((bool) test["admincount"]);
+            Assert.True((bool)test["admincount"]);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace CommonLibTest
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
-            Assert.False((bool) test["admincount"]);
+            Assert.False((bool)test["admincount"]);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace CommonLibTest
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
-            Assert.False((bool) test["admincount"]);
+            Assert.False((bool)test["admincount"]);
         }
 
         [Fact]
@@ -250,7 +250,7 @@ namespace CommonLibTest
             var props = test.Props;
             var keys = props.Keys;
             Assert.Contains("admincount", keys);
-            Assert.False((bool) props["admincount"]);
+            Assert.False((bool)props["admincount"]);
         }
 
         [WindowsOnlyFact]
@@ -289,33 +289,33 @@ namespace CommonLibTest
             Assert.Contains("description", keys);
             Assert.Equal("Test", props["description"] as string);
             Assert.Contains("admincount", keys);
-            Assert.True((bool) props["admincount"]);
+            Assert.True((bool)props["admincount"]);
             Assert.Contains("lastlogon", keys);
-            Assert.Equal(1622827514, (long) props["lastlogon"]);
+            Assert.Equal(1622827514, (long)props["lastlogon"]);
             Assert.Contains("lastlogontimestamp", keys);
-            Assert.Equal(1622558209, (long) props["lastlogontimestamp"]);
+            Assert.Equal(1622558209, (long)props["lastlogontimestamp"]);
             Assert.Contains("pwdlastset", keys);
-            Assert.Equal(1568693134, (long) props["pwdlastset"]);
+            Assert.Equal(1568693134, (long)props["pwdlastset"]);
             Assert.Contains("homedirectory", keys);
             Assert.Equal(@"\\win10\testdir", props["homedirectory"] as string);
 
             //UAC stuff
             Assert.Contains("sensitive", keys);
-            Assert.False((bool) props["sensitive"]);
+            Assert.False((bool)props["sensitive"]);
             Assert.Contains("dontreqpreauth", keys);
-            Assert.False((bool) props["dontreqpreauth"]);
+            Assert.False((bool)props["dontreqpreauth"]);
             Assert.Contains("passwordnotreqd", keys);
-            Assert.False((bool) props["passwordnotreqd"]);
+            Assert.False((bool)props["passwordnotreqd"]);
             Assert.Contains("unconstraineddelegation", keys);
-            Assert.False((bool) props["unconstraineddelegation"]);
+            Assert.False((bool)props["unconstraineddelegation"]);
             Assert.Contains("enabled", keys);
-            Assert.True((bool) props["enabled"]);
+            Assert.True((bool)props["enabled"]);
             Assert.Contains("trustedtoauth", keys);
-            Assert.False((bool) props["trustedtoauth"]);
+            Assert.False((bool)props["trustedtoauth"]);
 
             //SPN
             Assert.Contains("hasspn", keys);
-            Assert.True((bool) props["hasspn"]);
+            Assert.True((bool)props["hasspn"]);
             Assert.Contains("serviceprincipalnames", keys);
             Assert.Contains("MSSQLSVC/win10", props["serviceprincipalnames"] as string[]);
 
@@ -367,7 +367,7 @@ namespace CommonLibTest
             Assert.Contains("sidhistory", keys);
             Assert.Empty(props["sidhistory"] as string[]);
             Assert.Contains("admincount", keys);
-            Assert.False((bool) props["admincount"]);
+            Assert.False((bool)props["admincount"]);
             Assert.Contains("sensitive", keys);
             Assert.Contains("dontreqpreauth", keys);
             Assert.Contains("passwordnotreqd", keys);
@@ -375,13 +375,13 @@ namespace CommonLibTest
             Assert.Contains("pwdneverexpires", keys);
             Assert.Contains("enabled", keys);
             Assert.Contains("trustedtoauth", keys);
-            Assert.False((bool) props["trustedtoauth"]);
-            Assert.False((bool) props["sensitive"]);
-            Assert.False((bool) props["dontreqpreauth"]);
-            Assert.False((bool) props["passwordnotreqd"]);
-            Assert.False((bool) props["unconstraineddelegation"]);
-            Assert.False((bool) props["pwdneverexpires"]);
-            Assert.True((bool) props["enabled"]);
+            Assert.False((bool)props["trustedtoauth"]);
+            Assert.False((bool)props["sensitive"]);
+            Assert.False((bool)props["dontreqpreauth"]);
+            Assert.False((bool)props["passwordnotreqd"]);
+            Assert.False((bool)props["unconstraineddelegation"]);
+            Assert.False((bool)props["pwdneverexpires"]);
+            Assert.True((bool)props["enabled"]);
         }
 
         [WindowsOnlyFact]
@@ -437,15 +437,15 @@ namespace CommonLibTest
             Assert.Contains("lastlogon", keys);
             Assert.Contains("lastlogontimestamp", keys);
             Assert.Contains("pwdlastset", keys);
-            Assert.True((bool) props["enabled"]);
-            Assert.False((bool) props["unconstraineddelegation"]);
+            Assert.True((bool)props["enabled"]);
+            Assert.False((bool)props["unconstraineddelegation"]);
 
             Assert.Contains("lastlogon", keys);
-            Assert.Equal(1622827514, (long) props["lastlogon"]);
+            Assert.Equal(1622827514, (long)props["lastlogon"]);
             Assert.Contains("lastlogontimestamp", keys);
-            Assert.Equal(1622558209, (long) props["lastlogontimestamp"]);
+            Assert.Equal(1622558209, (long)props["lastlogontimestamp"]);
             Assert.Contains("pwdlastset", keys);
-            Assert.Equal(1568693134, (long) props["pwdlastset"]);
+            Assert.Equal(1568693134, (long)props["pwdlastset"]);
 
             //AllowedToDelegate
             Assert.Single(test.AllowedToDelegate);
@@ -524,12 +524,13 @@ namespace CommonLibTest
             Assert.Contains("unconstraineddelegation", keys);
             Assert.Contains("enabled", keys);
             Assert.Contains("trustedtoauth", keys);
-            Assert.False((bool) props["unconstraineddelegation"]);
-            Assert.True((bool) props["enabled"]);
-            Assert.False((bool) props["trustedtoauth"]);
+            Assert.False((bool)props["unconstraineddelegation"]);
+            Assert.True((bool)props["enabled"]);
+            Assert.False((bool)props["trustedtoauth"]);
             Assert.Contains("sidhistory", keys);
             Assert.Empty(props["sidhistory"] as string[]);
         }
+
 
         [Fact]
         public async Task LDAPPropertyProcessor_ReadComputerProperties_TestDumpSMSAPassword()
@@ -602,6 +603,114 @@ namespace CommonLibTest
 
         }
 
-        // //TODO: Add coverage for ParseAllProperties
+
+        [Fact]
+        public void LDAPPropertyProcessor_ReadNTAuthStoreProperties()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "NTAUTHCERTIFICATES@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ReadNTAuthStoreProperties(mock);
+            var keys = props.Keys;
+
+            Assert.Contains("description", keys);
+            Assert.Contains("whencreated", keys);
+        }
+
+        // ReservedAttributes
+
+        [Fact]
+        public void LDAPPropertyProcessor_ParseAllProperties()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "NTAUTHCERTIFICATES@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ParseAllProperties(mock);
+            var keys = props.Keys;
+
+            //These are reserved properties and so they should be filtered out
+            Assert.DoesNotContain("description", keys);
+            Assert.DoesNotContain("whencreated", keys);
+            Assert.DoesNotContain("name", keys);
+
+            Assert.Contains("domainsid", keys);
+            Assert.Contains("domain", keys);
+        }
+
+        [Fact]
+        public void LDAPPropertyProcessor_ParseAllProperties_NoProperties()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                { }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ParseAllProperties(mock);
+            var keys = props.Keys;
+
+            Assert.Empty(keys);
+
+        }
+
+        [Fact]
+        public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_NullString()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {{"domainsid", null} }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ParseAllProperties(mock);
+            var keys = props.Keys;
+
+            Assert.Empty(keys);
+        }
+
+        [Fact]
+        public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_BadPasswordTime()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {{"badpasswordtime", "130435290000000000"} }, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ParseAllProperties(mock);
+            var keys = props.Keys;
+
+            Assert.Contains("badpasswordtime", keys);
+            Assert.Single(keys);
+        }
+
+        [Fact]
+        public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_NotBadPasswordTime()
+        {
+            var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {{"domainsid", "S-1-5-21-2697957641-2271029196-387917394"}}, "2F9F3630-F46A-49BF-B186-6629994EBCF9", Label.NTAuthStore);
+
+            var processor = new LDAPPropertyProcessor(new MockLDAPUtils());
+            var props = processor.ParseAllProperties(mock);
+            var keys = props.Keys;
+
+            Assert.Contains("domainsid", keys);
+            Assert.Single(keys);
+        }
+
     }
 }

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -104,7 +104,7 @@ namespace CommonLibTest
             Assert.Null(result);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void BuildLdapPath_HappyPath()
         {
             var mock = new Mock<LDAPUtils>();

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -2,14 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.DirectoryServices.ActiveDirectory;
 using System.DirectoryServices.Protocols;
-using System.Linq;
 using System.Threading;
 using CommonLibTest.Facades;
 using Moq;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.Exceptions;
-using SharpHoundCommonLib.Processors;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -101,11 +99,11 @@ namespace CommonLibTest
             var mock = new Mock<LDAPUtils>();
             //var mockDomain = MockableDomain.Construct("TESTLAB.LOCAL");
             mock.Setup(x => x.GetDomain(It.IsAny<string>()))
-                .Returns((Domain) null);
+                .Returns((Domain)null);
             var result = mock.Object.BuildLdapPath("TEST", "ABC");
             Assert.Null(result);
         }
-        
+
         [Fact]
         public void BuildLdapPath_HappyPath()
         {
@@ -135,7 +133,7 @@ namespace CommonLibTest
             Assert.Equal(Label.Group, typedPrincipal.ObjectType);
             Assert.Equal($"{_testDomainName}-S-1-5-32-544", typedPrincipal.ObjectIdentifier);
         }
-        
+
         [Fact]
         public void DistinguishedNameToDomain_RegularObject_CorrectDomain()
         {
@@ -151,7 +149,7 @@ namespace CommonLibTest
         public void GetDomainRangeSize_BadDomain_ReturnsDefault()
         {
             var mock = new Mock<LDAPUtils>();
-            mock.Setup(x => x.GetDomain(It.IsAny<string>())).Returns((Domain) null);
+            mock.Setup(x => x.GetDomain(It.IsAny<string>())).Returns((Domain)null);
             var result = mock.Object.GetDomainRangeSize();
             Assert.Equal(750, result);
         }
@@ -160,13 +158,13 @@ namespace CommonLibTest
         public void GetDomainRangeSize_RespectsDefaultParam()
         {
             var mock = new Mock<LDAPUtils>();
-            mock.Setup(x => x.GetDomain(It.IsAny<string>())).Returns((Domain) null);
+            mock.Setup(x => x.GetDomain(It.IsAny<string>())).Returns((Domain)null);
 
             var result = mock.Object.GetDomainRangeSize(null, 1000);
             Assert.Equal(1000, result);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void GetDomainRangeSize_NoLdapEntry_ReturnsDefault()
         {
             var mock = new Mock<LDAPUtils>();
@@ -180,7 +178,7 @@ namespace CommonLibTest
             Assert.Equal(750, result);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void GetDomainRangeSize_ExpectedResults()
         {
             var mock = new Mock<LDAPUtils>();
@@ -193,10 +191,10 @@ namespace CommonLibTest
                     "MaxPageSize=1250"
                 }},
             }, "abc123", Label.Base);
-            
+
             mock.Setup(x => x.QueryLDAP(It.IsAny<string>(), It.IsAny<SearchScope>(), null,
                 It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<bool>(),
-                It.IsAny<bool>(), It.IsAny<bool>())).Returns(new List<ISearchResultEntry> {searchResult});
+                It.IsAny<bool>(), It.IsAny<bool>())).Returns(new List<ISearchResultEntry> { searchResult });
             var result = mock.Object.GetDomainRangeSize();
             Assert.Equal(1250, result);
         }


### PR DESCRIPTION
## Description
This adds some test coverage around the NTAuthStore properties and the `parseAllProperties` method.

## Motivation and Context
Improving code quality.

## How Has This Been Tested?
These tests were run on my mac laptop. I updated some of the test labels to `[WindowsOnlyFact]` since they were calling windows specific APIs and failed to run on my OS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [x] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.
