### PR TITLE
Check if ResolveAccountName returns a value

### DIFF
--- a/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
@@ -531,6 +531,11 @@ namespace SharpHoundCommonLib.Processors
                                     var domain = s[0];
 
                                     var res = _utils.ResolveAccountName(name, domain);
+                                    if (res == null)
+                                    {
+                                        _log.LogWarning("Failed to resolve member {memberName}", memberName);
+                                        continue;
+                                    }
                                     ga.Target = GroupActionTarget.LocalGroup;
                                     ga.TargetSid = res.ObjectIdentifier;
                                     ga.TargetType = res.ObjectType;
@@ -540,6 +545,11 @@ namespace SharpHoundCommonLib.Processors
                                 else
                                 {
                                     var res = _utils.ResolveAccountName(memberName, gpoDomain);
+                                    if (res == null)
+                                    {
+                                        _log.LogWarning("Failed to resolve member {memberName}", memberName);
+                                        continue;
+                                    }
                                     ga.Target = GroupActionTarget.LocalGroup;
                                     ga.TargetSid = res.ObjectIdentifier;
                                     ga.TargetType = res.ObjectType;


### PR DESCRIPTION
The GPOLocalGroup processor crashes when ResolveAccountName fails to resolve the member name and this stops processing for the GPO entirely.
One such case I've seen is when the group name has a format like PT0-%ComputerName%-LocalAdmin. 

Ideally it would be great if some process variables such as %ComputerName% and %DomainName% could be resolved by sharphound, but I don't see a clean way to implement this.
But at least we can prevent a crash and print a warning.
