### PR TITLE
Fix authentication with DirectoryEntry

### DIFF
--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -1702,18 +1702,30 @@ namespace SharpHoundCommonLib
 
         public string GetConfigurationPath(string domainName = null)
         {
-            var rootDse = domainName == null
-                ? new DirectoryEntry("LDAP://RootDSE")
-                : new DirectoryEntry($"LDAP://{NormalizeDomainName(domainName)}/RootDSE");
+            string path = domainName == null
+                ? "LDAP://RootDSE"
+                : $"LDAP://{NormalizeDomainName(domainName)}/RootDSE";
+
+            DirectoryEntry rootDse;
+            if (_ldapConfig.Username != null)
+                rootDse = new DirectoryEntry(path, _ldapConfig.Username, _ldapConfig.Password);
+            else
+                rootDse = new DirectoryEntry(path);
 
             return $"{rootDse.Properties["configurationNamingContext"]?[0]}";
         }
 
         public string GetSchemaPath(string domainName)
         {
-            var rootDse = domainName == null
-                ? new DirectoryEntry("LDAP://RootDSE")
-                : new DirectoryEntry($"LDAP://{NormalizeDomainName(domainName)}/RootDSE");
+            string path = domainName == null
+                ? "LDAP://RootDSE"
+                : $"LDAP://{NormalizeDomainName(domainName)}/RootDSE";
+
+            DirectoryEntry rootDse;
+            if (_ldapConfig.Username != null)
+                rootDse = new DirectoryEntry(path, _ldapConfig.Username, _ldapConfig.Password);
+            else
+                rootDse = new DirectoryEntry(path);
 
             return $"{rootDse.Properties["schemaNamingContext"]?[0]}";
         }


### PR DESCRIPTION
Had a case where sharphound would return invalid username and password. 
To fix the issue I had to provide ldap credentials to DirectoryEntry similar as in the [GetDomain](https://github.com/BloodHoundAD/SharpHoundCommon/blob/v3/src/CommonLib/LDAPUtils.cs#L1140) function 