### PR TITLE
ServerDown Retry Logic

### DIFF
--- a/src/CommonLib/Enums/LdapErrorCodes.cs
+++ b/src/CommonLib/Enums/LdapErrorCodes.cs
@@ -4,5 +4,6 @@
     {
         Success = 0,
         Busy = 51,
+        ServerDown = 81
     }
 }


### PR DESCRIPTION
## Description
This MR adds logic if we hit a serverdown to create a new ldap connectin and retry the search


## Motivation and Context
Occasionally, we get kicked off the ldap server because reasons. In theory we should be able to retry the request with the same cookie after a delay to let the LDAP server get itself together.

## How Has This Been Tested?
Unfortunately, no real way to test this, this is experimental logic since we cant repro this in any lab

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Documentation updates are needed, and have been made accordingly.
- [ ] I have added and/or updated tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My changes include a database migration.
