### PR TITLE
feat: collect ECA RoleSeparation

### DIFF
--- a/src/CommonLib/OutputTypes/CARegistryData.cs
+++ b/src/CommonLib/OutputTypes/CARegistryData.cs
@@ -5,5 +5,6 @@
         public AceRegistryAPIResult CASecurity { get; set; }
         public EnrollmentAgentRegistryAPIResult EnrollmentAgentRestrictions { get; set; }
         public BoolRegistryAPIResult IsUserSpecifiesSanEnabled { get; set; }
+        public BoolRegistryAPIResult RoleSeparationEnabled { get; set; }
     }
 }

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -246,6 +246,40 @@ namespace SharpHoundCommonLib.Processors
             return ret;
         }
 
+        /// <summary>
+        /// This function checks a registry setting on the target host for the specified CA to see if role seperation is enabled.
+        /// If enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.
+        /// </summary>
+        /// <remarks>https://www.itprotoday.com/security/q-how-can-i-make-sure-given-windows-account-assigned-only-single-certification-authority-ca</remarks>
+        /// <param name="target"></param>
+        /// <param name="caName"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        [ExcludeFromCodeCoverage]
+        public BoolRegistryAPIResult RoleSeparationEnabled(string target, string caName)
+        {
+            var ret = new BoolRegistryAPIResult();
+            var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
+            const string regValue = "RoleSeparationEnabled";
+            var data = Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
+
+            ret.Collected = data.Collected;
+            if (!data.Collected)
+            {
+                ret.FailureReason = data.FailureReason;
+                return ret;
+            }
+
+            if (data.Value == null)
+            {
+                return ret;
+            }
+
+            ret.Value = (int)data.Value == 1;
+
+            return ret;
+        }
+
         public TypedPrincipal GetRegistryPrincipal(SecurityIdentifier sid, string computerDomain, string computerName, bool isDomainController, string computerObjectId, SecurityIdentifier machineSid)
         {
             _log.LogTrace("Got principal with sid {SID} on computer {ComputerName}", sid.Value, computerName);


### PR DESCRIPTION
## Description

Collection of enterpriseCA setting RoleSeparationEnabled

Ticket: BED-4351

## Motivation and Context

If this setting is enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.

We need it for the ESC7 implementation, as some attack narratives require both ManageCA and ManageCertificates and could therefore be blocked by this setting.

More info on the setting: [Q: How can I make sure that a given Windows account is assigned only](https://www.itprotoday.com/security/q-how-can-i-make-sure-given-windows-account-assigned-only-single-certification-authority-ca)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Collection in my lab:
[20240426013313_BloodHound.zip](https://github.com/BloodHoundAD/SharpHoundCommon/files/15128061/20240426013313_BloodHound.zip)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
