### PR TITLE
Add proper timeouts to all computer api calls

### DIFF
--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -82,7 +82,7 @@ namespace SharpHoundCommonLib.Processors {
 
             if (result.IsFailed) {
                 await SendComputerStatus(new CSVComputerStatus {
-                    Status = result.Status.ToString(),
+                    Status = result.GetErrorStatus(),
                     Task = "NetSessionEnum",
                     ComputerName = computerName
                 });
@@ -200,7 +200,7 @@ namespace SharpHoundCommonLib.Processors {
             
             if (result.IsFailed) {
                 await SendComputerStatus(new CSVComputerStatus {
-                    Status = result.Status.ToString(),
+                    Status = result.GetErrorStatus(),
                     Task = "NetWkstaUserEnum",
                     ComputerName = computerName
                 });

--- a/src/SharpHoundRPC/NetAPINative/NetAPIResult.cs
+++ b/src/SharpHoundRPC/NetAPINative/NetAPIResult.cs
@@ -37,5 +37,13 @@
         {
             return Fail(error);
         }
+
+        public string GetErrorStatus() {
+            if (!string.IsNullOrEmpty(Error)) {
+                return Error;
+            }
+
+            return Status.ToString();
+        }
     }
 }

--- a/src/SharpHoundRPC/Result.cs
+++ b/src/SharpHoundRPC/Result.cs
@@ -7,6 +7,7 @@
         public T Value { get; private set; }
         public string Error { get; private set; }
         public bool IsFailed => !IsSuccess;
+        public bool IsTimeout { get; set; }
 
         public static Result<T> Ok(T value)
         {

--- a/test/unit/ComputerSessionProcessorTest.cs
+++ b/test/unit/ComputerSessionProcessorTest.cs
@@ -237,6 +237,9 @@ namespace CommonLibTest
             nativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Callback(() => {
                 Thread.Sleep(200);
             }).Returns(Array.Empty<NetSessionEnumResults>());
+            nativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>())).Callback(() => {
+                Thread.Sleep(200);
+            }).Returns(Array.Empty<NetWkstaUserEnumResults>());
             var processor = new ComputerSessionProcessor(new MockLdapUtils(),"", nativeMethods.Object);
             var receivedStatus = new List<CSVComputerStatus>();
             var machineDomainSid = $"{Consts.MockDomainSid}-1000";


### PR DESCRIPTION
## Description
API calls to computers can sometimes just go out to lunch and never come back. Add a default 2 minute timeout to all these calls to prevent deadlocking the application

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
