### PR TITLE
[BED-4075] Recording awareness of unknown Trust Attribute flag

### DIFF
--- a/src/CommonLib/Enums/TrustAttributes.cs
+++ b/src/CommonLib/Enums/TrustAttributes.cs
@@ -16,7 +16,6 @@ namespace SharpHoundCommonLib.Enums
         TrustUsesAes = 0x100,
         CrossOrganizationNoTGTDelegation = 0x200,
         PIMTrust = 0x400,
-        // We believe this deprecated flag represents a parent/child relationship
-        DeprecatedParentChild = 0x400000,
+        Unknown = 0x400000,
     }
 }

--- a/src/CommonLib/Enums/TrustAttributes.cs
+++ b/src/CommonLib/Enums/TrustAttributes.cs
@@ -15,6 +15,8 @@ namespace SharpHoundCommonLib.Enums
         TrustUsesRc4 = 0x80,
         TrustUsesAes = 0x100,
         CrossOrganizationNoTGTDelegation = 0x200,
-        PIMTrust = 0x400
+        PIMTrust = 0x400,
+        // We believe this deprecated flag represents a parent/child relationship
+        DeprecatedParentChild = 0x400000,
     }
 }

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -74,12 +74,12 @@ namespace SharpHoundCommonLib.Processors
                     continue;
                 }
 
-                trust.IsTransitive = (attributes & TrustAttributes.NonTransitive) == 0;
+                trust.IsTransitive = !attributes.HasFlag(TrustAttributes.NonTransitive);
                 var name = result.GetProperty(LDAPProperties.CanonicalName)?.ToUpper();
                 if (name != null)
                     trust.TargetDomainName = name;
 
-                trust.SidFilteringEnabled = (attributes & TrustAttributes.FilterSids) != 0;
+                trust.SidFilteringEnabled = attributes.HasFlag(TrustAttributes.FilterSids);
                 trust.TrustType = TrustAttributesToType(attributes);
 
                 yield return trust;
@@ -90,12 +90,12 @@ namespace SharpHoundCommonLib.Processors
         {
             TrustType trustType;
 
-            if ((attributes & TrustAttributes.WithinForest) != 0)
+            if (attributes.HasFlag(TrustAttributes.WithinForest) || attributes.HasFlag(TrustAttributes.DeprecatedParentChild))
                 trustType = TrustType.ParentChild;
-            else if ((attributes & TrustAttributes.ForestTransitive) != 0)
+            else if (attributes.HasFlag(TrustAttributes.ForestTransitive))
                 trustType = TrustType.Forest;
-            else if ((attributes & TrustAttributes.WithinForest) == 0 &&
-                     (attributes & TrustAttributes.ForestTransitive) == 0)
+            else if (!attributes.HasFlag(TrustAttributes.WithinForest) &&
+                     !attributes.HasFlag(TrustAttributes.ForestTransitive))
                 trustType = TrustType.External;
             else
                 trustType = TrustType.Unknown;

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -90,7 +90,7 @@ namespace SharpHoundCommonLib.Processors
         {
             TrustType trustType;
 
-            if (attributes.HasFlag(TrustAttributes.WithinForest) || attributes.HasFlag(TrustAttributes.DeprecatedParentChild))
+            if (attributes.HasFlag(TrustAttributes.WithinForest))
                 trustType = TrustType.ParentChild;
             else if (attributes.HasFlag(TrustAttributes.ForestTransitive))
                 trustType = TrustType.Forest;

--- a/test/unit/DomainTrustProcessorTest.cs
+++ b/test/unit/DomainTrustProcessorTest.cs
@@ -109,10 +109,6 @@ namespace CommonLibTest
             var test = DomainTrustProcessor.TrustAttributesToType(attrib);
             Assert.Equal(TrustType.ParentChild, test);
 
-            attrib = TrustAttributes.DeprecatedParentChild;
-            test = DomainTrustProcessor.TrustAttributesToType(attrib);
-            Assert.Equal(TrustType.ParentChild, test);
-
             attrib = TrustAttributes.ForestTransitive;
             test = DomainTrustProcessor.TrustAttributesToType(attrib);
             Assert.Equal(TrustType.Forest, test);

--- a/test/unit/DomainTrustProcessorTest.cs
+++ b/test/unit/DomainTrustProcessorTest.cs
@@ -109,6 +109,10 @@ namespace CommonLibTest
             var test = DomainTrustProcessor.TrustAttributesToType(attrib);
             Assert.Equal(TrustType.ParentChild, test);
 
+            attrib = TrustAttributes.DeprecatedParentChild;
+            test = DomainTrustProcessor.TrustAttributesToType(attrib);
+            Assert.Equal(TrustType.ParentChild, test);
+
             attrib = TrustAttributes.ForestTransitive;
             test = DomainTrustProcessor.TrustAttributesToType(attrib);
             Assert.Equal(TrustType.Forest, test);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Deprecated attribute flag appears to indicate parent/child relationship between domain objects, applying this type resolution to flag processing.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-315

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
