### PR TITLE
Filter empty hosts in host resolution

### DIFF
--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -571,6 +571,10 @@ namespace SharpHoundCommonLib
         public async Task<string> ResolveHostToSid(string hostname, string domain)
         {
             var strippedHost = Helpers.StripServicePrincipalName(hostname).ToUpper().TrimEnd('$');
+            if (string.IsNullOrEmpty(strippedHost))
+            {
+                return null;
+            }
 
             if (_hostResolutionMap.TryGetValue(strippedHost, out var sid)) return sid;
 

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -166,6 +166,15 @@ namespace CommonLibTest
             var actual = SharpHoundCommonLib.Helpers.StripServicePrincipalName(testString);
             Assert.Equal(expected, actual);
         }
+        
+        [Fact]
+        public void StripServicePrincipalName_EmptyHost_Valid()
+        {
+            var testString = "MSSQLSvc/:1433";
+            var expected = "";
+            var actual = SharpHoundCommonLib.Helpers.StripServicePrincipalName(testString);
+            Assert.Equal(expected, actual);
+        }
 
         [Fact]
         public void B64ToBytes_String_ValidBase64String()


### PR DESCRIPTION
Prevents resolving empty hosts as localhost, creating false positives