### PR TITLE
ACL Inheritance Tracking

### DIFF
--- a/src/CommonLib/OutputTypes/ACE.cs
+++ b/src/CommonLib/OutputTypes/ACE.cs
@@ -1,39 +1,33 @@
 ﻿using SharpHoundCommonLib.Enums;
 
-namespace SharpHoundCommonLib.OutputTypes
-{
-    public class ACE
-    {
+namespace SharpHoundCommonLib.OutputTypes {
+    public class ACE {
         public string PrincipalSID { get; set; }
         public Label PrincipalType { get; set; }
         public string RightName { get; set; }
         public bool IsInherited { get; set; }
+        public string InheritanceHash { get; set; }
 
-        public override string ToString()
-        {
+        public override string ToString() {
             return $"{PrincipalType} {PrincipalSID} - {RightName} {(IsInherited ? "" : "Not")} Inherited";
         }
 
-        protected bool Equals(ACE other)
-        {
+        protected bool Equals(ACE other) {
             return PrincipalSID == other.PrincipalSID && PrincipalType == other.PrincipalType &&
                    RightName == other.RightName && IsInherited == other.IsInherited;
         }
 
-        public override bool Equals(object obj)
-        {
+        public override bool Equals(object obj) {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
-            return Equals((ACE) obj);
+            return Equals((ACE)obj);
         }
 
-        public override int GetHashCode()
-        {
-            unchecked
-            {
+        public override int GetHashCode() {
+            unchecked {
                 var hashCode = PrincipalSID != null ? PrincipalSID.GetHashCode() : 0;
-                hashCode = (hashCode * 397) ^ (int) PrincipalType;
+                hashCode = (hashCode * 397) ^ (int)PrincipalType;
                 hashCode = (hashCode * 397) ^ (RightName != null ? RightName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ IsInherited.GetHashCode();
                 return hashCode;

--- a/src/CommonLib/OutputTypes/Container.cs
+++ b/src/CommonLib/OutputTypes/Container.cs
@@ -5,5 +5,6 @@ namespace SharpHoundCommonLib.OutputTypes
     public class Container : OutputBase
     {
         public TypedPrincipal[] ChildObjects { get; set; } = Array.Empty<TypedPrincipal>();
+        public string[] InheritanceHashes { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/CommonLib/OutputTypes/Domain.cs
+++ b/src/CommonLib/OutputTypes/Domain.cs
@@ -8,5 +8,6 @@ namespace SharpHoundCommonLib.OutputTypes
         public TypedPrincipal[] ChildObjects { get; set; } = Array.Empty<TypedPrincipal>();
         public DomainTrust[] Trusts { get; set; } = Array.Empty<DomainTrust>();
         public GPLink[] Links { get; set; } = Array.Empty<GPLink>();
+        public string[] InheritanceHashes { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/CommonLib/OutputTypes/OU.cs
+++ b/src/CommonLib/OutputTypes/OU.cs
@@ -7,5 +7,6 @@ namespace SharpHoundCommonLib.OutputTypes
         public ResultingGPOChanges GPOChanges = new();
         public GPLink[] Links { get; set; } = Array.Empty<GPLink>();
         public TypedPrincipal[] ChildObjects { get; set; } = Array.Empty<TypedPrincipal>();
+        public string[] InheritanceHashes { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -79,8 +79,8 @@ namespace SharpHoundCommonLib.Processors {
         /// <param name="entry"></param>
         /// <returns></returns>
         public bool IsACLProtected(IDirectoryObject entry) {
-            if (entry.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var ntsd)) {
-                return IsACLProtected(ntsd);
+            if (entry.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var ntSecurityDescriptor)) {
+                return IsACLProtected(ntSecurityDescriptor);
             }
 
             return false;

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -120,7 +120,7 @@ namespace SharpHoundCommonLib.Processors {
             return ProcessACL(descriptor, domain, type, hasLaps, name);
         }
 
-        private static string CalculateInheritanceHash(string identityReference, ActiveDirectoryRights rights,
+        internal static string CalculateInheritanceHash(string identityReference, ActiveDirectoryRights rights,
             string aceType, string inheritedObjectType) {
             var hash = identityReference + rights + aceType + inheritedObjectType;
             using (var md5 = MD5.Create()) {

--- a/src/CommonLib/SecurityDescriptor.cs
+++ b/src/CommonLib/SecurityDescriptor.cs
@@ -15,6 +15,8 @@ namespace SharpHoundCommonLib
             _inner = inner;
         }
 
+        public InheritanceFlags InheritanceFlags => _inner.InheritanceFlags;
+
         public virtual AccessControlType AccessControlType()
         {
             return _inner.AccessControlType;
@@ -28,6 +30,10 @@ namespace SharpHoundCommonLib
         public virtual bool IsInherited()
         {
             return _inner.IsInherited;
+        }
+
+        public virtual string InheritedObjectType() {
+            return _inner.InheritedObjectType.ToString();
         }
 
         public virtual bool IsAceInheritedFrom(string guid)

--- a/src/CommonLib/SecurityDescriptor.cs
+++ b/src/CommonLib/SecurityDescriptor.cs
@@ -15,7 +15,7 @@ namespace SharpHoundCommonLib
             _inner = inner;
         }
 
-        public InheritanceFlags InheritanceFlags => _inner.InheritanceFlags;
+        public virtual InheritanceFlags InheritanceFlags => _inner.InheritanceFlags;
 
         public virtual AccessControlType AccessControlType()
         {

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -16,11 +16,9 @@ using SharpHoundCommonLib.Processors;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CommonLibTest
-{
+namespace CommonLibTest {
     [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
-    public class ACLProcessorTest : IDisposable
-    {
+    public class ACLProcessorTest : IDisposable {
         private const string ProtectedUserNTSecurityDescriptor =
             "AQAEnIgEAAAAAAAAAAAAABQAAAAEAHQEGAAAAAUAPAAQAAAAAwAAAABCFkzAINARp2gAqgBuBSkUzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAABCFkzAINARp2gAqgBuBSm6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAABAgIF+ledARkCAAwE/C1M8UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAABAgIF+ledARkCAAwE/C1M+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEDCCrypedARkCAAwE/C1M8UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEDCCrypedARkCAAwE/C1M+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEIvulmiedARkCAAwE/C088UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEIvulmiedARkCAAwE/C08+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAPiIcAPhCtIRtCIAoMlo+TkUzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAPiIcAPhCtIRtCIAoMlo+Tm6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAOAAwAAAAAQAAAH96lr/mDdARooUAqgAwSeIBBQAAAAAABRUAAAAgT5C6f0aEpXZIFpAFAgAABQAsABAAAAABAAAAHbGpRq5gWkC36P+KWNRW0gECAAAAAAAFIAAAADACAAAFACwAMAAAAAEAAAAcmrZtIpTREa69AAD4A2fBAQIAAAAAAAUgAAAAMQIAAAUALAAwAAAAAQAAAGK8BVjJvShEpeKFag9MGF4BAgAAAAAABSAAAAAxAgAABQAsAJQAAgACAAAAFMwoSDcUvEWbB61vAV5fKAECAAAAAAAFIAAAACoCAAAFACwAlAACAAIAAAC6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAKAAAAQAAAQAAAFMacqsvHtARmBkAqgBAUpsBAQAAAAAAAQAAAAAFACgAAAEAAAEAAABTGnKrLx7QEZgZAKoAQFKbAQEAAAAAAAUKAAAABQIoADABAAABAAAA3kfmkW/ZcEuVV9Y/9PPM2AEBAAAAAAAFCgAAAAAAJAC/AQ4AAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAAAJAC/AQ4AAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAAAGAC/AQ8AAQIAAAAAAAUgAAAAIAIAAAAAFACUAAIAAQEAAAAAAAULAAAAAAAUAP8BDwABAQAAAAAABRIAAAABBQAAAAAABRUAAAAgT5C6f0aEpXZIFpAAAgAA";
 
@@ -38,34 +36,29 @@ namespace CommonLibTest
         private readonly string _testDomainName;
         private readonly ITestOutputHelper _testOutputHelper;
 
-        public ACLProcessorTest(ITestOutputHelper testOutputHelper)
-        {
+        public ACLProcessorTest(ITestOutputHelper testOutputHelper) {
             _testOutputHelper = testOutputHelper;
             _testDomainName = "TESTLAB.LOCAL";
             _baseProcessor = new ACLProcessor(new LdapUtils());
         }
 
-        public void Dispose()
-        {
+        public void Dispose() {
         }
 
         [Fact]
-        public void SanityCheck()
-        {
+        public void SanityCheck() {
             Assert.True(true);
         }
 
         [Fact]
-        public void ACLProcessor_IsACLProtected_NullNTSD_ReturnsFalse()
-        {
+        public void ACLProcessor_IsACLProtected_NullNTSD_ReturnsFalse() {
             var processor = new ACLProcessor(new MockLdapUtils());
             var result = processor.IsACLProtected((byte[])null);
             Assert.False(result);
         }
 
         [WindowsOnlyFact]
-        public async Task ACLProcessor_TestKnownDataAddMember()
-        {
+        public async Task ACLProcessor_TestKnownDataAddMember() {
             var mockLdapUtils = new MockLdapUtils();
             var mockUtils = new Mock<ILdapUtils>();
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
@@ -89,957 +82,992 @@ namespace CommonLibTest
                 x => x.RightName == EdgeNames.AddMember &&
                      x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-2119");
         }
-    
-    [Fact]
-    public void ACLProcessor_IsACLProtected_ReturnsTrue()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(true);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(ProtectedUserNTSecurityDescriptor);
-        var result = processor.IsACLProtected(bytes);
-        Assert.True(result);
-    }
-    
-    [Fact]
-    public void ACLProcessor_IsACLProtected_ReturnsFalse()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        mockSecurityDescriptor.Setup(m => m.AreAccessRulesProtected()).Returns(false);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = processor.IsACLProtected(bytes);
-        Assert.False(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessGMSAReaders_NullNTSD_ReturnsNothing()
-    {
-        var test =await  _baseProcessor.ProcessGMSAReaders(null, "").ToArrayAsync();
-        Assert.Empty(test);
-    }
-    
-    [Fact]
-    public async Task ACLProcess_ProcessGMSAReaders_YieldsCorrectAce()
-    {
-        var expectedRightName = EdgeNames.ReadGMSAPassword;
-        var expectedSID = "S-1-5-21-3130019616-2776909439-2417379446-500";
-        var expectedPrincipalType = Label.User;
-        var expectedInheritance = false;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-    
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedSID);
-    
-        var collection = new List<ActiveDirectoryRuleDescriptor> { mockRule.Object };
 
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(GMSAProperty);
-        var result = await  processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        _testOutputHelper.WriteLine(actual.ToString());
-        Assert.Equal(expectedRightName, actual.RightName);
-        Assert.Equal(expectedSID, actual.PrincipalSID);
-        Assert.Equal(expectedPrincipalType, actual.PrincipalType);
-        Assert.Equal(expectedInheritance, actual.IsInherited);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessGMSAReaders_Null_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor> { null };
+        [Fact]
+        public void ACLProcessor_IsACLProtected_ReturnsTrue() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(true);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(GMSAProperty);
-        var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessGMSAReaders_Deny_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-    
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Deny);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(GMSAProperty);
-        var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessGMSAReaders_Null_PrincipalID()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-    
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(GMSAProperty);
-        var result =await  processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Null_NTSecurityDescriptor()
-    {
-        var processor = new ACLProcessor(new MockLdapUtils());
-        var result = await processor.ProcessACL(null, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Yields_Owns_ACE()
-    {
-        var expectedSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedPrincipalType = Label.Group;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns(expectedSID);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedSID, expectedPrincipalType)));
-    
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalSID, expectedSID);
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, EdgeNames.Owns);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Null_SID()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Null_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor> { null };
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(ProtectedUserNTSecurityDescriptor);
+            var result = processor.IsACLProtected(bytes);
+            Assert.True(result);
+        }
 
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Deny_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Deny);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Unmatched_Inheritance_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(false);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Null_SID_ACE()
-    {
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericAll_Unmatched_Guid()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var unmatchedGuid = new Guid("583991c8-629d-4a07-8a70-74d19d22ac9c");
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericAll);
-        mockRule.Setup(x => x.ObjectType()).Returns(unmatchedGuid);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericAll()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericAll);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, EdgeNames.GenericAll);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_WriteDacl()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = ActiveDirectoryRights.WriteDacl;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(expectedRightName);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName.ToString());
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_WriteOwner()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = ActiveDirectoryRights.WriteOwner;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(expectedRightName);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName.ToString());
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_Self()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AddSelf;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.Self);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_Unmatched()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_DSReplicationGetChanges()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.GetChanges;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.DSReplicationGetChanges));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_All()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AllExtendedRights;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_DSReplicationGetChangesAll()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.GetChangesAll;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.DSReplicationGetChangesAll));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-        mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-            .Returns(mockData.ToAsyncEnumerable());
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_User_Unmatched()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.GetChangesAll;
-        var unmatchedGuid = new Guid("583991c8-629d-4a07-8a70-74d19d22ac9c");
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(unmatchedGuid);
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_User_UserForceChangePassword()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.ForceChangePassword;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.UserForceChangePassword));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_User_All()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AllExtendedRights;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Computer_NoLAPS()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AllExtendedRights;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, false).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Computer_All()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AllExtendedRights;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact(Skip = "Need to populate cache to reach this case")]
-    public async Task ACLProcessor_ProcessACL_ExtendedRight_Computer_MappedGuid()
-    {
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericWrite_Unmatched()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AllExtendedRights;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Container, true).ToArrayAsync();
-    
-        Assert.Empty(result);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericWrite_User_All()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.GenericWrite;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, true).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericWrite_User_WriteMember()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AddMember;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, true).ToArrayAsync();
-    
-        _testOutputHelper.WriteLine(JsonConvert.SerializeObject(result));
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
-    
-    [Fact]
-    public async Task ACLProcessor_ProcessACL_GenericWrite_Computer_WriteAllowedToAct()
-    {
-        var expectedPrincipalType = Label.Group;
-        var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        var expectedRightName = EdgeNames.AddAllowedToAct;
-    
-        var mockLDAPUtils = new Mock<ILdapUtils>();
-        var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        var collection = new List<ActiveDirectoryRuleDescriptor>();
-        mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
-        mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteAllowedToAct));
-        collection.Add(mockRule.Object);
-    
-        mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-            .Returns(collection);
-        mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync((true,new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-    
-        var processor = new ACLProcessor(mockLDAPUtils.Object);
-        var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
-    
-        Assert.Single(result);
-        var actual = result.First();
-        Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        Assert.False(actual.IsInherited);
-        Assert.Equal(actual.RightName, expectedRightName);
-    }
+        [Fact]
+        public void ACLProcessor_IsACLProtected_ReturnsFalse() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            mockSecurityDescriptor.Setup(m => m.AreAccessRulesProtected()).Returns(false);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = processor.IsACLProtected(bytes);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessGMSAReaders_NullNTSD_ReturnsNothing() {
+            var test = await _baseProcessor.ProcessGMSAReaders(null, "").ToArrayAsync();
+            Assert.Empty(test);
+        }
+
+        [Fact]
+        public async Task ACLProcess_ProcessGMSAReaders_YieldsCorrectAce() {
+            var expectedRightName = EdgeNames.ReadGMSAPassword;
+            var expectedSID = "S-1-5-21-3130019616-2776909439-2417379446-500";
+            var expectedPrincipalType = Label.User;
+            var expectedInheritance = false;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedSID);
+
+            var collection = new List<ActiveDirectoryRuleDescriptor> { mockRule.Object };
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedSID, expectedPrincipalType)));
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(GMSAProperty);
+            var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            _testOutputHelper.WriteLine(actual.ToString());
+            Assert.Equal(expectedRightName, actual.RightName);
+            Assert.Equal(expectedSID, actual.PrincipalSID);
+            Assert.Equal(expectedPrincipalType, actual.PrincipalType);
+            Assert.Equal(expectedInheritance, actual.IsInherited);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessGMSAReaders_Null_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor> { null };
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(GMSAProperty);
+            var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessGMSAReaders_Deny_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Deny);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(GMSAProperty);
+            var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessGMSAReaders_Null_PrincipalID() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(GMSAProperty);
+            var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Null_NTSecurityDescriptor() {
+            var processor = new ACLProcessor(new MockLdapUtils());
+            var result = await processor.ProcessACL(null, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Yields_Owns_ACE() {
+            var expectedSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedPrincipalType = Label.Group;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns(expectedSID);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedSID, expectedPrincipalType)));
+
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalSID, expectedSID);
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, EdgeNames.Owns);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Null_SID() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Null_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor> { null };
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Deny_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Deny);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Unmatched_Inheritance_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(false);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Null_SID_ACE() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns((string)null);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericAll_Unmatched_Guid() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var unmatchedGuid = new Guid("583991c8-629d-4a07-8a70-74d19d22ac9c");
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericAll);
+            mockRule.Setup(x => x.ObjectType()).Returns(unmatchedGuid);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericAll() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericAll);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, EdgeNames.GenericAll);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_WriteDacl() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = ActiveDirectoryRights.WriteDacl;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(expectedRightName);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName.ToString());
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_WriteOwner() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = ActiveDirectoryRights.WriteOwner;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(expectedRightName);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName.ToString());
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Self() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AddSelf;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.Self);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_Unmatched() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_DSReplicationGetChanges() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.GetChanges;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.DSReplicationGetChanges));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_All() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AllExtendedRights;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_DSReplicationGetChangesAll() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.GetChangesAll;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.DSReplicationGetChangesAll));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Domain, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_User_Unmatched() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var unmatchedGuid = new Guid("583991c8-629d-4a07-8a70-74d19d22ac9c");
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(unmatchedGuid);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_User_UserForceChangePassword() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.ForceChangePassword;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.UserForceChangePassword));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_User_All() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AllExtendedRights;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Computer_NoLAPS() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_ExtendedRight_Computer_All() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AllExtendedRights;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericWrite_Unmatched() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Container, true).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericWrite_User_All() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.GenericWrite;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.User, true).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericWrite_User_WriteMember() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AddMember;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteMember));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, true).ToArrayAsync();
+
+            _testOutputHelper.WriteLine(JsonConvert.SerializeObject(result));
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_GenericWrite_Computer_WriteAllowedToAct() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AddAllowedToAct;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteAllowedToAct));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+
+        [Fact]
+        public void GetInheritedAceHashes_NullSD_Empty() {
+            var proc = new ACLProcessor(new MockLdapUtils());
+            var result = proc.GetInheritedAceHashes(null).ToArray();
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetInheritedAceHashes_HappyPath() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            const string expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteAllowedToAct));
+            mockRule.Setup(x => x.IsInherited()).Returns(true);
+            mockRule.Setup(x => x.InheritanceFlags).Returns(InheritanceFlags.ContainerInherit);
+            collection.Add(mockRule.Object);
+            mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteAllowedToAct));
+            mockRule.Setup(x => x.IsInherited()).Returns(false);
+            mockRule.Setup(x => x.InheritanceFlags).Returns(InheritanceFlags.ContainerInherit);
+            collection.Add(mockRule.Object);
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var result = processor.GetInheritedAceHashes(Array.Empty<byte>()).ToArray();
+            Assert.Single(result);
+        }
+        
+        [Fact]
+        public void Test_ACLInheritanceHashSame() {
+            const string expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var g = new Guid().ToString();
+            var result1 = ACLProcessor.CalculateInheritanceHash(expectedPrincipalSID,
+                ActiveDirectoryRights.GenericWrite, new Guid(ACEGuids.WriteAllowedToAct).ToString(), g);
+            var result2 = ACLProcessor.CalculateInheritanceHash(expectedPrincipalSID,
+                ActiveDirectoryRights.GenericWrite, new Guid(ACEGuids.WriteAllowedToAct).ToString(), g);
+            
+            Assert.Equal(result1, result2);
+        }
     }
 }

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1069,5 +1069,29 @@ namespace CommonLibTest {
             
             Assert.Equal(result1, result2);
         }
+        
+        [Fact]
+        public void Test_ACLProcessor_IsACLProtected_Protected() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(true);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var result = processor.IsACLProtected(Array.Empty<byte>());
+            Assert.True(result);
+        }
+        
+        [Fact]
+        public void Test_ACLProcessor_IsACLProtected_NotProtected() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(false);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var result = processor.IsACLProtected(Array.Empty<byte>());
+            Assert.False(result);
+        }
     }
 }


### PR DESCRIPTION
## Description
Add tracking of ACL inheritance to determine likely predecessors
<!--- Describe your changes in detail -->

## Motivation and Context
Currently, we only have information on if an ACL is inherited or not, but not where this ACL is inherited from. Implementing this will allow users to track sources of an ACE and use that for remediation or other purposes

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-4308

## How Has This Been Tested?
Tested locally in a lab

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
