### PR TITLE
fix: use correct constants for Enterprise CA flags

### DIFF
--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -450,7 +450,7 @@ namespace SharpHoundCommonLib.Processors
         public static Dictionary<string, object> ReadEnterpriseCAProperties(ISearchResultEntry entry)
         {
             var props = GetCommonProps(entry);
-            if (entry.GetIntProperty("flags", out var flags)) props.Add("flags", (PKIEnrollmentFlag)flags);
+            if (entry.GetIntProperty("flags", out var flags)) props.Add("flags", (PKICertificateAuthorityFlags)flags);
             props.Add("caname", entry.GetProperty(LDAPProperties.Name));
             props.Add("dnshostname", entry.GetProperty(LDAPProperties.DNSHostName));
 


### PR DESCRIPTION
We used the wrong flags:
![image](https://github.com/BloodHoundAD/SharpHoundCommon/assets/12843299/ef6a9f19-b05c-4d65-9e93-420209d812b0)

Now the correct ones:
![image](https://github.com/BloodHoundAD/SharpHoundCommon/assets/12843299/7e6d09f5-11e6-4ac3-b531-76c5187a82ba)
