### PR TITLE
[BED-4820] Fix: Min-valued nano durations would throw Overflow exceptions

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -724,6 +724,11 @@ namespace SharpHoundCommonLib.Processors {
 
         private static string ConvertNanoDuration(long duration)
         {
+            // In case duration is long.MinValue, Math.Abs will overflow.  Value represents Forever or Never
+            if (duration == long.MinValue) {
+                return "Forever";
+            }
+
             // duration is in 100-nanosecond intervals
             // Convert it to TimeSpan (which uses 1 tick = 100 nanoseconds)
             TimeSpan durationSpan = TimeSpan.FromTicks(Math.Abs(duration));


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Min-value data for new duration properties throw OverflowException when converted to positive values via Math.Abs
While negative, the values collected actually represent positive numbers ...
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/e270cd0a-5295-41be-9e89-2c3dc3a39536?redirectedfrom=MSDN

It appears that min-value represents "N/A" data, or "Forever", so we'll record this value when resolving the property for this circumstance.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
