### PR TITLE
fix: replace BUILTIN container with domain node

### DIFF
--- a/src/CommonLib/Processors/ContainerProcessor.cs
+++ b/src/CommonLib/Processors/ContainerProcessor.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
 using Microsoft.Extensions.Logging;
+using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
 
@@ -47,6 +48,13 @@ namespace SharpHoundCommonLib.Processors
         public TypedPrincipal GetContainingObject(string distinguishedName)
         {
             var containerDn = Helpers.RemoveDistinguishedNamePrefix(distinguishedName);
+
+            if (containerDn.StartsWith("CN=BUILTIN", StringComparison.OrdinalIgnoreCase))
+            {
+                var domain = Helpers.DistinguishedNameToDomain(distinguishedName);
+                var domainSid = _utils.GetSidFromDomainName(domain);
+                return new TypedPrincipal(domainSid, Label.Domain);
+            }
 
             if (string.IsNullOrEmpty(containerDn))
                 return null;

--- a/test/unit/ContainerProcessorTest.cs
+++ b/test/unit/ContainerProcessorTest.cs
@@ -143,6 +143,10 @@ namespace CommonLibTest
             result = proc.GetContainingObject("CN=PRIMARY,OU=DOMAIN CONTROLLERS,DC=TESTLAB,DC=LOCAL");
             Assert.Equal(Label.OU, result.ObjectType);
             Assert.Equal("0DE400CD-2FF3-46E0-8A26-2C917B403C65", result.ObjectIdentifier);
+
+            result = proc.GetContainingObject("CN=ADMINISTRATORS,CN=BUILTIN,DC=TESTLAB,DC=LOCAL");
+            Assert.Equal(Label.Domain, result.ObjectType);
+            Assert.Equal("S-1-5-21-3130019616-2776909439-2417379446", result.ObjectIdentifier);
         }
 
         [Fact]

--- a/test/unit/Facades/MockLDAPUtils.cs
+++ b/test/unit/Facades/MockLDAPUtils.cs
@@ -690,7 +690,12 @@ namespace CommonLibTest.Facades
 
         public string GetSidFromDomainName(string domainName)
         {
-            throw new NotImplementedException();
+            if (domainName.Equals("TESTLAB.LOCAL", StringComparison.OrdinalIgnoreCase))
+            {
+                return "S-1-5-21-3130019616-2776909439-2417379446";
+            }
+
+            return null;
         }
 
         public string ConvertWellKnownPrincipal(string sid, string domain)


### PR DESCRIPTION
## Description

Add hardcoded edge case for BUILTIN container to present to BH as domain instead. 

## Motivation and Context

This will fix the missing `Contains` edges that are tied to the BUILTIN container but are otherwise ignored.

## How Has This Been Tested?

Added case to unit testing

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
