### PR TITLE
When reading computer properties ignore hosts not resolved to SIDs

### DIFF
--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -286,7 +286,7 @@ namespace SharpHoundCommonLib.Processors
                     var hname = d.Contains("/") ? d.Split('/')[1] : d;
                     hname = hname.Split(':')[0];
                     var resolvedHost = await _utils.ResolveHostToSid(hname, domain);
-                    if (resolvedHost != null && (resolvedHost.Contains(".") || resolvedHost.Contains("S-1")))
+                    if (resolvedHost != null && resolvedHost.Contains("S-1"))
                         comps.Add(new TypedPrincipal
                         {
                             ObjectIdentifier = resolvedHost,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
We don't want to record computer host properies that aren't proper SIDs

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-508

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
