### PR TITLE
Replace System.Linq.Async with custom implementations

### DIFF
--- a/src/CommonLib/AsyncEnumerable.cs
+++ b/src/CommonLib/AsyncEnumerable.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SharpHoundCommonLib;
+
+public static class AsyncEnumerable {
+    public static IAsyncEnumerable<T> Empty<T>() => EmptyAsyncEnumerable<T>.Instance;
+    
+    private sealed class EmptyAsyncEnumerable<T> : IAsyncEnumerable<T> {
+        public static readonly EmptyAsyncEnumerable<T> Instance = new();
+        private readonly IAsyncEnumerator<T> _enumerator = new EmptyAsyncEnumerator<T>(); 
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken()) {
+            return _enumerator;
+        }
+    }
+
+    private sealed class EmptyAsyncEnumerator<T> : IAsyncEnumerator<T> {
+        public ValueTask DisposeAsync() => default;
+        public ValueTask<bool> MoveNextAsync() => new(false);
+        public T Current => default;
+    }
+}

--- a/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
@@ -15,7 +15,7 @@ public class SearchResultEntryWrapper : IDirectoryObject {
     }
 
     public bool TryGetDistinguishedName(out string value) {
-        return TryGetProperty(LDAPProperties.DistinguishedName, out value);
+        return TryGetProperty(LDAPProperties.DistinguishedName, out value) && !string.IsNullOrWhiteSpace(value);
     }
 
     public bool TryGetProperty(string propertyName, out string value) {

--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -21,6 +21,9 @@ namespace SharpHoundCommonLib
         
         public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> items)
         {
+            if (items == null) {
+                return new List<T>();
+            }
             var results = new List<T>();
             await foreach (var item in items
                                .ConfigureAwait(false))
@@ -30,6 +33,9 @@ namespace SharpHoundCommonLib
         
         public static async Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> items)
         {
+            if (items == null) {
+                return Array.Empty<T>();
+            }
             var results = new List<T>();
             await foreach (var item in items
                                .ConfigureAwait(false))
@@ -78,6 +84,7 @@ namespace SharpHoundCommonLib
             }
             
             public async ValueTask DisposeAsync() {
+                _enumeratorDisposed = true;
                 if (_enumerator != null) {
                     await _enumerator.DisposeAsync().ConfigureAwait(false);
                     _enumerator = null;
@@ -97,7 +104,6 @@ namespace SharpHoundCommonLib
 
                 _current = _defaultValue;
                 await _enumerator.DisposeAsync().ConfigureAwait(false);
-                _enumeratorDisposed = true;
                 return true;
             }
 

--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -115,7 +115,7 @@ namespace SharpHoundCommonLib
                 }
 
                 _current = _defaultValue;
-                await _enumerator.DisposeAsync().ConfigureAwait(false);
+                await DisposeAsync().ConfigureAwait(false);
                 return true;
             }
 

--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -54,7 +54,19 @@ namespace SharpHoundCommonLib
                 return first;
             }
         }
+        
+        public static async Task<T> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source, T defaultValue,
+            CancellationToken cancellationToken = default) {
+            if (source == null) {
+                return defaultValue;
+            }
 
+            await using (var enumerator = source.GetAsyncEnumerator(cancellationToken)) {
+                var first = await enumerator.MoveNextAsync() ? enumerator.Current : defaultValue;
+                return first;
+            }
+        }
+        
         public static IAsyncEnumerable<T> DefaultIfEmpty<T>(this IAsyncEnumerable<T> source,
             T defaultValue, CancellationToken cancellationToken = default) {
             return new DefaultIfEmptyAsyncEnumerable<T>(source, defaultValue);

--- a/src/CommonLib/Extensions.cs
+++ b/src/CommonLib/Extensions.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.DirectoryServices;
 using System.Linq;
 using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
 
@@ -16,14 +19,91 @@ namespace SharpHoundCommonLib
             Log = Logging.LogProvider.CreateLogger("Extensions");
         }
         
-        // internal static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> items)
-        // {
-        //     var results = new List<T>();
-        //     await foreach (var item in items
-        //                        .ConfigureAwait(false))
-        //         results.Add(item);
-        //     return results;
-        // }
+        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> items)
+        {
+            var results = new List<T>();
+            await foreach (var item in items
+                               .ConfigureAwait(false))
+                results.Add(item);
+            return results;
+        }
+        
+        public static async Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> items)
+        {
+            var results = new List<T>();
+            await foreach (var item in items
+                               .ConfigureAwait(false))
+                results.Add(item);
+            return results.ToArray();
+        }
+
+        public static async Task<T> FirstOrDefaultAsync<T>(this IAsyncEnumerable<T> source,
+            CancellationToken cancellationToken = default) {
+            if (source == null) {
+                return default;
+            }
+
+            await using (var enumerator = source.GetAsyncEnumerator(cancellationToken)) {
+                var first = await enumerator.MoveNextAsync() ? enumerator.Current : default;
+                return first;
+            }
+        }
+
+        public static IAsyncEnumerable<T> DefaultIfEmpty<T>(this IAsyncEnumerable<T> source,
+            T defaultValue, CancellationToken cancellationToken = default) {
+            return new DefaultIfEmptyAsyncEnumerable<T>(source, defaultValue);
+        }
+
+        private sealed class DefaultIfEmptyAsyncEnumerable<T> : IAsyncEnumerable<T> {
+            private readonly DefaultIfEmptyAsyncEnumerator<T> _enumerator;
+            public DefaultIfEmptyAsyncEnumerable(IAsyncEnumerable<T> source, T defaultValue) {
+                _enumerator = new DefaultIfEmptyAsyncEnumerator<T>(source, defaultValue);
+            }
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken()) {
+                return _enumerator;
+            }
+        }
+
+        private sealed class DefaultIfEmptyAsyncEnumerator<T> : IAsyncEnumerator<T> {
+            private readonly IAsyncEnumerable<T> _source;
+            private readonly T _defaultValue;
+            private T _current;
+            private bool _enumeratorDisposed;
+
+            private IAsyncEnumerator<T> _enumerator;
+            
+            public DefaultIfEmptyAsyncEnumerator(IAsyncEnumerable<T> source, T defaultValue) {
+                _source = source;
+                _defaultValue = defaultValue;
+            }
+            
+            public async ValueTask DisposeAsync() {
+                if (_enumerator != null) {
+                    await _enumerator.DisposeAsync().ConfigureAwait(false);
+                    _enumerator = null;
+                }
+            }
+
+            public async ValueTask<bool> MoveNextAsync() {
+                if (_enumeratorDisposed) {
+                    return false;
+                }
+                _enumerator ??= _source.GetAsyncEnumerator();
+
+                if (await _enumerator.MoveNextAsync().ConfigureAwait(false)) {
+                    _current = _enumerator.Current;
+                    return true;
+                }
+
+                _current = _defaultValue;
+                await _enumerator.DisposeAsync().ConfigureAwait(false);
+                _enumeratorDisposed = true;
+                return true;
+            }
+
+            public T Current => _current;
+        }
+
 
         public static string LdapValue(this SecurityIdentifier s)
         {

--- a/src/CommonLib/ILdapUtils.cs
+++ b/src/CommonLib/ILdapUtils.cs
@@ -88,6 +88,8 @@ namespace SharpHoundCommonLib {
         /// <param name="domain">The Domain object</param>
         /// <returns>True if the domain was found, false if not</returns>
         bool GetDomain(out System.DirectoryServices.ActiveDirectory.Domain domain);
+
+        Task<(bool Success, string ForestName)> GetForest(string domain);
         /// <summary>
         /// Attempts to resolve an account name to its corresponding typed principal
         /// </summary>

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -21,7 +21,6 @@
         <PackageReference Include="AntiXSS" Version="4.3.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.DirectoryServices" />

--- a/test/unit/AsyncEnumerableTests.cs
+++ b/test/unit/AsyncEnumerableTests.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using SharpHoundCommonLib;
+using Xunit;
+
+namespace CommonLibTest;
+
+public class AsyncEnumerableTests {
+    [Fact]
+    public async Task AsyncEnumerable_DefaultIfEmpty_Empty() {
+        var enumerable = AsyncEnumerable.Empty<int>().DefaultIfEmpty(1);
+        var e = enumerable.GetAsyncEnumerator();
+        var res = await e.MoveNextAsync();
+        Assert.True(res);
+        Assert.Equal(1, e.Current);
+        Assert.False(await e.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task AsyncEnumerable_FirstOrDefault() {
+        var enumerable = AsyncEnumerable.Empty<int>();
+        var res = await enumerable.FirstOrDefaultAsync();
+        Assert.Equal(0, res);
+    }
+
+    [Fact]
+    public async Task AsyncEnumerable_CombinedOperators() {
+        var enumerable = AsyncEnumerable.Empty<string>();
+        var res = await enumerable.DefaultIfEmpty("abc").FirstOrDefaultAsync();
+        Assert.Equal("abc", res);
+    }
+}

--- a/test/unit/AsyncEnumerableTests.cs
+++ b/test/unit/AsyncEnumerableTests.cs
@@ -21,6 +21,13 @@ public class AsyncEnumerableTests {
         var res = await enumerable.FirstOrDefaultAsync();
         Assert.Equal(0, res);
     }
+    
+    [Fact]
+    public async Task AsyncEnumerable_FirstOrDefault_WithDefault() {
+        var enumerable = AsyncEnumerable.Empty<int>();
+        var res = await enumerable.FirstOrDefaultAsync(10);
+        Assert.Equal(10, res);
+    }
 
     [Fact]
     public async Task AsyncEnumerable_CombinedOperators() {

--- a/test/unit/AsyncEnumerableTests.cs
+++ b/test/unit/AsyncEnumerableTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using SharpHoundCommonLib;
 using Xunit;
@@ -34,5 +35,58 @@ public class AsyncEnumerableTests {
         var enumerable = AsyncEnumerable.Empty<string>();
         var res = await enumerable.DefaultIfEmpty("abc").FirstOrDefaultAsync();
         Assert.Equal("abc", res);
+    }
+
+    [Fact]
+    public async Task AsyncEnumerable_ToAsyncEnumerable() {
+        var collection = new[] {
+            "a", "b", "c"
+        };
+        
+        var test = collection.ToAsyncEnumerable();
+
+        var index = 0;
+        await foreach (var item in test) {
+            Assert.Equal(collection[index], item);
+            index++;
+        }
+    }
+
+    [Fact]
+    public async Task AsyncEnumerable_FirstOrDefaultFunction() {
+        var test = await TestFunc().FirstOrDefaultAsync();
+        Assert.Equal("a", test);
+    }
+    
+    [Fact]
+    public async Task AsyncEnumerable_CombinedFunction() {
+        var test = await TestFunc().DefaultIfEmpty("d").FirstOrDefaultAsync();
+        Assert.Equal("a", test);
+    }
+    
+    [Fact]
+    public async Task AsyncEnumerable_FirstOrDefaultEmptyFunction() {
+        var test = await EmptyFunc().FirstOrDefaultAsync();
+        Assert.Null(test);
+    }
+    
+    [Fact]
+    public async Task AsyncEnumerable_CombinedEmptyFunction() {
+        var test = await EmptyFunc().DefaultIfEmpty("d").FirstOrDefaultAsync();
+        Assert.Equal("d", test);
+    }
+
+    private async IAsyncEnumerable<string> TestFunc() {
+        var collection = new[] {
+            "a", "b", "c"
+        };
+
+        foreach (var i in collection) {
+            yield return i;
+        }
+    }
+    
+    private async IAsyncEnumerable<string> EmptyFunc() {
+        yield break;
     }
 }

--- a/test/unit/Facades/MockLdapUtils.cs
+++ b/test/unit/Facades/MockLdapUtils.cs
@@ -671,7 +671,7 @@ namespace CommonLibTest.Facades
 
         public async Task<(bool Success, TypedPrincipal WellKnownPrincipal)> GetWellKnownPrincipal(string securityIdentifier, string objectDomain) {
             if (!WellKnownPrincipal.GetWellKnownPrincipal(securityIdentifier, out var commonPrincipal)) return (false, default);
-            commonPrincipal.ObjectIdentifier = ConvertWellKnownPrincipal(securityIdentifier, objectDomain);
+            commonPrincipal.ObjectIdentifier = await ConvertWellKnownPrincipal(securityIdentifier, objectDomain);
             _seenWellKnownPrincipals.TryAdd(commonPrincipal.ObjectIdentifier, securityIdentifier);
             return (true, commonPrincipal);
         }
@@ -747,13 +747,13 @@ namespace CommonLibTest.Facades
             throw new NotImplementedException();
         }
 
-        public string ConvertWellKnownPrincipal(string sid, string domain)
+        public async Task<string> ConvertWellKnownPrincipal(string sid, string domain)
         {
             if (!WellKnownPrincipal.GetWellKnownPrincipal(sid, out _)) return sid;
 
             if (sid != "S-1-5-9") return $"{domain}-{sid}".ToUpper();
 
-            var forest = GetForest(domain)?.Name;
+            var (success, forest) = await GetForest(domain);
             return $"{forest}-{sid}".ToUpper();
         }
 
@@ -1052,9 +1052,9 @@ namespace CommonLibTest.Facades
             throw new NotImplementedException();
         }
 
-        public Forest GetForest(string domainName = null)
+        public async Task<(bool Success, string ForestName)> GetForest(string domainName = null)
         {
-            return _forest;
+            return (true, _forest.Name);
         }
 
         public ActiveDirectorySecurityDescriptor MakeSecurityDescriptor()

--- a/test/unit/Utils.cs
+++ b/test/unit/Utils.cs
@@ -55,7 +55,7 @@ namespace CommonLibTest
                 _enumerator = new IAsyncEnumeratorCollectionAdapter<T>(source);
             }
             public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken()) {
-                throw new NotImplementedException();
+                return _enumerator;
             }
         }
 

--- a/test/unit/Utils.cs
+++ b/test/unit/Utils.cs
@@ -24,12 +24,62 @@ namespace CommonLibTest
 
     internal static class Extensions
     {
+        public static async Task<T[]> ToArrayAsync<T>(this IAsyncEnumerable<T> items)
+        {
+            var results = new List<T>();
+            await foreach (var item in items
+                               .ConfigureAwait(false))
+                results.Add(item);
+            return results.ToArray();
+        }
+        
         internal static bool IsArray(this object obj)
         {
             var valueType = obj?.GetType();
             if (valueType == null)
                 return false;
             return valueType.IsArray;
+        }
+
+        internal static IAsyncEnumerable<T> ToAsyncEnumerable<T>(this IEnumerable<T> source) {
+            return source switch {
+                ICollection<T> collection => new IAsyncEnumerableCollectionAdapter<T>(collection),
+                _ => null
+            };
+        }
+
+        private sealed class IAsyncEnumerableCollectionAdapter<T> : IAsyncEnumerable<T> {
+            private readonly IAsyncEnumerator<T> _enumerator;
+
+            public IAsyncEnumerableCollectionAdapter(ICollection<T> source) {
+                _enumerator = new IAsyncEnumeratorCollectionAdapter<T>(source);
+            }
+            public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken()) {
+                throw new NotImplementedException();
+            }
+        }
+
+        private sealed class IAsyncEnumeratorCollectionAdapter<T> : IAsyncEnumerator<T> {
+            private readonly IEnumerable<T> _source;
+            private IEnumerator<T> _enumerator;
+
+            public IAsyncEnumeratorCollectionAdapter(ICollection<T> source) {
+                _source = source;
+            }
+            
+            public ValueTask DisposeAsync() {
+                _enumerator = null;
+                return ValueTask.CompletedTask;
+            }
+
+            public ValueTask<bool> MoveNextAsync() {
+                if (_enumerator == null) {
+                    _enumerator = _source.GetEnumerator();
+                }
+                return ValueTask.FromResult(_enumerator.MoveNext());
+            }
+
+            public T Current => _enumerator.Current;
         }
     }
 


### PR DESCRIPTION
## Description
Adds a few functions to cover our usage of the System.Linq.Async library
<!--- Describe your changes in detail -->

## Motivation and Context
The System.Linq.Async library is over 1mb by itself. This will make shipping FOSS SharpHound build extremely difficult for use in pentests. We're only using a few functions, so just implement those ourselves.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added tests to cover the expected behaviors
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
