### PR TITLE
Fix: use correct CacheInstance for GetDomainSidMapping

### DIFF
--- a/src/CommonLib/Cache.cs
+++ b/src/CommonLib/Cache.cs
@@ -63,7 +63,7 @@ namespace SharpHoundCommonLib
         /// <returns></returns>
         internal static bool GetDomainSidMapping(string key, out string value)
         {
-            if (CacheInstance != null) return CacheInstance.MachineSidCache.TryGetValue(key, out value);
+            if (CacheInstance != null) return CacheInstance.SIDToDomainCache.TryGetValue(key, out value);
             value = null;
             return false;
         }


### PR DESCRIPTION
The pull request repairs the use of an incorrect CacheInstance (probably copy paste error), so that the SIDToDomain cache is also used when the domain cache is queried (GetDomainSidMapping). 