### PR TITLE
Add NTLMv1 flag on GPO

### DIFF
--- a/src/CommonLib/OutputTypes/GPO.cs
+++ b/src/CommonLib/OutputTypes/GPO.cs
@@ -2,5 +2,6 @@
 {
     public class GPO : OutputBase
     {
+        public bool NTLMv1Enabled { get; set; }
     }
 }

--- a/src/CommonLib/Processors/GPOLmCompatibilityLevelProcessor.cs
+++ b/src/CommonLib/Processors/GPOLmCompatibilityLevelProcessor.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using System.Xml.XPath;
 using Microsoft.Extensions.Logging;
-using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
-using SharpHoundCommonLib.OutputTypes;
 
 namespace SharpHoundCommonLib.Processors
 {
@@ -51,17 +46,16 @@ namespace SharpHoundCommonLib.Processors
                 return false;
             }
 
-
-            //Add the actions for each file. The GPO template file actions will override the XML file actions
             return await ProcessGPOTemplateFile(filePath);
         }
 
         /// <summary>
-        ///     Parses a GPO GptTmpl.inf file and pulls group membership changes out
+        ///     Parses a GPO GptTmpl.inf file and grep lmcompatibilitylevel value
         /// </summary>
         /// <param name="basePath"></param>
-        /// <param name="gpoDomain"></param>
-        /// <returns></returns>
+        /// <returns>
+        ///     lmcompatibilitylevel < 3
+        /// </returns>
         internal async Task<Boolean> ProcessGPOTemplateFile(string basePath)
         {
             var templatePath = Path.Combine(basePath, "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf");

--- a/src/CommonLib/Processors/GPOLmCompatibilityLevelProcessor.cs
+++ b/src/CommonLib/Processors/GPOLmCompatibilityLevelProcessor.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.DirectoryServices.Protocols;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml.XPath;
+using Microsoft.Extensions.Logging;
+using SharpHoundCommonLib.Enums;
+using SharpHoundCommonLib.LDAPQueries;
+using SharpHoundCommonLib.OutputTypes;
+
+namespace SharpHoundCommonLib.Processors
+{
+    public class GPOLmCompatibilityLevelProcessor
+    {
+        private static readonly Regex NTLMv1Regex = new Regex(@"\\LmCompatibilityLevel *= *\d+ *, *(\d)", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+        private readonly ILogger _log;
+
+        private readonly ILDAPUtils _utils;
+
+        public GPOLmCompatibilityLevelProcessor(ILDAPUtils utils, ILogger log = null)
+        {
+            _utils = utils;
+            _log = log ?? Logging.LogProvider.CreateLogger("GPOLmCompatProc");
+        }
+
+        public Task<Boolean> ReadGPOLmCompatibilityLevel(ISearchResultEntry entry)
+        {
+            var dn = entry.DistinguishedName;
+            return ReadGPOLmCompatibilityLevel(dn);
+        }
+
+        public async Task<Boolean> ReadGPOLmCompatibilityLevel(string gpDn)
+        {
+            var opts = new LDAPQueryOptions
+            {
+                Filter = new LDAPFilter().AddAllObjects().GetFilter(),
+                Scope = SearchScope.Base,
+                Properties = CommonProperties.GPCFileSysPath,
+                AdsPath = gpDn
+            };
+            var filePath = _utils.QueryLDAP(opts).FirstOrDefault()?
+                .GetProperty(LDAPProperties.GPCFileSYSPath);
+            if (filePath == null)
+            {
+                _log.LogWarning("Unable to process {} for NTLMv1 flag", gpDn);
+                return false;
+            }
+
+
+            //Add the actions for each file. The GPO template file actions will override the XML file actions
+            return await ProcessGPOTemplateFile(filePath);
+        }
+
+        /// <summary>
+        ///     Parses a GPO GptTmpl.inf file and pulls group membership changes out
+        /// </summary>
+        /// <param name="basePath"></param>
+        /// <param name="gpoDomain"></param>
+        /// <returns></returns>
+        internal async Task<Boolean> ProcessGPOTemplateFile(string basePath)
+        {
+            var templatePath = Path.Combine(basePath, "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf");
+
+            if (!File.Exists(templatePath))
+                return false;
+
+            FileStream fs;
+            try
+            {
+                fs = new FileStream(templatePath, FileMode.Open, FileAccess.Read);
+            }
+            catch
+            {
+                return false;
+            }
+
+            using var reader = new StreamReader(fs);
+            var content = await reader.ReadToEndAsync();
+            var ntlmv1Match = NTLMv1Regex.Match(content);
+
+            if (!ntlmv1Match.Success)
+                return false;
+
+            //We've got a match! Lets figure out whats going on
+            var ntlmv1Text = int.Parse(ntlmv1Match.Groups[1].Value);
+            return ntlmv1Text < 3;
+        }
+    }
+}


### PR DESCRIPTION
Similar to https://github.com/BloodHoundAD/SharpHound3/pull/47

If GPO object forces LmCompatibilityLevel to be less than 3, then the computers it will be applied on will use NTLMv1 when authenticating.

This information seems very useful from an attacking perspective as authentication can be coerced and NTLMv1 hash cracked or relayed without MIC

(Also https://github.com/BloodHoundAD/SharpHound/pull/87 on SharpHound)

![image](https://github.com/BloodHoundAD/SharpHoundCommon/assets/11051803/a76f05f8-7598-40ce-8ebc-9f07d69dd4d9)
