### PR TITLE
[BED-4342] Don't throw on Server Down (unless we want to)

### DIFF
--- a/src/CommonLib/LDAPUtils.cs
+++ b/src/CommonLib/LDAPUtils.cs
@@ -959,13 +959,6 @@ namespace SharpHoundCommonLib
                             le.ErrorCode, le.ServerErrorMessage, le.Message, ldapFilter, domainName);
                     }
 
-                    if (le.ErrorCode == (int)LdapErrorCodes.ServerDown)
-                    {
-                        throw new LDAPQueryException(
-                            $"LDAP Exception in Loop: {le.ErrorCode}. {le.ServerErrorMessage}. {le.Message}. Filter: {ldapFilter}. Domain: {domainName}",
-                            le);
-                    }
-
                     yield break;
                 }
                 catch (Exception e)


### PR DESCRIPTION
## Description
LDAPQuery throws exception when a DC can't be reached after it's exhausted its retries, whether or not our `throwException` flag is set.

## Motivation and Context
https://specterops.atlassian.net/browse/BP-642

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
