### PR TITLE
fix: update oid property to certtemplateoid to match documentation

### DIFF
--- a/src/CommonLib/Processors/LDAPPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LDAPPropertyProcessor.cs
@@ -148,14 +148,14 @@ namespace SharpHoundCommonLib.Processors
         {
             var userProps = new UserProperties();
             var props = GetCommonProps(entry);
-            
+
             var uacFlags = (UacFlags)0;
             var uac = entry.GetProperty(LDAPProperties.UserAccountControl);
             if (int.TryParse(uac, out var flag))
             {
                 uacFlags = (UacFlags)flag;
             }
-            
+
             props.Add("sensitive", uacFlags.HasFlag(UacFlags.NotDelegated));
             props.Add("dontreqpreauth", uacFlags.HasFlag(UacFlags.DontReqPreauth));
             props.Add("passwordnotreqd", uacFlags.HasFlag(UacFlags.PasswordNotRequired));
@@ -260,14 +260,14 @@ namespace SharpHoundCommonLib.Processors
         {
             var compProps = new ComputerProperties();
             var props = GetCommonProps(entry);
-            
+
             var flags = (UacFlags)0;
             var uac = entry.GetProperty(LDAPProperties.UserAccountControl);
             if (int.TryParse(uac, out var flag))
             {
                 flags = (UacFlags)flag;
             }
-            
+
             props.Add("enabled", !flags.HasFlag(UacFlags.AccountDisable));
             props.Add("unconstraineddelegation", flags.HasFlag(UacFlags.TrustedForDelegation));
             props.Add("trustedtoauth", flags.HasFlag(UacFlags.TrustedToAuthForDelegation));
@@ -510,7 +510,7 @@ namespace SharpHoundCommonLib.Processors
             props.Add("ekus", ekus);
             var certificateApplicationPolicy = entry.GetArrayProperty(LDAPProperties.CertificateApplicationPolicy);
             props.Add("certificateapplicationpolicy", certificateApplicationPolicy);
-            
+
             var certificatePolicy = entry.GetArrayProperty(LDAPProperties.CertificatePolicy);
             props.Add("certificatepolicy", certificatePolicy);
 
@@ -543,7 +543,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new IssuancePolicyProperties();
             var props = GetCommonProps(entry);
             props.Add("displayname", entry.GetProperty(LDAPProperties.DisplayName));
-            props.Add("oid", entry.GetProperty(LDAPProperties.CertTemplateOID));
+            props.Add("certtemplateoid", entry.GetProperty(LDAPProperties.CertTemplateOID));
 
             var link = entry.GetProperty(LDAPProperties.OIDGroupLink);
             if (!string.IsNullOrEmpty(link))
@@ -621,9 +621,12 @@ namespace SharpHoundCommonLib.Processors
                 || applicationPolicies.Length == 0
                 || schemaVersion == 1
                 || schemaVersion == 2
-                || (schemaVersion == 4 && hasUseLegacyProvider)) {
+                || (schemaVersion == 4 && hasUseLegacyProvider))
+            {
                 return applicationPolicies;
-            } else {
+            }
+            else
+            {
                 // Format: "Name`Type`Value`Name`Type`Value`..."
                 // (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-crtd/c55ec697-be3f-4117-8316-8895e4399237)
                 // Return the Value of Name = "msPKI-RA-Application-Policies" entries

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -23,7 +23,7 @@ namespace CommonLibTest
                 "OU=Test\\, OU,OU=Test,DC=Fabrikam,DC=COM");
             Assert.Equal("OU=Test,DC=Fabrikam,DC=COM", result);
         }
-        
+
         [Fact]
         public void SplitGPLinkProperty_ValidPropFilterEnabled_ExpectedResult()
         {
@@ -166,7 +166,7 @@ namespace CommonLibTest
             var actual = SharpHoundCommonLib.Helpers.StripServicePrincipalName(testString);
             Assert.Equal(expected, actual);
         }
-        
+
         [Fact]
         public void StripServicePrincipalName_EmptyHost_Valid()
         {
@@ -202,7 +202,7 @@ namespace CommonLibTest
             Assert.Equal(-1, result);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ConvertFileTimeToUnixEpoch_WrongFormat_FortmatException()
         {
             Exception ex =
@@ -229,7 +229,7 @@ namespace CommonLibTest
             Assert.Equal(d.ToUniversalTime().Date, testDate);
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ConvertTimestampToUnixEpoch_InvalidTimestamp_FormatException()
         {
             Exception ex = Assert.Throws<FormatException>(() =>

--- a/test/unit/Facades/MockLDAPUtils.cs
+++ b/test/unit/Facades/MockLDAPUtils.cs
@@ -41,10 +41,10 @@ namespace CommonLibTest.Facades
             name = name.ToLower();
             return name switch
             {
-                "dfm" => new[] {"S-1-5-21-3130019616-2776909439-2417379446-1105"},
+                "dfm" => new[] { "S-1-5-21-3130019616-2776909439-2417379446-1105" },
                 "administrator" => new[]
                     {"S-1-5-21-3130019616-2776909439-2417379446-500", "S-1-5-21-3084884204-958224920-2707782874-500"},
-                "admin" => new[] {"S-1-5-21-3130019616-2776909439-2417379446-2116"},
+                "admin" => new[] { "S-1-5-21-3130019616-2776909439-2417379446-2116" },
                 _ => Array.Empty<string>()
             };
         }
@@ -1021,7 +1021,8 @@ namespace CommonLibTest.Facades
                     "S-1-5-21-3130019616-2776909439-2417379446-2106", Label.User),
                 "CN=KRBTGT,CN=USERS,DC=TESTLAB,DC=LOCAL" => new TypedPrincipal(
                     "S-1-5-21-3130019616-2776909439-2417379446-502", Label.User),
-                _ => null
+                "CN=ENTERPRISE KEY ADMINS,CN=USERS,DC=ESC10,DC=LOCAL" => new TypedPrincipal("S-1-5-21-3662707843-2053279151-3839588741-527", Label.Group),
+                _ => null,
             };
         }
 
@@ -1064,7 +1065,7 @@ namespace CommonLibTest.Facades
 
         private Group GetBaseEnterpriseDC()
         {
-            var g = new Group {ObjectIdentifier = "TESTLAB.LOCAL-S-1-5-9".ToUpper()};
+            var g = new Group { ObjectIdentifier = "TESTLAB.LOCAL-S-1-5-9".ToUpper() };
             g.Properties.Add("name", "ENTERPRISE DOMAIN CONTROLLERS@TESTLAB.LOCAL".ToUpper());
             return g;
         }

--- a/test/unit/LDAPPropertyTests.cs
+++ b/test/unit/LDAPPropertyTests.cs
@@ -771,6 +771,78 @@ namespace CommonLibTest
         }
 
         [Fact]
+        public void LDAPPropertyProcessor_ReadIssuancePolicyProperties()
+        {
+            var mock = new MockSearchResultEntry("CN\u003d6250993.11BB1AB25A8A65E9FCDF709FCDD5FBC6,CN\u003dOID,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dESC10,DC\u003dLOCAL",
+                new Dictionary<string, object>
+                {
+                    {"domain", "ESC10.LOCAL"},
+                    {"name", "KEYADMINSOID@ESC10.LOCAL"},
+                    {"domainsid", "S-1-5-21-3662707843-2053279151-3839588741"},
+                    {"description", null},
+                    {"whencreated", 1712567279},
+                    {"displayname", "KeyAdminsOID"},
+                    {"certtemplateoid", "1.3.6.1.4.1.311.21.8.4571196.1884641.3293620.10686285.12068043.134.1.30"},
+                    {"msds-oidtogrouplink", "CN=ENTERPRISE KEY ADMINS,CN=USERS,DC=ESC10,DC=LOCAL"}
+                    ,
+                }, "1E5311A8-E949-4E02-8E08-234ED63200DE", Label.IssuancePolicy);
+
+            var mockLDAPUtils = new MockLDAPUtils();
+            var ldapPropertyProcessor = new LDAPPropertyProcessor(mockLDAPUtils);
+
+
+            var test = ldapPropertyProcessor.ReadIssuancePolicyProperties(mock);
+            var keys = test.Props.Keys;
+
+            //These are not common properties
+            Assert.DoesNotContain("domain", keys);
+            Assert.DoesNotContain("name", keys);
+            Assert.DoesNotContain("domainsid", keys);
+
+            Assert.Contains("description", keys);
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("displayname", keys);
+            Assert.Contains("certtemplateoid", keys);
+            Assert.Contains("oidgrouplink", keys);
+        }
+
+        [Fact]
+        public void LDAPPropertyProcessor_ReadIssuancePolicyProperties_NoOIDGroupLink()
+        {
+            var mock = new MockSearchResultEntry("CN\u003d6250993.11BB1AB25A8A65E9FCDF709FCDD5FBC6,CN\u003dOID,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dESC10,DC\u003dLOCAL",
+                new Dictionary<string, object>
+                {
+                    {"domain", "ESC10.LOCAL"},
+                    {"name", "KEYADMINSOID@ESC10.LOCAL"},
+                    {"domainsid", "S-1-5-21-3662707843-2053279151-3839588741"},
+                    {"description", null},
+                    {"whencreated", 1712567279},
+                    {"displayname", "KeyAdminsOID"},
+                    {"certtemplateoid", "1.3.6.1.4.1.311.21.8.4571196.1884641.3293620.10686285.12068043.134.1.30"},
+                    {"msds-oidtogrouplink", null}
+                    ,
+                }, "1E5311A8-E949-4E02-8E08-234ED63200DE", Label.IssuancePolicy);
+
+            var mockLDAPUtils = new MockLDAPUtils();
+            var ldapPropertyProcessor = new LDAPPropertyProcessor(mockLDAPUtils);
+
+
+            var test = ldapPropertyProcessor.ReadIssuancePolicyProperties(mock);
+            var keys = test.Props.Keys;
+
+            //These are not common properties
+            Assert.DoesNotContain("domain", keys);
+            Assert.DoesNotContain("name", keys);
+            Assert.DoesNotContain("domainsid", keys);
+            Assert.DoesNotContain("oidgrouplink", keys);
+
+            Assert.Contains("description", keys);
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("displayname", keys);
+            Assert.Contains("certtemplateoid", keys);
+        }
+
+        [Fact]
         public void LDAPPropertyProcessor_ParseAllProperties()
         {
             var mock = new MockSearchResultEntry("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",


### PR DESCRIPTION
## Description
The property `oid` was renamed to `certtemplateoid`
<!--- Describe your changes in detail -->

## Motivation and Context
`certtemplateoid` is what has been documented to have this property named as and this is the property name that the logic in BloodHound pivots off of for creating `ExtendedByPolicy` edges.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Two unit tests were added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
