### PR TITLE
Split ResolveHostToSid

### DIFF
--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -316,7 +316,7 @@ namespace SharpHoundCommonLib
                 return Label.Base;
             }
 
-            if (objectId.StartsWith("S-1") &&
+            if (Helpers.IsSid(objectId) &&
                 WellKnownPrincipal.GetWellKnownPrincipal(objectId, out var commonPrincipal))
             {
                 Log.LogDebug("GetLabel - {ObjectID} is a WellKnownPrincipal with {Type}", objectId,

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -327,6 +327,11 @@ namespace SharpHoundCommonLib
             CommonOids.SmartcardLogon,
             CommonOids.AnyPurpose
         };
+
+        public static bool IsSid(string sidContender)
+        {
+            return sidContender != null && sidContender.StartsWith("S-1-");
+        }
     }
 
     public class ParsedGPLink

--- a/src/CommonLib/ILDAPUtils.cs
+++ b/src/CommonLib/ILDAPUtils.cs
@@ -56,6 +56,14 @@ namespace SharpHoundCommonLib
         IEnumerable<string> DoRangedRetrieval(string distinguishedName, string attributeName);
 
         /// <summary>
+        ///     Takes a host in most applicable forms from AD and attempts to resolve it into a SID, falling back to hostname if SID cannot be resolved.
+        /// </summary>
+        /// <param name="hostname"></param>
+        /// <param name="domain"></param>
+        /// <returns></returns>
+        Task<string> ResolveHostToSidWithHostnameFallback(string hostname, string domain);
+
+        /// <summary>
         ///     Takes a host in most applicable forms from AD and attempts to resolve it into a SID.
         /// </summary>
         /// <param name="hostname"></param>

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -134,7 +134,7 @@ namespace SharpHoundCommonLib.Processors
                     resolvedComputerSID = await _utils.ResolveHostToSid(computerSessionName, computerDomain);
 
                 //Throw out this data if we couldn't resolve it successfully. 
-                if (resolvedComputerSID == null || !resolvedComputerSID.StartsWith("S-1"))
+                if (!Helpers.IsSid(resolvedComputerSID))
                 {
                     _log.LogTrace("Unable to resolve {ComputerSessionName} to real SID", computerSessionName);
                     continue;

--- a/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
@@ -356,7 +356,7 @@ namespace SharpHoundCommonLib.Processors
         /// <returns></returns>
         private TypedPrincipal GetSid(string account, string domainName)
         {
-            if (!account.StartsWith("S-1-", StringComparison.CurrentCulture))
+            if (!Helpers.IsSid(account))
             {
                 string user;
                 string domain;

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -178,7 +178,7 @@ namespace SharpHoundCommonLib.Processors
                         continue;
 
                     var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                    if (resolvedHost != null && resolvedHost.StartsWith("S-1"))
+                    if (Helpers.IsSid(resolvedHost))
                         comps.Add(new TypedPrincipal
                         {
                             ObjectIdentifier = resolvedHost,

--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -178,7 +178,7 @@ namespace SharpHoundCommonLib.Processors
                         continue;
 
                     var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                    if (resolvedHost != null && resolvedHost.Contains("S-1"))
+                    if (resolvedHost != null && resolvedHost.StartsWith("S-1"))
                         comps.Add(new TypedPrincipal
                         {
                             ObjectIdentifier = resolvedHost,
@@ -285,8 +285,8 @@ namespace SharpHoundCommonLib.Processors
                 {
                     var hname = d.Contains("/") ? d.Split('/')[1] : d;
                     hname = hname.Split(':')[0];
-                    var resolvedHost = await _utils.ResolveHostToSid(hname, domain);
-                    if (resolvedHost != null && (resolvedHost.Contains(".") || resolvedHost.Contains("S-1")))
+                    var resolvedHost = await _utils.ResolveHostToSidWithHostnameFallback(hname, domain);
+                    if (resolvedHost != null && (resolvedHost.Contains(".") || resolvedHost.StartsWith("S-1")))
                         comps.Add(new TypedPrincipal
                         {
                             ObjectIdentifier = resolvedHost,

--- a/src/CommonLib/Processors/SPNProcessors.cs
+++ b/src/CommonLib/Processors/SPNProcessors.cs
@@ -59,7 +59,7 @@ namespace SharpHoundCommonLib.Processors
 
                     var host = await _utils.ResolveHostToSid(spn, domain);
                     _log.LogTrace("Resolved {SPN} to {Hostname}", spn, host);
-                    if (host != null && host.StartsWith("S-1-"))
+                    if (Helpers.IsSid(host))
                         yield return new SPNPrivilege
                         {
                             ComputerSID = host,

--- a/src/CommonLib/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/SearchResultEntryWrapper.cs
@@ -76,7 +76,7 @@ namespace SharpHoundCommonLib
             string itemDomain;
             if (distinguishedName == null)
             {
-                if (objectId.StartsWith("S-1-"))
+                if (Helpers.IsSid(objectId))
                 {
                     itemDomain = _utils.GetDomainNameFromSid(objectId);
                 }
@@ -113,7 +113,7 @@ namespace SharpHoundCommonLib
                 return res;
             }
 
-            if (objectId.StartsWith("S-1-"))
+            if (Helpers.IsSid(objectId))
                 try
                 {
                     res.DomainSid = new SecurityIdentifier(objectId).AccountDomainSid.Value;

--- a/test/unit/Facades/MockLDAPUtils.cs
+++ b/test/unit/Facades/MockLDAPUtils.cs
@@ -754,6 +754,11 @@ namespace CommonLibTest.Facades
         }
 
 #pragma warning disable CS1998
+        public async Task<string> ResolveHostToSidWithHostnameFallback(string hostname, string domain)
+        {
+            return await ResolveHostToSid(hostname, domain);
+        }
+
         public async Task<string> ResolveHostToSid(string hostname, string domain)
         {
             var h = SharpHoundCommonLib.Helpers.StripServicePrincipalName(hostname);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
ResolveHostToSid resolves to a SID when a SID can be resolved, and falls back to a hostname from DNS when a SID cannot be resolved.  This produces unwanted behavior when a SID is expected but a hostname is returned, so we split the method in two - one that returns null where no SID can be resolved and another that falls back onto the hostname.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-508

Bug in SHS when an AD object is deleted but remains on DNS.  Such objects currently are collected and recorded into our BloodHound graphs as empty domain CAs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
