### PR TITLE
chore: remove CertAuthority label

### DIFF
--- a/src/CommonLib/Enums/Labels.cs
+++ b/src/CommonLib/Enums/Labels.cs
@@ -14,7 +14,6 @@
         Container,
         Configuration,
         CertTemplate,
-        CertAuthority,
         RootCA,
         AIACA,
         EnterpriseCA,


### PR DESCRIPTION
We don't remove the removed label so let's remove it.