### PR TITLE
More fixes

### DIFF
--- a/src/CommonLib/DirectoryObjects/DirectoryEntryWrapper.cs
+++ b/src/CommonLib/DirectoryObjects/DirectoryEntryWrapper.cs
@@ -89,7 +89,7 @@ public class DirectoryEntryWrapper : IDirectoryObject {
         return true;
     }
 
-    public bool TryGetIntProperty(string propertyName, out int value) {
+    public bool TryGetLongProperty(string propertyName, out long value) {
         value = 0;
         if (!CheckCache(propertyName)) return false;
 
@@ -97,7 +97,7 @@ public class DirectoryEntryWrapper : IDirectoryObject {
             return false;
         }
 
-        return int.TryParse(s, out value);
+        return long.TryParse(s, out value);
     }
 
     public bool TryGetCertificateArrayProperty(string propertyName, out X509Certificate2[] value) {

--- a/src/CommonLib/DirectoryObjects/DirectoryObjectExtensions.cs
+++ b/src/CommonLib/DirectoryObjects/DirectoryObjectExtensions.cs
@@ -35,7 +35,7 @@ public static class DirectoryObjectExtensions {
             return false;
         }
         
-        if (!directoryObject.TryGetIntProperty(LDAPProperties.Flags, out var flags)) {
+        if (!directoryObject.TryGetLongProperty(LDAPProperties.Flags, out var flags)) {
             flags = 0;
         }
 
@@ -43,7 +43,7 @@ public static class DirectoryObjectExtensions {
         directoryObject.TryGetProperty(LDAPProperties.SAMAccountType, out var samAccountType);
         directoryObject.TryGetArrayProperty(LDAPProperties.ObjectClass, out var objectClasses);
 
-        return LdapUtils.ResolveLabel(objectIdentifier, distinguishedName, samAccountType, objectClasses, flags,
+        return LdapUtils.ResolveLabel(objectIdentifier, distinguishedName, samAccountType, objectClasses, (int)flags,
             out type);
     }
     
@@ -56,12 +56,12 @@ public static class DirectoryObjectExtensions {
     }
     
     public static bool HasLAPS(this IDirectoryObject directoryObject) {
-        if (directoryObject.TryGetIntProperty(LDAPProperties.LAPSExpirationTime, out var lapsExpiration) &&
+        if (directoryObject.TryGetLongProperty(LDAPProperties.LAPSExpirationTime, out var lapsExpiration) &&
             lapsExpiration > 0) {
             return true;
         }
 
-        if (directoryObject.TryGetIntProperty(LDAPProperties.LegacyLAPSExpirationTime, out var legacyLapsExpiration) &&
+        if (directoryObject.TryGetLongProperty(LDAPProperties.LegacyLAPSExpirationTime, out var legacyLapsExpiration) &&
             legacyLapsExpiration > 0) {
             return true;
         }

--- a/src/CommonLib/DirectoryObjects/IDirectoryObject.cs
+++ b/src/CommonLib/DirectoryObjects/IDirectoryObject.cs
@@ -9,7 +9,7 @@ public interface IDirectoryObject {
     bool TryGetByteProperty(string propertyName, out byte[] value);
     bool TryGetArrayProperty(string propertyName, out string[] value);
     bool TryGetByteArrayProperty(string propertyName, out byte[][] value);
-    bool TryGetIntProperty(string propertyName, out int value);
+    bool TryGetLongProperty(string propertyName, out long value);
     bool TryGetCertificateArrayProperty(string propertyName, out X509Certificate2[] value);
     bool TryGetSecurityIdentifier(out string securityIdentifier);
     bool TryGetGuid(out string guid);

--- a/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
-using System.Linq;
+using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 
 namespace SharpHoundCommonLib;
-
+[DataContract]
 public class SearchResultEntryWrapper : IDirectoryObject {
+    [DataMember]
     private readonly SearchResultEntry _entry;
 
     public SearchResultEntryWrapper(SearchResultEntry entry) {

--- a/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
+++ b/src/CommonLib/DirectoryObjects/SearchResultEntryWrapper.cs
@@ -83,13 +83,13 @@ public class SearchResultEntryWrapper : IDirectoryObject {
         return true;
     }
 
-    public bool TryGetIntProperty(string propertyName, out int value) {
+    public bool TryGetLongProperty(string propertyName, out long value) {
         if (!TryGetProperty(propertyName, out var raw)) {
             value = 0;
             return false;
         }
         
-        return int.TryParse(raw, out value);
+        return long.TryParse(raw, out value);
     }
 
     public bool TryGetCertificateArrayProperty(string propertyName, out X509Certificate2[] value) {

--- a/src/CommonLib/LdapProducerQueryGenerator.cs
+++ b/src/CommonLib/LdapProducerQueryGenerator.cs
@@ -28,6 +28,10 @@ public class LdapProducerQueryGenerator {
                 properties.AddRange(CommonProperties.ACLProps);
             }
 
+            if (methods.HasFlag(CollectionMethod.ObjectProps)) {
+                properties.AddRange(CommonProperties.ObjectPropsProps);
+            }
+
             if (methods.IsComputerCollectionSet()) {
                 properties.AddRange(CommonProperties.ComputerMethodProps);
             }

--- a/src/CommonLib/LdapQueries/LdapFilter.cs
+++ b/src/CommonLib/LdapQueries/LdapFilter.cs
@@ -124,7 +124,7 @@ namespace SharpHoundCommonLib.LDAPQueries {
         /// <param name="conditions"></param>
         /// <returns></returns>
         public LdapFilter AddContainers(params string[] conditions) {
-            _filterParts.Add(BuildString("(objectClass=container)", conditions));
+            _filterParts.Add(BuildString("(&(!(objectClass=groupPolicyContainer))(objectClass=container))", conditions));
 
             return this;
         }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -22,6 +22,7 @@ using SharpHoundCommonLib.OutputTypes;
 using SharpHoundCommonLib.Processors;
 using SharpHoundRPC.NetAPINative;
 using Domain = System.DirectoryServices.ActiveDirectory.Domain;
+using Group = SharpHoundCommonLib.OutputTypes.Group;
 using SearchScope = System.DirectoryServices.Protocols.SearchScope;
 using SecurityMasks = System.DirectoryServices.Protocols.SecurityMasks;
 
@@ -905,7 +906,7 @@ namespace SharpHoundCommonLib {
                 try {
                     var account = new NTAccount(domainName, name);
                     var sid = (SecurityIdentifier)account.Translate(typeof(SecurityIdentifier));
-                    domainSid = sid.AccountDomainSid.ToString();
+                    domainSid = sid.AccountDomainSid.ToString().ToUpper();
                     Cache.AddDomainSidMapping(domainName, domainSid);
                     return (true, domainSid);
                 } catch {
@@ -919,7 +920,7 @@ namespace SharpHoundCommonLib {
             }).DefaultIfEmpty(LdapResult<IDirectoryObject>.Fail()).FirstOrDefaultAsync();
 
             if (result.IsSuccess && result.Value.TryGetSecurityIdentifier(out var securityIdentifier)) {
-                domainSid = new SecurityIdentifier(securityIdentifier).AccountDomainSid.Value;
+                domainSid = new SecurityIdentifier(securityIdentifier).AccountDomainSid.Value.ToUpper();
                 Cache.AddDomainSidMapping(domainName, domainSid);
                 return (true, domainSid);
             }
@@ -1394,6 +1395,41 @@ namespace SharpHoundCommonLib {
                 output.ObjectIdentifier = wkp.Key;
                 yield return output;
             }
+
+            await foreach (var entdc in GetEnterpriseDCGroups()) {
+                yield return entdc;
+            }
+        }
+        
+        private async IAsyncEnumerable<Group> GetEnterpriseDCGroups() {
+            var grouped = new Dictionary<string, List<string>>();
+            var forestSidToName = new Dictionary<string, string>();
+            foreach (var domainSid in DomainControllers.GroupBy(x => new SecurityIdentifier(x.Key).AccountDomainSid.Value)) {
+                if (await GetDomainNameFromSid(domainSid.Key) is (true, var domainName) &&
+                    await GetForest(domainName) is (true, var forestName) &&
+                    await GetDomainSidFromDomainName(forestName) is (true, var forestDomainSid)) {
+                    forestSidToName.Add(forestDomainSid, forestName);
+                    if (grouped.ContainsKey(forestDomainSid)) {
+                        foreach (var k in domainSid) {
+                            grouped[forestDomainSid].Add(k.Key);    
+                        }
+                    } else {
+                        grouped[forestDomainSid] = new List<string>();
+                        foreach (var k in domainSid) {
+                            grouped[forestDomainSid].Add(k.Key);    
+                        }
+                    }
+                }
+            }
+
+            foreach (var f in grouped) {
+                var group = new Group() { ObjectIdentifier = $"{f.Key}-S-1-5-9" };
+                group.Properties.Add("name", $"ENTERPRISE DOMAIN CONTROLLERS@{forestSidToName[f.Key]}".ToUpper());
+                group.Properties.Add("domainsid", f.Key);
+                group.Properties.Add("domain", forestSidToName[f.Key]);
+                group.Members = f.Value.Select(x => new TypedPrincipal(x, Label.Computer)).ToArray();
+                yield return group;
+            }
         }
 
         public void SetLdapConfig(LdapConfig config) {
@@ -1551,7 +1587,7 @@ namespace SharpHoundCommonLib {
                 return (true, res);
             }
 
-            if (directoryObject.TryGetIntProperty(LDAPProperties.UserAccountControl, out var rawUac)) {
+            if (directoryObject.TryGetLongProperty(LDAPProperties.UserAccountControl, out var rawUac)) {
                 var flags = (UacFlags)rawUac;
                 if (flags.HasFlag(UacFlags.ServerTrustAccount)) {
                     res.IsDomainController = true;

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -1516,11 +1516,11 @@ namespace SharpHoundCommonLib {
                 type = Label.EnterpriseCA;
             else if (objectClasses.Contains(ObjectClass.CertificationAuthorityClass,
                          StringComparer.OrdinalIgnoreCase)) {
-                if (distinguishedName.IndexOf(DirectoryPaths.RootCALocation, StringComparison.OrdinalIgnoreCase) > 0)
+                if (distinguishedName.IndexOf(DirectoryPaths.RootCALocation, StringComparison.OrdinalIgnoreCase) >= 0)
                     type = Label.RootCA;
-                if (distinguishedName.IndexOf(DirectoryPaths.AIACALocation, StringComparison.OrdinalIgnoreCase) > 0)
+                if (distinguishedName.IndexOf(DirectoryPaths.AIACALocation, StringComparison.OrdinalIgnoreCase) >= 0)
                     type = Label.AIACA;
-                if (distinguishedName.IndexOf(DirectoryPaths.NTAuthStoreLocation, StringComparison.OrdinalIgnoreCase) >
+                if (distinguishedName.IndexOf(DirectoryPaths.NTAuthStoreLocation, StringComparison.OrdinalIgnoreCase) >=
                     0)
                     type = Label.NTAuthStore;
             } else if (objectClasses.Contains(ObjectClass.OIDContainerClass, StringComparer.OrdinalIgnoreCase)) {

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -478,7 +478,7 @@ namespace SharpHoundCommonLib {
 
         public async Task<(bool Success, TypedPrincipal Principal)>
             ResolveIDAndType(string identifier, string objectDomain) {
-            if (identifier.Contains("0ACNF")) {
+            if (identifier.IndexOf("0ACNF", StringComparison.OrdinalIgnoreCase) >= 0) {
                 return (false, new TypedPrincipal(identifier, Label.Base));
             }
 

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -106,8 +106,10 @@ namespace SharpHoundCommonLib.Processors
                     principalDomain = objectDomain;
                 }
                 var (resSuccess, resolvedPrincipal) = await GetRegistryPrincipal(new SecurityIdentifier(principalSid), principalDomain, computerName, isDomainController, computerObjectId, machineSid);
-                if (!resSuccess)
-                    continue;
+                if (!resSuccess) {
+                    resolvedPrincipal.ObjectType = Label.Base;
+                    resolvedPrincipal.ObjectIdentifier = principalSid;
+                }
                 var isInherited = rule.IsInherited();
 
                 var cARights = (CertificationAuthorityRights)rule.ActiveDirectoryRights();

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -57,7 +57,7 @@ namespace SharpHoundCommonLib.Processors
 
                 trust.TargetDomainSid = sid;
 
-                if (!entry.TryGetIntProperty(LDAPProperties.TrustDirection, out var td)) {
+                if (!entry.TryGetLongProperty(LDAPProperties.TrustDirection, out var td)) {
                     _log.LogTrace("Failed to convert trustdirection for target: {Domain}", domain);
                     continue;
                 }
@@ -66,7 +66,7 @@ namespace SharpHoundCommonLib.Processors
                 
                 TrustAttributes attributes;
 
-                if (!entry.TryGetIntProperty(LDAPProperties.TrustAttributes, out var ta)) {
+                if (!entry.TryGetLongProperty(LDAPProperties.TrustAttributes, out var ta)) {
                     _log.LogTrace("Failed to convert trustattributes for target: {Domain}", domain);
                     continue;
                 }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -60,11 +60,11 @@ namespace SharpHoundCommonLib.Processors {
         public static Dictionary<string, object> ReadDomainProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
 
-            if (!entry.TryGetIntProperty(LDAPProperties.DomainFunctionalLevel, out var functionalLevel)) {
+            if (!entry.TryGetLongProperty(LDAPProperties.DomainFunctionalLevel, out var functionalLevel)) {
                 functionalLevel = -1;
             }
 
-            props.Add("functionallevel", FunctionalLevelToString(functionalLevel));
+            props.Add("functionallevel", FunctionalLevelToString((int)functionalLevel));
 
             return props;
         }
@@ -119,7 +119,7 @@ namespace SharpHoundCommonLib.Processors {
         /// <returns></returns>
         public static Dictionary<string, object> ReadGroupProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
-            entry.TryGetIntProperty(LDAPProperties.AdminCount, out var ac);
+            entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
             props.Add("admincount", ac != 0);
             return props;
         }
@@ -150,7 +150,7 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
 
             var uacFlags = (UacFlags)0;
-            if (entry.TryGetIntProperty(LDAPProperties.UserAccountControl, out var uac)) {
+            if (entry.TryGetLongProperty(LDAPProperties.UserAccountControl, out var uac)) {
                 uacFlags = (UacFlags)uac;
             }
 
@@ -213,7 +213,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("sfupassword", entry.GetProperty(LDAPProperties.MsSFU30Password));
             props.Add("logonscript", entry.GetProperty(LDAPProperties.ScriptPath));
 
-            entry.TryGetIntProperty(LDAPProperties.AdminCount, out var ac);
+            entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
             props.Add("admincount", ac != 0);
 
             entry.TryGetByteArrayProperty(LDAPProperties.SIDHistory, out var sh);
@@ -258,7 +258,7 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
 
             var flags = (UacFlags)0;
-            if (entry.TryGetIntProperty(LDAPProperties.UserAccountControl, out var uac)) {
+            if (entry.TryGetLongProperty(LDAPProperties.UserAccountControl, out var uac)) {
                 flags = (UacFlags)uac;
             }
 
@@ -399,7 +399,7 @@ namespace SharpHoundCommonLib.Processors {
 
         public static Dictionary<string, object> ReadEnterpriseCAProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
-            if (entry.TryGetIntProperty("flags", out var flags))
+            if (entry.TryGetLongProperty("flags", out var flags))
                 props.Add("flags", (PKICertificateAuthorityFlags)flags);
             props.Add("caname", entry.GetProperty(LDAPProperties.Name));
             props.Add("dnshostname", entry.GetProperty(LDAPProperties.DNSHostName));
@@ -438,13 +438,13 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("validityperiod", ConvertPKIPeriod(entry.GetByteProperty(LDAPProperties.PKIExpirationPeriod)));
             props.Add("renewalperiod", ConvertPKIPeriod(entry.GetByteProperty(LDAPProperties.PKIOverlappedPeriod)));
 
-            if (entry.TryGetIntProperty(LDAPProperties.TemplateSchemaVersion, out var schemaVersion))
+            if (entry.TryGetLongProperty(LDAPProperties.TemplateSchemaVersion, out var schemaVersion))
                 props.Add("schemaversion", schemaVersion);
 
             props.Add("displayname", entry.GetProperty(LDAPProperties.DisplayName));
             props.Add("oid", entry.GetProperty(LDAPProperties.CertTemplateOID));
 
-            if (entry.TryGetIntProperty(LDAPProperties.PKIEnrollmentFlag, out var enrollmentFlagsRaw)) {
+            if (entry.TryGetLongProperty(LDAPProperties.PKIEnrollmentFlag, out var enrollmentFlagsRaw)) {
                 var enrollmentFlags = (PKIEnrollmentFlag)enrollmentFlagsRaw;
 
                 props.Add("enrollmentflag", enrollmentFlags);
@@ -452,7 +452,7 @@ namespace SharpHoundCommonLib.Processors {
                 props.Add("nosecurityextension", enrollmentFlags.HasFlag(PKIEnrollmentFlag.NO_SECURITY_EXTENSION));
             }
 
-            if (entry.TryGetIntProperty(LDAPProperties.PKINameFlag, out var nameFlagsRaw)) {
+            if (entry.TryGetLongProperty(LDAPProperties.PKINameFlag, out var nameFlagsRaw)) {
                 var nameFlags = (PKICertificateNameFlag)nameFlagsRaw;
 
                 props.Add("certificatenameflag", nameFlags);
@@ -481,11 +481,11 @@ namespace SharpHoundCommonLib.Processors {
             entry.TryGetArrayProperty(LDAPProperties.CertificatePolicy, out var certificatePolicy);
             props.Add("certificatepolicy", certificatePolicy);
 
-            if (entry.TryGetIntProperty(LDAPProperties.NumSignaturesRequired, out var authorizedSignatures))
+            if (entry.TryGetLongProperty(LDAPProperties.NumSignaturesRequired, out var authorizedSignatures))
                 props.Add("authorizedsignatures", authorizedSignatures);
 
             var hasUseLegacyProvider = false;
-            if (entry.TryGetIntProperty(LDAPProperties.PKIPrivateKeyFlag, out var privateKeyFlagsRaw)) {
+            if (entry.TryGetLongProperty(LDAPProperties.PKIPrivateKeyFlag, out var privateKeyFlagsRaw)) {
                 var privateKeyFlags = (PKIPrivateKeyFlag)privateKeyFlagsRaw;
                 hasUseLegacyProvider = privateKeyFlags.HasFlag(PKIPrivateKeyFlag.USE_LEGACY_PROVIDER);
             }
@@ -494,7 +494,7 @@ namespace SharpHoundCommonLib.Processors {
 
             props.Add("applicationpolicies",
                 ParseCertTemplateApplicationPolicies(appPolicies,
-                    schemaVersion, hasUseLegacyProvider));
+                    (int)schemaVersion, hasUseLegacyProvider));
             entry.TryGetArrayProperty(LDAPProperties.IssuancePolicies, out var issuancePolicies);
             props.Add("issuancepolicies", issuancePolicies);
 

--- a/test/unit/DirectoryObjectTests.cs
+++ b/test/unit/DirectoryObjectTests.cs
@@ -299,6 +299,19 @@ namespace CommonLibTest {
             Assert.True(mock.GetLabel(out label));
             Assert.Equal(Label.NTAuthStore, label);
         }
+        
+        [Fact]
+        public void Test_GetLabel_NTAuthCertificateObject() {
+            var attribs = new Dictionary<string, object> {
+                { LDAPProperties.ObjectClass, new[] { "top", ObjectClass.CertificationAuthorityClass } },
+            };
+
+            var mock = new MockDirectoryObject($"{DirectoryPaths.NTAuthStoreLocation.ToUpper()},DC=Testlab,DC=local",
+                attribs,
+                "123456", new Guid().ToString());
+            Assert.True(mock.GetLabel(out var label));
+            Assert.Equal(Label.NTAuthStore, label);
+        }
 
         [Fact]
         public void Test_GetLabel_NoLabel() {

--- a/test/unit/Facades/MockDirectoryObject.cs
+++ b/test/unit/Facades/MockDirectoryObject.cs
@@ -102,7 +102,7 @@ public class MockDirectoryObject : IDirectoryObject {
         return false;
     }
 
-    public bool TryGetIntProperty(string propertyName, out int value) {
+    public bool TryGetLongProperty(string propertyName, out long value) {
         if (!Properties.Contains(propertyName)) {
             value = default;
             return false;
@@ -114,6 +114,9 @@ public class MockDirectoryObject : IDirectoryObject {
                 return true;
             case string s when int.TryParse(s, out var val):
                 value = val;
+                return true;
+            case long i:
+                value = i;
                 return true;
             default:
                 value = 0;


### PR DESCRIPTION
## Description
A check was using > 0 instead of >= 0 which prevented the NTAuthCertificates node from being collected properly. Also adds some serialization tags to a directory object class for further testing

Preserves non-resolved ACEs in enterprise CA properties

Fixes a missing attribute store in generation

Uses `long` instead of `int` to allow fetching properties like LAPS expiration properly

Fixes the ldap filter for containers to exclude GPOs since they have the same objectclass

<!--- Describe your changes in detail -->

## Motivation and Context
Data inconsistency
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tests written
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
