### PR TITLE
Fix LDAP backoff retry logic for serverdown to actually use new connections

### DIFF
--- a/src/CommonLib/Enums/LdapErrorCodes.cs
+++ b/src/CommonLib/Enums/LdapErrorCodes.cs
@@ -4,6 +4,7 @@
     {
         Success = 0,
         Busy = 51,
-        ServerDown = 81
+        ServerDown = 81,
+        LocalError = 82
     }
 }

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -64,7 +64,7 @@ namespace SharpHoundCommonLib
         private readonly ConcurrentDictionary<string, string> _netbiosCache = new();
         private readonly PortScanner _portScanner;
         private LDAPConfig _ldapConfig = new();
-        private readonly ManualResetEvent _manualResetEvent = new(false);
+        private readonly ManualResetEvent _connectionResetEvent = new(false);
         
 
         /// <summary>
@@ -886,7 +886,7 @@ namespace SharpHoundCommonLib
                     retryCount++;
 
                     //If we are the holders of the reset event, we need to do logic to reset the connection
-                    if (_manualResetEvent.Reset())
+                    if (_connectionResetEvent.Reset())
                     {
                         try
                         {
@@ -906,13 +906,13 @@ namespace SharpHoundCommonLib
                         }
                         finally
                         {
-                            _manualResetEvent.Set();
+                            _connectionResetEvent.Set();
                         }
                     }
                     else
                     {
                         //If someone else is holding the reset event, we want to just wait and then pull the newly created connection out of the cache
-                        _manualResetEvent.WaitOne();
+                        _connectionResetEvent.WaitOne();
                         conn = CreateNewConnection(domainName, globalCatalog);
                     }
                     

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -1026,7 +1026,7 @@ namespace SharpHoundCommonLib
         private static TimeSpan GetNextBackoff(int retryCount)
         {
             return TimeSpan.FromSeconds(Math.Min(
-                BackoffDelayMultiplier * (retryCount + 1) * retryCount,
+                MinBackoffDelay.TotalSeconds * Math.Pow(BackoffDelayMultiplier, retryCount),
                 MaxBackoffDelay.TotalSeconds));
         }
 

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.DirectoryServices;
 using System.DirectoryServices.ActiveDirectory;
 using System.DirectoryServices.Protocols;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -879,7 +879,9 @@ namespace SharpHoundCommonLib
                     while the other threads that hit the ServerDown exception simply wait. The initial caller will hold the semaphore
                     and do a backoff delay before trying to make a new connection which will replace the existing connection in the 
                     _ldapConnections cache. Other threads will retrieve the new connection from the cache instead of making a new one
-                    This minimizes overhead of new connections while still fixing our core problem*/
+                    This minimizes overhead of new connections while still fixing our core problem.
+                    
+                    A CurrentCount of 0 indicates the semaphore is already held because c# semaphores are weird and backwards*/
                     var isSemaphoreHeld = _semaphoreSlim.CurrentCount == 0;
                     //Always increment retry count
                     retryCount++;

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -892,7 +892,6 @@ namespace SharpHoundCommonLib
                             //If no one is holding this semaphore, we're the first entrant into this logic, so its our responsibility
                             //to make the new LDAP connection
                             Thread.Sleep(backoffDelay);
-                            backoffDelay = GetNextBackoff(retryCount);
                             //Explicitly skip the cache so we don't get the same connection back
                             conn = CreateNewConnection(domainName, globalCatalog, true);
                             if (conn == null)
@@ -907,12 +906,12 @@ namespace SharpHoundCommonLib
                         else
                         {
                             //If the semaphore is already held, we're just waiting until we get the semaphore, at which point a new connection should be available
-                            backoffDelay = GetNextBackoff(retryCount);
                             conn = CreateNewConnection(domainName, globalCatalog);
                         }
                     }
                     finally
                     {
+                        backoffDelay = GetNextBackoff(retryCount);
                         //Always release
                         _semaphoreSlim.Release();
                     }

--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -890,8 +890,6 @@ namespace SharpHoundCommonLib
                     {
                         try
                         {
-                            //If no one is holding this semaphore, we're the first entrant into this logic, so its our responsibility
-                            //to make the new LDAP connection
                             Thread.Sleep(backoffDelay);
                             //Explicitly skip the cache so we don't get the same connection back
                             conn = CreateNewConnection(domainName, globalCatalog, true);


### PR DESCRIPTION
The current implementation was re-using the cached, invalid connection repeatedly and not actually creating a new one. The new implementation takes multi-consumer into account, properly creates new connections, and cleans up some bad logic around retry implementation.