### PR TITLE
feat: collect unresolved published cert templates

### DIFF
--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -170,14 +170,23 @@ namespace SharpHoundCommonLib.Processors
             return ret;
         }
         
-        public IEnumerable<TypedPrincipal> ProcessCertTemplates(string[] templates, string domainName)
+        public (IEnumerable<TypedPrincipal> resolvedTemplates, IEnumerable<String> unresolvedTemplates) ProcessCertTemplates(string[] templates, string domainName)
         {
+            var resolvedTemplates = new List<TypedPrincipal>();
+            var unresolvedTemplates = new List<String>();
+
             var certTemplatesLocation = _utils.BuildLdapPath(DirectoryPaths.CertTemplateLocation, domainName);
             foreach (var templateCN in templates)
             {
                 var res = _utils.ResolveCertTemplateByProperty(Encoder.LdapFilterEncode(templateCN), LDAPProperties.CanonicalName, certTemplatesLocation, domainName);
-                yield return res;
+                if (res != null) {
+                    resolvedTemplates.Add(res);
+                } else {
+                    unresolvedTemplates.Add(templateCN);
+                }
             }
+
+            return (resolvedTemplates: resolvedTemplates, unresolvedTemplates: unresolvedTemplates);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Collect unresolved published cert templates for EnterpriseCAs and store them in a property list.

## Motivation and Context

We want to collect the names of unresolved published cert templates, as an attacker can create or rename a cert template to have one of these names and then it will be published automatically.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Collected in my lab with one EnterpriseCA with no unresolved cert templates and another with.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/BloodHoundAD/SharpHoundCommon/assets/12843299/fe4a67c0-5f66-4f41-a763-3103030384cf)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
