### PR TITLE
Rename EnrollmentService to EnterpriseCA

### DIFF
--- a/src/CommonLib/Enums/DataType.cs
+++ b/src/CommonLib/Enums/DataType.cs
@@ -12,7 +12,7 @@
         public const string RootCAs = "rootcas";
         public const string AIACAs = "aiacas";
         public const string NTAuthStores = "ntauthstores";
-        public const string EnrollmentServices = "enrollmentservices";
+        public const string EnterpriseCAs = "enterprisecas";
         public const string CertTemplates = "certtemplates";
     }
 }

--- a/src/CommonLib/Enums/DirectoryPaths.cs
+++ b/src/CommonLib/Enums/DirectoryPaths.cs
@@ -2,7 +2,7 @@
 {
     public class DirectoryPaths
     {
-        public const string EnrollmentServiceLocation = "CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration";
+        public const string EnterpriseCALocation = "CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration";
         public const string RootCALocation = "CN=Certification Authorities,CN=Public Key Services,CN=Services,CN=Configuration";
         public const string AIACALocation = "CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration";
         public const string CertTemplateLocation = "CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration";

--- a/src/CommonLib/Enums/Labels.cs
+++ b/src/CommonLib/Enums/Labels.cs
@@ -16,7 +16,7 @@
         CertAuthority,
         RootCA,
         AIACA,
-        EnrollmentService,
+        EnterpriseCA,
         NTAuthStore
     }
 }

--- a/src/CommonLib/Enums/PKIEnterpriseCAFlags.cs
+++ b/src/CommonLib/Enums/PKIEnterpriseCAFlags.cs
@@ -3,7 +3,7 @@
 namespace SharpHoundCommonLib.Enums
 {
     [Flags]
-    public enum PKIEnrollmentServiceFlags
+    public enum PKIEnterpriseCAFlags
     {
         NO_TEMPLATE_SUPPORT = 0x00000001,
         SUPPORTS_NT_AUTHENTICATION = 0x00000002,

--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -372,7 +372,7 @@ namespace SharpHoundCommonLib
                 else if (objectClasses.Contains(PKICertificateTemplateClass, StringComparer.InvariantCultureIgnoreCase))
                     objectType = Label.CertTemplate;
                 else if (objectClasses.Contains(PKIEnrollmentServiceClass, StringComparer.InvariantCultureIgnoreCase))
-                    objectType = Label.EnrollmentService;
+                    objectType = Label.EnterpriseCA;
                 else if (objectClasses.Contains(CertificationAutorityClass, StringComparer.InvariantCultureIgnoreCase))
                 {
                     if (entry.DistinguishedName.Contains(DirectoryPaths.RootCALocation))

--- a/src/CommonLib/OutputTypes/EnterpriseCA.cs
+++ b/src/CommonLib/OutputTypes/EnterpriseCA.cs
@@ -1,6 +1,6 @@
 ﻿namespace SharpHoundCommonLib.OutputTypes
 {
-    public class EnrollmentService : OutputBase
+    public class EnterpriseCA : OutputBase
     {
         public TypedPrincipal[] EnabledCertTemplates { get; set; }
         public string HostingComputer { get; set; }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -33,7 +33,7 @@ namespace SharpHoundCommonLib.Processors
                 {Label.Container, "bf967a8b-0de6-11d0-a285-00aa003049e2"},
                 {Label.RootCA, "3fdfee50-47f4-11d1-a9c3-0000f80367c1"},
                 {Label.AIACA, "3fdfee50-47f4-11d1-a9c3-0000f80367c1"},
-                {Label.EnrollmentService, "ee4aa692-3bba-11d2-90cc-00c04fd91ab1"},
+                {Label.EnterpriseCA, "ee4aa692-3bba-11d2-90cc-00c04fd91ab1"},
                 {Label.NTAuthStore, "3fdfee50-47f4-11d1-a9c3-0000f80367c1"},
                 {Label.CertTemplate, "e5209ca2-3bba-11d2-90cc-00c04fd91ab1"}
             };
@@ -444,8 +444,8 @@ namespace SharpHoundCommonLib.Processors
                     }
                 }
 
-                // Enrollment service rights
-                if (objectType == Label.EnrollmentService)
+                // EnterpriseCA rights
+                if (objectType == Label.EnterpriseCA)
                 {
                     if (aceType is ACEGuids.Enroll)
                         yield return new ACE

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -406,10 +406,10 @@ namespace SharpHoundCommonLib.Processors
             return props;
         }
 
-        public static Dictionary<string, object> ReadEnrollmentServiceProperties(ISearchResultEntry entry)
+        public static Dictionary<string, object> ReadEnterpriseCAProperties(ISearchResultEntry entry)
         {
             var props = GetCommonProps(entry);
-            if (entry.GetIntProperty("flags", out var flags)) props.Add("flags", (PKIEnrollmentServiceFlags)flags);
+            if (entry.GetIntProperty("flags", out var flags)) props.Add("flags", (PKIEnterpriseCAFlags)flags);
 
             return props;
         }

--- a/src/CommonLib/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/SearchResultEntryWrapper.cs
@@ -171,7 +171,7 @@ namespace SharpHoundCommonLib
                 case Label.RootCA:
                 case Label.AIACA:
                 case Label.NTAuthStore:
-                case Label.EnrollmentService:
+                case Label.EnterpriseCA:
                 case Label.CertTemplate:
                     res.DisplayName = $"{GetProperty(LDAPProperties.Name)}@{itemDomain}";
                     break;


### PR DESCRIPTION
## Description

Rename EnrollmentService node type to EnterpriseCA.

## Motivation and Context

The AD object is called enrollment service but Enterprise CA seems to be the name used everywhere.

## How Has This Been Tested?

Ran collection. It worked.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My changes include a database migration.

I will fix the documentation and jira tickets when the PR is accepted.