### PR TITLE
Throw ddl not found exception when missing SharpHoundRPC on init

### DIFF
--- a/src/CommonLib/CommonLib.cs
+++ b/src/CommonLib/CommonLib.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
 
 namespace SharpHoundCommonLib
 {
@@ -23,6 +25,12 @@ namespace SharpHoundCommonLib
             _initialized = true;
             if (log != null)
                 Logging.ConfigureLogging(log);
+
+            if (!File.Exists("SharpHoundRPC.dll"))
+            {
+                log.LogCritical("SharpHoundRPC.dll not found. Please reinstall and try again.");
+                throw new DllNotFoundException("SharpHoundRPC.dll not found.");
+            }
 
             if (cache == null)
             {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We want to exit SharpHound collection if SharpHoundRPC.dll is missing as we'd rather not support incomplete installations.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-316

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Install SharpHound to environment, remove SharpHoundRPC.dll, run SharpHound collection.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
