### PR TITLE
Additional Organizational Units ACLs

### DIFF
--- a/src/CommonLib/EdgeNames.cs
+++ b/src/CommonLib/EdgeNames.cs
@@ -21,7 +21,7 @@
         public const string AddKeyCredentialLink = "AddKeyCredentialLink";
         public const string SQLAdmin = "SQLAdmin";
         public const string WriteAccountRestrictions = "WriteAccountRestrictions";
-        public const string ManageGPLink = "ManageGPLink";
+        public const string WriteGPLink = "WriteGPLink";
 
         //CertAbuse edges
         public const string WritePKIEnrollmentFlag = "WritePKIEnrollmentFlag";

--- a/src/CommonLib/EdgeNames.cs
+++ b/src/CommonLib/EdgeNames.cs
@@ -21,6 +21,7 @@
         public const string AddKeyCredentialLink = "AddKeyCredentialLink";
         public const string SQLAdmin = "SQLAdmin";
         public const string WriteAccountRestrictions = "WriteAccountRestrictions";
+        public const string ManageGPLink = "ManageGPLink";
 
         //CertAbuse edges
         public const string WritePKIEnrollmentFlag = "WritePKIEnrollmentFlag";

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -12,6 +12,8 @@
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";
         public const string UserAccountRestrictions = "4c164200-20c0-11d0-a768-00aa006e0529";
+        public const string ManageGPLink = "f30e3bbf-9ff0-11d1-b603-0000f80367c1";
+
 
         //Cert abuse ACEs
         public const string PKINameFlag = "ea1dddc4-60ff-416e-8cc0-17cee534bce7";

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -12,7 +12,7 @@
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";
         public const string UserAccountRestrictions = "4c164200-20c0-11d0-a768-00aa006e0529";
-        public const string ManageGPLink = "f30e3bbf-9ff0-11d1-b603-0000f80367c1";
+        public const string WriteGPLink = "f30e3bbf-9ff0-11d1-b603-0000f80367c1";
 
 
         //Cert abuse ACEs

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -12,7 +12,7 @@
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";
         public const string UserAccountRestrictions = "4c164200-20c0-11d0-a768-00aa006e0529";
-        public const string WriteGPLink = "f30e3bbf-9ff0-11d1-b603-0000f80367c1";
+        public const string WriteGPLink = "f30e3bbe-9ff0-11d1-b603-0000f80367c1";
 
 
         //Cert abuse ACEs

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -380,6 +380,7 @@ namespace SharpHoundCommonLib.Processors
                         or Label.Computer 
                         or Label.GPO 
                         or Label.OU 
+                        or Label.Domain
                         or Label.CertTemplate 
                         or Label.RootCA 
                         or Label.EnterpriseCA 
@@ -419,7 +420,7 @@ namespace SharpHoundCommonLib.Processors
                             IsInherited = inherited,
                             RightName = EdgeNames.WriteAccountRestrictions
                         };
-                    else if (objectType == Label.OU && aceType == ACEGuids.WriteGPLink)
+                    else if (objectType is Label.OU or Label.Domain && aceType == ACEGuids.WriteGPLink)
                         yield return new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -419,13 +419,13 @@ namespace SharpHoundCommonLib.Processors
                             IsInherited = inherited,
                             RightName = EdgeNames.WriteAccountRestrictions
                         };
-                    else if (objectType == Label.OU && aceType == ACEGuids.ManageGPLink)
+                    else if (objectType == Label.OU && aceType == ACEGuids.WriteGPLink)
                         yield return new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,
                             IsInherited = inherited,
-                            RightName = EdgeNames.ManageGPLink
+                            RightName = EdgeNames.WriteGPLink
                         };
                     else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
                         yield return new ACE

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -379,6 +379,7 @@ namespace SharpHoundCommonLib.Processors
                         or Label.Group 
                         or Label.Computer 
                         or Label.GPO 
+                        or Label.OU 
                         or Label.CertTemplate 
                         or Label.RootCA 
                         or Label.EnterpriseCA 
@@ -417,6 +418,14 @@ namespace SharpHoundCommonLib.Processors
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,
                             IsInherited = inherited,
                             RightName = EdgeNames.WriteAccountRestrictions
+                        };
+                    else if (objectType == Label.OU && aceType == ACEGuids.ManageGPLink)
+                        yield return new ACE
+                        {
+                            PrincipalType = resolvedPrincipal.ObjectType,
+                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                            IsInherited = inherited,
+                            RightName = EdgeNames.ManageGPLink
                         };
                     else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
                         yield return new ACE


### PR DESCRIPTION
## Description

This pull request adds the collection of two ACLs related to Organizational Units: **GenericWrite** and **Manage Group Policy Links**. The motivation behind the pull request is described in the following article: https://www.synacktiv.com/publications/ounedpy-exploiting-hidden-organizational-units-acl-attack-vectors-in-active-directory

## Motivation and Context

This is a new feature adding two potentially exploitable OU ACLs to the collector. Note that a similar pull request was created for the python collector BloodHound.py. An additional pull request was created for the Specterops BloodHound GUI, in order to create two new edges associated with the GenericWrite and Manage Group Policy Links OU ACLs.

## How Has This Been Tested?

Various domain extracts with the SharpHound binary built with the modified SharpHoundCommon DLL have been performed and result in the collection of the GenericWrite and Manage Group Policy Links permissions on OUs as expected.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.

About this part, I do not think that documentation updates are necessary, nor the addition of tests, but feel free to correct me if I am wrong !

I am at your disposal for any further information