### PR TITLE
Bed-4487: fix handling for unicode control characters

### DIFF
--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -80,5 +80,6 @@
         public const string ServerName = "servername";
         public const string OU = "ou";
         public const string ProfilePath = "profilepath";
+        public const string DSASignature = "dsasignature";
     }
 }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -15,13 +15,22 @@ using SharpHoundCommonLib.OutputTypes;
 
 namespace SharpHoundCommonLib.Processors {
     public class LdapPropertyProcessor {
-        private static readonly HashSet<string> ReservedAttributes = new HashSet<string>(CommonProperties.TypeResolutionProps
-            .Concat(CommonProperties.BaseQueryProps).Concat(CommonProperties.GroupResolutionProps)
-            .Concat(CommonProperties.ComputerMethodProps).Concat(CommonProperties.ACLProps)
-            .Concat(CommonProperties.ObjectPropsProps).Concat(CommonProperties.ContainerProps)
-            .Concat(CommonProperties.SPNTargetProps).Concat(CommonProperties.DomainTrustProps)
-            .Concat(CommonProperties.GPOLocalGroupProps).Concat(CommonProperties.CertAbuseProps)
-            .Concat(new string[] { LDAPProperties.DSASignature }));
+        private static readonly HashSet<string> ReservedAttributes = new();
+
+        static LdapPropertyProcessor() {
+            ReservedAttributes.IntersectWith(CommonProperties.TypeResolutionProps);
+            ReservedAttributes.IntersectWith(CommonProperties.BaseQueryProps);
+            ReservedAttributes.IntersectWith(CommonProperties.GroupResolutionProps);
+            ReservedAttributes.IntersectWith(CommonProperties.ComputerMethodProps);
+            ReservedAttributes.IntersectWith(CommonProperties.ACLProps);
+            ReservedAttributes.IntersectWith(CommonProperties.ObjectPropsProps);
+            ReservedAttributes.IntersectWith(CommonProperties.ContainerProps);
+            ReservedAttributes.IntersectWith(CommonProperties.SPNTargetProps);
+            ReservedAttributes.IntersectWith(CommonProperties.DomainTrustProps);
+            ReservedAttributes.IntersectWith(CommonProperties.GPOLocalGroupProps);
+            ReservedAttributes.IntersectWith(CommonProperties.CertAbuseProps);
+            ReservedAttributes.Add(LDAPProperties.DSASignature);
+        }
 
         private readonly ILdapUtils _utils;
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
+
 // ReSharper disable StringLiteralTypo
 
 namespace SharpHoundCommonLib.Processors {
@@ -186,7 +187,7 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             props.Add("lastlogon", Helpers.ConvertFileTimeToUnixEpoch(lastLogon));
-            
+
             if (!entry.TryGetProperty(LDAPProperties.LastLogonTimestamp, out var lastLogonTimeStamp)) {
                 lastLogonTimeStamp = null;
             }
@@ -196,6 +197,7 @@ namespace SharpHoundCommonLib.Processors {
             if (!entry.TryGetProperty(LDAPProperties.PasswordLastSet, out var passwordLastSet)) {
                 passwordLastSet = null;
             }
+
             props.Add("pwdlastset",
                 Helpers.ConvertFileTimeToUnixEpoch(passwordLastSet));
             entry.TryGetArrayProperty(LDAPProperties.ServicePrincipalNames, out var spn);
@@ -264,7 +266,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("unconstraineddelegation", flags.HasFlag(UacFlags.TrustedForDelegation));
             props.Add("trustedtoauth", flags.HasFlag(UacFlags.TrustedToAuthForDelegation));
             props.Add("isdc", flags.HasFlag(UacFlags.ServerTrustAccount));
-            
+
             var comps = new List<TypedPrincipal>();
             if (flags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
                 entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
@@ -365,7 +367,7 @@ namespace SharpHoundCommonLib.Processors {
                 props.Add("hasbasicconstraints", cert.HasBasicConstraints);
                 props.Add("basicconstraintpathlength", cert.BasicConstraintPathLength);
             }
-            
+
             return props;
         }
 
@@ -376,7 +378,7 @@ namespace SharpHoundCommonLib.Processors {
         /// <returns>Returns a dictionary with the common properties and the crosscertificatepair property of the AICA</returns>
         public static Dictionary<string, object> ReadAIACAProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
-            entry.TryGetByteArrayProperty(LDAPProperties.CrossCertificatePair,  out var crossCertificatePair);
+            entry.TryGetByteArrayProperty(LDAPProperties.CrossCertificatePair, out var crossCertificatePair);
             var hasCrossCertificatePair = crossCertificatePair.Length > 0;
 
             props.Add("crosscertificatepair", crossCertificatePair);
@@ -397,7 +399,8 @@ namespace SharpHoundCommonLib.Processors {
 
         public static Dictionary<string, object> ReadEnterpriseCAProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
-            if (entry.TryGetIntProperty("flags", out var flags)) props.Add("flags", (PKICertificateAuthorityFlags)flags);
+            if (entry.TryGetIntProperty("flags", out var flags))
+                props.Add("flags", (PKICertificateAuthorityFlags)flags);
             props.Add("caname", entry.GetProperty(LDAPProperties.Name));
             props.Add("dnshostname", entry.GetProperty(LDAPProperties.DNSHostName));
 
@@ -471,7 +474,8 @@ namespace SharpHoundCommonLib.Processors {
 
             entry.TryGetArrayProperty(LDAPProperties.ExtendedKeyUsage, out var ekus);
             props.Add("ekus", ekus);
-            entry.TryGetArrayProperty(LDAPProperties.CertificateApplicationPolicy, out var certificateApplicationPolicy);
+            entry.TryGetArrayProperty(LDAPProperties.CertificateApplicationPolicy,
+                out var certificateApplicationPolicy);
             props.Add("certificateapplicationpolicy", certificateApplicationPolicy);
 
             entry.TryGetArrayProperty(LDAPProperties.CertificatePolicy, out var certificatePolicy);
@@ -487,7 +491,7 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             entry.TryGetArrayProperty(LDAPProperties.ApplicationPolicies, out var appPolicies);
-            
+
             props.Add("applicationpolicies",
                 ParseCertTemplateApplicationPolicies(appPolicies,
                     schemaVersion, hasUseLegacyProvider));
@@ -551,21 +555,28 @@ namespace SharpHoundCommonLib.Processors {
                     if (entry.TryGetByteProperty(property, out var testBytes)) {
                         if (testBytes == null || testBytes.Length == 0) {
                             continue;
-                        };
+                        }
+
+                        ;
                         // SIDs
                         try {
                             var sid = new SecurityIdentifier(testBytes, 0);
                             props.Add(property, sid.Value);
                             continue;
-                        } catch { /* Ignore */ }
+                        } catch {
+                            /* Ignore */
+                        }
 
                         // GUIDs
                         try {
                             var guid = new Guid(testBytes);
                             props.Add(property, guid.ToString());
                             continue;
-                        } catch { /* Ignore */ }
+                        } catch {
+                            /* Ignore */
+                        }
                     }
+
                     if (entry.TryGetArrayProperty(property, out var arr) && arr.Length > 0) {
                         props.Add(property, arr.Select(BestGuessConvert).ToArray());
                     }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -547,25 +547,6 @@ namespace SharpHoundCommonLib.Processors {
                         Console.Write(b);
                     }
 
-                    // SIDs
-                    try {
-                        var sid = new SecurityIdentifier(testBytes, 0);
-                        props.Add(property, sid.Value);
-                        continue;
-                    } catch { /* Ignore */ }
-
-                    // GUIDs
-                    try {
-                        Console.WriteLine(testBytes);
-                        var guid = new Guid(testBytes);
-                        Console.Write("woooooooooooookkkkkk");
-                        props.Add(property, guid.ToString());
-                        continue;
-                    } catch (Exception e) {
-                        /* Ignore */
-                        Console.WriteLine(e);
-                    }
-
                     var testString = entry.GetProperty(property);
 
                     if (!string.IsNullOrEmpty(testString)) {
@@ -575,6 +556,26 @@ namespace SharpHoundCommonLib.Processors {
                             props.Add(property, BestGuessConvert(testString));
                     }
                 } else {
+                    if (entry.TryGetByteProperty(property, out var bArr)) {
+                        // SIDs
+                        try {
+                            var sid = new SecurityIdentifier(bArr, 0);
+                            props.Add(property, sid.Value);
+                            continue;
+                        } catch { /* Ignore */ }
+
+                        // GUIDs
+                        try {
+                            Console.WriteLine(bArr);
+                            var guid = new Guid(bArr);
+                            Console.Write("woooooooooooookkkkkk");
+                            props.Add(property, guid.ToString());
+                            continue;
+                        } catch (Exception e) {
+                            /* Ignore */
+                            Console.WriteLine(e);
+                        }
+                    }
                     if (entry.TryGetArrayProperty(property, out var arr) && arr.Length > 0) {
                         props.Add(property, arr.Select(BestGuessConvert).ToArray());
                     }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -556,8 +556,7 @@ namespace SharpHoundCommonLib.Processors {
                         if (testBytes == null || testBytes.Length == 0) {
                             continue;
                         }
-
-                        ;
+                        
                         // SIDs
                         try {
                             var sid = new SecurityIdentifier(testBytes, 0);

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -19,17 +19,17 @@ namespace SharpHoundCommonLib.Processors {
         private static readonly HashSet<string> ReservedAttributes = new();
 
         static LdapPropertyProcessor() {
-            ReservedAttributes.IntersectWith(CommonProperties.TypeResolutionProps);
-            ReservedAttributes.IntersectWith(CommonProperties.BaseQueryProps);
-            ReservedAttributes.IntersectWith(CommonProperties.GroupResolutionProps);
-            ReservedAttributes.IntersectWith(CommonProperties.ComputerMethodProps);
-            ReservedAttributes.IntersectWith(CommonProperties.ACLProps);
-            ReservedAttributes.IntersectWith(CommonProperties.ObjectPropsProps);
-            ReservedAttributes.IntersectWith(CommonProperties.ContainerProps);
-            ReservedAttributes.IntersectWith(CommonProperties.SPNTargetProps);
-            ReservedAttributes.IntersectWith(CommonProperties.DomainTrustProps);
-            ReservedAttributes.IntersectWith(CommonProperties.GPOLocalGroupProps);
-            ReservedAttributes.IntersectWith(CommonProperties.CertAbuseProps);
+            ReservedAttributes.UnionWith(CommonProperties.TypeResolutionProps);
+            ReservedAttributes.UnionWith(CommonProperties.BaseQueryProps);
+            ReservedAttributes.UnionWith(CommonProperties.GroupResolutionProps);
+            ReservedAttributes.UnionWith(CommonProperties.ComputerMethodProps);
+            ReservedAttributes.UnionWith(CommonProperties.ACLProps);
+            ReservedAttributes.UnionWith(CommonProperties.ObjectPropsProps);
+            ReservedAttributes.UnionWith(CommonProperties.ContainerProps);
+            ReservedAttributes.UnionWith(CommonProperties.SPNTargetProps);
+            ReservedAttributes.UnionWith(CommonProperties.DomainTrustProps);
+            ReservedAttributes.UnionWith(CommonProperties.GPOLocalGroupProps);
+            ReservedAttributes.UnionWith(CommonProperties.CertAbuseProps);
             ReservedAttributes.Add(LDAPProperties.DSASignature);
         }
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -532,25 +532,39 @@ namespace SharpHoundCommonLib.Processors {
                     continue;
 
                 var collCount = entry.PropertyCount(property);
+                Console.WriteLine("Before guid check {0}", collCount);
                 if (collCount == 0)
                     continue;
 
                 if (collCount == 1) {
-                    var testBytes = entry.GetByteProperty(property);
-                    if (testBytes == null || testBytes.Length == 0) continue;
+                    entry.TryGetByteProperty(property, out var testBytes);
+                    if (testBytes == null || testBytes.Length == 0) {
+                        Console.WriteLine("failure", testBytes);
+                        continue;
+                    };
+                    Console.WriteLine("Before guid check {0}", testBytes.Length);
+                    foreach (byte b in testBytes) {
+                        Console.Write(b);
+                    }
+
                     // SIDs
                     try {
                         var sid = new SecurityIdentifier(testBytes, 0);
                         props.Add(property, sid.Value);
                         continue;
-                    } catch {/* Ignore */}
+                    } catch { /* Ignore */ }
 
                     // GUIDs
                     try {
+                        Console.WriteLine(testBytes);
                         var guid = new Guid(testBytes);
+                        Console.Write("woooooooooooookkkkkk");
                         props.Add(property, guid.ToString());
                         continue;
-                    } catch {/* Ignore */}
+                    } catch (Exception e) {
+                        /* Ignore */
+                        Console.WriteLine(e);
+                    }
 
                     var testString = entry.GetProperty(property);
 

--- a/test/unit/Facades/MockDirectoryObject.cs
+++ b/test/unit/Facades/MockDirectoryObject.cs
@@ -75,7 +75,11 @@ public class MockDirectoryObject : IDirectoryObject {
 
         var temp = Properties[propertyName];
         if (temp.IsArray()) {
-            value = temp as string[];
+            if (temp is string[] s) {
+                value = s;
+                return true;
+            }
+            value = Array.Empty<string>(); 
             return true;
         }
 

--- a/test/unit/Facades/MockDirectoryObject.cs
+++ b/test/unit/Facades/MockDirectoryObject.cs
@@ -153,8 +153,15 @@ public class MockDirectoryObject : IDirectoryObject {
         var property = Properties[propertyName];
         if (property.IsArray())
         {
-            var cast = property as string[];
-            return cast?.Length ?? 0;
+            if (property is string[] s) {
+                return s.Length;
+            }
+
+            if (property is byte[] b) {
+                return b.Length;
+            }
+
+            return 0;
         }
 
         return 1;

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -950,9 +950,10 @@ namespace CommonLibTest
 
         [WindowsOnlyFact]
         public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_SID() {
+            var creatorSIDExpected = "S-1-5-21-2697957641-2271029196-387917394";
             var mock = new MockDirectoryObject("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
-                    {{"ms-ds-creatorsid", "S-1-5-21-2697957641-2271029196-387917394"}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
+                    {{"ms-ds-creatorsid", System.Text.Encoding.UTF8.GetBytes(creatorSIDExpected)}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var props = processor.ParseAllProperties(mock);
@@ -960,29 +961,26 @@ namespace CommonLibTest
 
             Assert.Contains("ms-ds-creatorsid", keys);
             Assert.Single(keys);
-            var hasSID = props.TryGetValue("ms-ds-creatorsid", out var creatorSID);
+            var hasSID = props.TryGetValue("ms-ds-creatorsid", out var creatorSIDActual);
             Assert.True(hasSID);
-            Assert.Equal("S-1-5-21-2697957641-2271029196-387917394", props["ms-ds-creatorsid"]);
+            Assert.Equal(creatorSIDExpected, creatorSIDActual.ToString());
         }
 
         [Fact]
-        public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_GUID() {
-            var guid = Guid.NewGuid();
-            Console.WriteLine(guid);
+        public void LDAPPropertyProcessor_ParseAllProperties_GUID() {
+            var guidExpected = Guid.NewGuid();
             var mock = new MockDirectoryObject("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
-                    {{"guid", guid.ToByteArray()}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
+                    {{"guid", guidExpected.ToByteArray()}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var props = processor.ParseAllProperties(mock);
             var keys = props.Keys;
 
-            Assert.Contains("guid", keys);
             Assert.Single(keys);
-            var hasGuid = props.TryGetValue("guid", out var guid2);
+            var hasGuid = props.TryGetValue("guid", out var guidActual);
             Assert.True(hasGuid);
-            Console.WriteLine(guid);
-            Assert.Equal(guid.ToString(), guid2);
+            Assert.Equal(guidExpected.ToString(), guidActual);
         }
     }
 }

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -10,6 +10,8 @@ using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
 using Xunit;
 using Xunit.Abstractions;
+using static System.Text.Encoding;
+
 // ReSharper disable StringLiteralTypo
 
 namespace CommonLibTest
@@ -945,7 +947,7 @@ namespace CommonLibTest
             Assert.Single(keys);
             var hasCert = props.TryGetValue("usercertificate", out var usercert);
             Assert.True(hasCert);
-            Assert.Equal("\u0000", System.Text.Encoding.UTF8.GetString(usercert as byte[]));
+            Assert.Equal("\u0000", UTF8.GetString(usercert as byte[]));
         }
 
         [WindowsOnlyFact]
@@ -953,7 +955,7 @@ namespace CommonLibTest
             var creatorSIDExpected = "S-1-5-21-2697957641-2271029196-387917394";
             var mock = new MockDirectoryObject("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
-                    {{"ms-ds-creatorsid", System.Text.Encoding.UTF8.GetBytes(creatorSIDExpected)}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
+                    {{"ms-ds-creatorsid", UTF8.GetBytes(creatorSIDExpected)}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var props = processor.ParseAllProperties(mock);

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
+using SharpHoundRPC;
 using Xunit;
 using Xunit.Abstractions;
 using static System.Text.Encoding;
@@ -953,9 +955,10 @@ namespace CommonLibTest
         [WindowsOnlyFact]
         public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_SID() {
             var creatorSIDExpected = "S-1-5-21-2697957641-2271029196-387917394";
+            var sidBytes = new SecurityIdentifier(creatorSIDExpected).GetBytes();
             var mock = new MockDirectoryObject("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
-                    {{"ms-ds-creatorsid", UTF8.GetBytes(creatorSIDExpected)}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
+                    {{"ms-ds-creatorsid", sidBytes}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var props = processor.ParseAllProperties(mock);

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -855,7 +855,7 @@ namespace CommonLibTest
                     {"name", "NTAUTHCERTIFICATES@DUMPSTER.FIRE"},
                     {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
                     {"whencreated", 1683986131},
-                    {"dsasignature", "jkr"}
+                    {LDAPProperties.DSASignature, "jkr"}
                 }, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
@@ -866,7 +866,7 @@ namespace CommonLibTest
             Assert.DoesNotContain("description", keys);
             Assert.DoesNotContain("whencreated", keys);
             Assert.DoesNotContain("name", keys);
-            Assert.DoesNotContain("dsasignature", keys);
+            Assert.DoesNotContain(LDAPProperties.DSASignature, keys);
 
             Assert.Contains("domainsid", keys);
             Assert.Contains("domain", keys);

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -967,11 +967,11 @@ namespace CommonLibTest
 
         [Fact]
         public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_GUID() {
-            var guid = Guid.NewGuid().ToString();
+            var guid = Guid.NewGuid();
             Console.WriteLine(guid);
             var mock = new MockDirectoryObject("CN\u003dNTAUTHCERTIFICATES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
-                    {{"guid", guid}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
+                    {{"guid", guid.ToByteArray()}}, "", "2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var props = processor.ParseAllProperties(mock);
@@ -982,7 +982,7 @@ namespace CommonLibTest
             var hasGuid = props.TryGetValue("guid", out var guid2);
             Assert.True(hasGuid);
             Console.WriteLine(guid);
-            Assert.Equal(guid, guid2);
+            Assert.Equal(guid.ToString(), guid2);
         }
     }
 }


### PR DESCRIPTION
## Description

Closes BED-4487

Add protection around control characters such as null unicode `\u0000`by base64 encoding any properties we encounter.

## Motivation and Context

Running the collection with `--collectallproperties` brings in properties with binary control characters that cause issues downstream during ingestion into db's.

## How Has This Been Tested?

Added unit tests
Tested on AD lab

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
