### PR TITLE
Disable Semaphore and fix some flaky tests

### DIFF
--- a/src/CommonLib/ConnectionPoolManager.cs
+++ b/src/CommonLib/ConnectionPoolManager.cs
@@ -99,13 +99,13 @@ namespace SharpHoundCommonLib {
             return await pool.GetConnectionAsync();
         }
     
-        public async Task<(bool Success, LdapConnectionWrapper connectionWrapper, string Message)> GetLdapConnectionForServer(
+        public (bool Success, LdapConnectionWrapper connectionWrapper, string Message) GetLdapConnectionForServer(
             string identifier, string server, bool globalCatalog) {
             if (!GetPool(identifier, out var pool)) {
                 return (false, default, $"Unable to resolve a pool for {identifier}");
             }
         
-            return await pool.GetConnectionForSpecificServerAsync(server, globalCatalog);
+            return pool.GetConnectionForSpecificServerAsync(server, globalCatalog);
         }
 
         private string ResolveIdentifier(string identifier) {

--- a/src/CommonLib/LdapQueryParameters.cs
+++ b/src/CommonLib/LdapQueryParameters.cs
@@ -1,10 +1,11 @@
 using System;
 using System.DirectoryServices.Protocols;
+using System.Threading;
 using SharpHoundCommonLib.Enums;
 
 namespace SharpHoundCommonLib {
-    public class LdapQueryParameters
-    {
+    public class LdapQueryParameters {
+        private static int _queryIDIndex;
         private string _searchBase;
         private string _relativeSearchBase;
         public string LDAPFilter { get; set; }
@@ -14,6 +15,12 @@ namespace SharpHoundCommonLib {
         public bool GlobalCatalog { get; set; }
         public bool IncludeSecurityDescriptor { get; set; } = false;
         public bool IncludeDeleted { get; set; } = false;
+        private int QueryID { get; }
+
+        public LdapQueryParameters() {
+            QueryID = _queryIDIndex;
+            Interlocked.Increment(ref _queryIDIndex);
+        }
 
         public string SearchBase {
             get => _searchBase;
@@ -35,7 +42,7 @@ namespace SharpHoundCommonLib {
 
         public string GetQueryInfo()
         {
-            return $"Query Information - Filter: {LDAPFilter}, Domain: {DomainName}, GlobalCatalog: {GlobalCatalog}, ADSPath: {SearchBase}";
+            return $"Query Information - Filter: {LDAPFilter}, Domain: {DomainName}, GlobalCatalog: {GlobalCatalog}, ADSPath: {SearchBase}, ID: {QueryID}";
         }
     }
 }

--- a/src/CommonLib/Processors/ComputerAvailability.cs
+++ b/src/CommonLib/Processors/ComputerAvailability.cs
@@ -16,7 +16,7 @@ namespace SharpHoundCommonLib.Processors
         private readonly bool _skipPasswordCheck;
         private readonly bool _skipPortScan;
 
-        public ComputerAvailability(int timeout = 500, int computerExpiryDays = 60, bool skipPortScan = false,
+        public ComputerAvailability(int timeout = 10000, int computerExpiryDays = 60, bool skipPortScan = false,
             bool skipPasswordCheck = false, ILogger log = null)
         {
             _scanner = new PortScanner();

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -24,8 +24,9 @@ namespace SharpHoundCommonLib.Processors {
         private readonly string _localAdminUsername;
         private readonly string _localAdminPassword;
 
-        public ComputerSessionProcessor(ILdapUtils utils, string currentUserName = null,
-            NativeMethods nativeMethods = null, ILogger log = null, bool doLocalAdminSessionEnum = false,
+        public ComputerSessionProcessor(ILdapUtils utils,
+            NativeMethods nativeMethods = null, ILogger log = null, string currentUserName = null,
+            bool doLocalAdminSessionEnum = false,
             string localAdminUsername = null, string localAdminPassword = null) {
             _utils = utils;
             _nativeMethods = nativeMethods ?? new NativeMethods();
@@ -92,7 +93,7 @@ namespace SharpHoundCommonLib.Processors {
                 return ret;
             }
 
-            _log.LogTrace("NetSessionEnum succeeded on {ComputerName}", computerName);
+            _log.LogDebug("NetSessionEnum succeeded on {ComputerName}", computerName);
             await SendComputerStatus(new CSVComputerStatus {
                 Status = CSVComputerStatus.StatusSuccess,
                 Task = "NetSessionEnum",

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -9,7 +9,7 @@
         <PackageDescription>Common library for C# BloodHound enumeration tasks</PackageDescription>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/BloodHoundAD/SharpHoundCommon</RepositoryUrl>
-        <Version>4.0.5</Version>
+        <Version>4.0.6</Version>
         <AssemblyName>SharpHoundCommonLib</AssemblyName>
         <RootNamespace>SharpHoundCommonLib</RootNamespace>
     </PropertyGroup>

--- a/test/unit/ComputerSessionProcessorTest.cs
+++ b/test/unit/ComputerSessionProcessorTest.cs
@@ -13,16 +13,13 @@ using SharpHoundRPC.NetAPINative;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace CommonLibTest
-{
-    public class ComputerSessionProcessorTest : IDisposable
-    {
+namespace CommonLibTest {
+    public class ComputerSessionProcessorTest : IDisposable {
         private readonly string _computerDomain;
         private readonly string _computerSid;
         private readonly ITestOutputHelper _testOutputHelper;
 
-        public ComputerSessionProcessorTest(ITestOutputHelper testOutputHelper)
-        {
+        public ComputerSessionProcessorTest(ITestOutputHelper testOutputHelper) {
             _testOutputHelper = testOutputHelper;
             _computerDomain = "TESTLAB.LOCAL";
             _computerSid = "S-1-5-21-3130019616-2776909439-2417379446-1104";
@@ -30,172 +27,148 @@ namespace CommonLibTest
 
         #region IDispose Implementation
 
-        public void Dispose()
-        {
+        public void Dispose() {
             // Tear down (called once per test)
         }
 
         #endregion
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_FilteringWorks()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_FilteringWorks() {
             var mockNativeMethods = new Mock<NativeMethods>();
 
-            var apiResult = new NetSessionEnumResults[]
-            {
+            var apiResult = new NetSessionEnumResults[] {
                 new("dfm", "\\\\192.168.92.110"),
                 new("admin", ""),
                 new("admin", "\\\\192.168.92.110")
             };
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object,null, "dfm");
             var result = await processor.ReadUserSessions("win10", _computerSid, _computerDomain);
             Assert.True(result.Collected);
             Assert.Empty(result.Results);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_ResolvesHost()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_ResolvesHost() {
             var mockNativeMethods = new Mock<NativeMethods>();
-            var apiResult = new NetSessionEnumResults[]
-            {
+            var apiResult = new NetSessionEnumResults[] {
                 new("admin", "\\\\192.168.1.1")
             };
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
 
-            var expected = new Session[]
-            {
-                new()
-                {
+            var expected = new Session[] {
+                new() {
                     ComputerSID = "S-1-5-21-3130019616-2776909439-2417379446-1104",
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-2116"
                 }
             };
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object,null, "dfm");
             var result = await processor.ReadUserSessions("win10", _computerSid, _computerDomain);
             Assert.True(result.Collected);
             Assert.Equal(expected, result.Results);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_ResolvesLocalHostEquivalent()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_ResolvesLocalHostEquivalent() {
             var mockNativeMethods = new Mock<NativeMethods>();
-            var apiResult = new NetSessionEnumResults[]
-            {
+            var apiResult = new NetSessionEnumResults[] {
                 new("admin", "\\\\127.0.0.1")
             };
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
 
-            var expected = new Session[]
-            {
-                new()
-                {
+            var expected = new Session[] {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-2116"
                 }
             };
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object,null, "dfm");
             var result = await processor.ReadUserSessions("win10", _computerSid, _computerDomain);
             Assert.True(result.Collected);
             Assert.Equal(expected, result.Results);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_MultipleMatches_AddsAll()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_MultipleMatches_AddsAll() {
             var mockNativeMethods = new Mock<NativeMethods>();
-            var apiResult = new NetSessionEnumResults[]
-            {
+            var apiResult = new NetSessionEnumResults[] {
                 new("administrator", "\\\\127.0.0.1")
             };
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
 
-            var expected = new Session[]
-            {
-                new()
-                {
+            var expected = new Session[] {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-500"
                 },
-                new()
-                {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3084884204-958224920-2707782874-500"
                 }
             };
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object,null, "dfm");
             var result = await processor.ReadUserSessions("win10", _computerSid, _computerDomain);
             Assert.True(result.Collected);
             Assert.Equal(expected, result.Results);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_NoGCMatch_TriesResolve()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_NoGCMatch_TriesResolve() {
             var mockNativeMethods = new Mock<NativeMethods>();
-            var apiResult = new NetSessionEnumResults[]
-            {
+            var apiResult = new NetSessionEnumResults[] {
                 new("test", "\\\\127.0.0.1")
             };
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
 
-            var expected = new Session[]
-            {
-                new()
-                {
+            var expected = new Session[] {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-1106"
                 }
             };
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object, null,"dfm");
             var result = await processor.ReadUserSessions("win10", _computerSid, _computerDomain);
             Assert.True(result.Collected);
             Assert.Equal(expected, result.Results);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessions_ComputerAccessDenied_Handled()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessions_ComputerAccessDenied_Handled() {
             var mockNativeMethods = new Mock<NativeMethods>();
             //mockNativeMethods.Setup(x => x.CallSamConnect(ref It.Ref<NativeMethods.UNICODE_STRING>.IsAny, out It.Ref<IntPtr>.IsAny, It.IsAny<NativeMethods.SamAccessMasks>(), ref It.Ref<NativeMethods.OBJECT_ATTRIBUTES>.IsAny)).Returns(NativeMethods.NtStatus.StatusAccessDenied);
             mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>()))
                 .Returns(NetAPIEnums.NetAPIStatus.ErrorAccessDenied);
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object, null,"dfm");
             var test = await processor.ReadUserSessions("test", "test", "test");
             Assert.False(test.Collected);
             Assert.Equal(NetAPIEnums.NetAPIStatus.ErrorAccessDenied.ToString(), test.FailureReason);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessionsPrivileged_ComputerAccessDenied_ExceptionCaught()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessionsPrivileged_ComputerAccessDenied_ExceptionCaught() {
             var mockNativeMethods = new Mock<NativeMethods>();
             //mockNativeMethods.Setup(x => x.CallSamConnect(ref It.Ref<NativeMethods.UNICODE_STRING>.IsAny, out It.Ref<IntPtr>.IsAny, It.IsAny<NativeMethods.SamAccessMasks>(), ref It.Ref<NativeMethods.OBJECT_ATTRIBUTES>.IsAny)).Returns(NativeMethods.NtStatus.StatusAccessDenied);
             mockNativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>()))
                 .Returns(NetAPIEnums.NetAPIStatus.ErrorAccessDenied);
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), "dfm", mockNativeMethods.Object);
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object, null,"dfm");
             var test = await processor.ReadUserSessionsPrivileged("test", "test", "test");
             Assert.False(test.Collected);
             Assert.Equal(NetAPIEnums.NetAPIStatus.ErrorAccessDenied.ToString(), test.FailureReason);
         }
 
         [Fact]
-        public async Task ComputerSessionProcessor_ReadUserSessionsPrivileged_FilteringWorks()
-        {
+        public async Task ComputerSessionProcessor_ReadUserSessionsPrivileged_FilteringWorks() {
             var mockNativeMethods = new Mock<NativeMethods>();
             const string samAccountName = "WIN10";
 
             //This is a sample response from a computer in a test environment. The duplicates are intentional
-            var apiResults = new NetWkstaUserEnumResults[]
-            {
+            var apiResults = new NetWkstaUserEnumResults[] {
                 new("dfm", "TESTLAB"),
                 new("Administrator", "PRIMARY"),
                 new("Administrator", ""),
@@ -209,21 +182,19 @@ namespace CommonLibTest
             };
             mockNativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>())).Returns(apiResults);
 
-            var expected = new Session[]
-            {
-                new()
-                {
+            var expected = new Session[] {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-1105"
                 },
-                new()
-                {
+                new() {
                     ComputerSID = _computerSid,
                     UserSID = "S-1-5-21-3130019616-2776909439-2417379446-500"
                 }
             };
 
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(), nativeMethods: mockNativeMethods.Object, currentUserName:"ADMINISTRATOR");
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), nativeMethods: mockNativeMethods.Object,
+                currentUserName: "ADMINISTRATOR");
             var test = await processor.ReadUserSessionsPrivileged("WIN10.TESTLAB.LOCAL", samAccountName, _computerSid);
             Assert.True(test.Collected);
             _testOutputHelper.WriteLine(JsonConvert.SerializeObject(test.Results));
@@ -234,15 +205,14 @@ namespace CommonLibTest
         [Fact]
         public async Task ComputerSessionProcessor_TestTimeout() {
             var nativeMethods = new Mock<NativeMethods>();
-            nativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Callback(() => {
+            nativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(() => {
                 Task.Delay(1000).Wait();
-            }).Returns(Array.Empty<NetSessionEnumResults>());
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(),"", nativeMethods.Object);
+                return Array.Empty<NetSessionEnumResults>();
+            });
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), nativeMethods.Object, null,"");
             var receivedStatus = new List<CSVComputerStatus>();
             var machineDomainSid = $"{Consts.MockDomainSid}-1000";
-            processor.ComputerStatusEvent += async status =>  {
-                receivedStatus.Add(status);
-            };
+            processor.ComputerStatusEvent += async status => { receivedStatus.Add(status); };
             var results = await processor.ReadUserSessions("primary.testlab.local", machineDomainSid, "testlab.local",
                 TimeSpan.FromMilliseconds(1));
             Assert.Empty(results.Results);
@@ -250,21 +220,21 @@ namespace CommonLibTest
             var status = receivedStatus[0];
             Assert.Equal("Timeout", status.Status);
         }
-        
+
         [Fact]
         public async Task ComputerSessionProcessor_TestTimeoutPrivileged() {
             var nativeMethods = new Mock<NativeMethods>();
-            nativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>())).Callback(() => {
+            nativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>())).Returns(() => {
                 Task.Delay(1000).Wait();
-            }).Returns(Array.Empty<NetWkstaUserEnumResults>());
-            var processor = new ComputerSessionProcessor(new MockLdapUtils(),"", nativeMethods.Object);
+                return Array.Empty<NetWkstaUserEnumResults>();
+            });
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), nativeMethods.Object, null,"");
             var receivedStatus = new List<CSVComputerStatus>();
             var machineDomainSid = $"{Consts.MockDomainSid}-1000";
-            processor.ComputerStatusEvent += async status =>  {
-                receivedStatus.Add(status);
-            };
-            
-            var results = await processor.ReadUserSessionsPrivileged("primary.testlab.local", machineDomainSid, "testlab.local",
+            processor.ComputerStatusEvent += async status => { receivedStatus.Add(status); };
+
+            var results = await processor.ReadUserSessionsPrivileged("primary.testlab.local", machineDomainSid,
+                "testlab.local",
                 TimeSpan.FromMilliseconds(1));
             Assert.Empty(results.Results);
             Assert.Single(receivedStatus);

--- a/test/unit/LocalGroupProcessorTest.cs
+++ b/test/unit/LocalGroupProcessorTest.cs
@@ -119,9 +119,10 @@ namespace CommonLibTest
             var mockUtils = new Mock<MockLdapUtils>();
             var mockProcessor = new Mock<LocalGroupProcessor>(mockUtils.Object, null);
             
-            mockProcessor.Setup(x => x.OpenSamServer(It.IsAny<string>())).Callback(() => {
+            mockProcessor.Setup(x => x.OpenSamServer(It.IsAny<string>())).Returns(() => {
                 Task.Delay(100).Wait();
-            }).Returns(NtStatus.StatusAccessDenied);
+                return NtStatus.StatusAccessDenied;
+            });
             var processor = mockProcessor.Object;
             var machineDomainSid = $"{Consts.MockDomainSid}-1000";
             var receivedStatus = new List<CSVComputerStatus>();

--- a/test/unit/UserRightsAssignmentProcessorTest.cs
+++ b/test/unit/UserRightsAssignmentProcessorTest.cs
@@ -71,9 +71,10 @@ namespace CommonLibTest
         [Fact]
         public async Task UserRightsAssignmentProcessor_TestTimeout() {
             var mockProcessor = new Mock<UserRightsAssignmentProcessor>(new MockLdapUtils(), null);
-            mockProcessor.Setup(x => x.OpenLSAPolicy(It.IsAny<string>())).Callback(() => {
+            mockProcessor.Setup(x => x.OpenLSAPolicy(It.IsAny<string>())).Returns(()=> {
                 Task.Delay(100).Wait();
-            }).Returns(NtStatus.StatusAccessDenied);
+                return NtStatus.StatusAccessDenied;
+            });
             var processor = mockProcessor.Object;
             var machineDomainSid = $"{Consts.MockDomainSid}-1000";
             var receivedStatus = new List<CSVComputerStatus>();


### PR DESCRIPTION
fix: temporarily disable semaphore until we can iron out deadlocks
chore: some misc test fixes to fix flakiness
chore: fix an async function that wasn't async

## Description

<!--- Describe your changes in detail -->

## Motivation and Context
The semaphore in LdapConnectionPool appears to be causing a deadlock during heavy enumeration in certain edge cases. Until we can figure out whats causing it, we're disabling the behavior

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
