### PR TITLE
[BED-4820] OPTIONAL: Going a step further - ignoring error code values

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -724,6 +724,11 @@ namespace SharpHoundCommonLib.Processors {
 
         private static string ConvertNanoDuration(long duration)
         {
+            // In case duration is long.MinValue, Math.Abs will overflow.  Value represents Forever or Never
+            if (duration == long.MinValue) {
+                return "Forever";
+            }
+
             // duration is in 100-nanosecond intervals
             // Convert it to TimeSpan (which uses 1 tick = 100 nanoseconds)
             TimeSpan durationSpan = TimeSpan.FromTicks(Math.Abs(duration));

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -8,6 +8,7 @@ using System.Security.AccessControl;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.LDAPQueries;
 using SharpHoundCommonLib.OutputTypes;
@@ -70,16 +71,28 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("lockoutthreshold", entry.GetProperty(LDAPProperties.LockoutThreshold));
 
             if (entry.TryGetLongProperty(LDAPProperties.MinPwdAge, out var minpwdage)) {
-                props.Add("minpwdage", ConvertNanoDuration(minpwdage));
+                var duration = ConvertNanoDuration(minpwdage);
+                if (duration != null) {
+                    props.Add("minpwdage", duration);
+                }
             }
             if (entry.TryGetLongProperty(LDAPProperties.MaxPwdAge, out var maxpwdage)) {
-                props.Add("maxpwdage", ConvertNanoDuration(maxpwdage));
+                var duration = ConvertNanoDuration(maxpwdage);
+                if (duration != null) {
+                    props.Add("maxpwdage", duration);
+                }
             }
             if (entry.TryGetLongProperty(LDAPProperties.LockoutDuration, out var lockoutduration)) {
-                props.Add("lockoutduration", ConvertNanoDuration(lockoutduration));
+                var duration = ConvertNanoDuration(lockoutduration);
+                if (duration != null) {
+                    props.Add("lockoutduration", duration);
+                }
             }
             if (entry.TryGetLongProperty(LDAPProperties.LockOutObservationWindow, out var lockoutobservationwindow)) {
-                props.Add("lockoutobservationwindow", ConvertNanoDuration(lockoutobservationwindow));
+                var duration = ConvertNanoDuration(lockoutobservationwindow);
+                if (duration != null) {
+                    props.Add("lockoutobservationwindow", lockoutobservationwindow);
+                }
             }
             if (!entry.TryGetLongProperty(LDAPProperties.DomainFunctionalLevel, out var functionalLevel)) {
                 functionalLevel = -1;
@@ -727,6 +740,9 @@ namespace SharpHoundCommonLib.Processors {
             // In case duration is long.MinValue, Math.Abs will overflow.  Value represents Forever or Never
             if (duration == long.MinValue) {
                 return "Forever";
+            // And if the value is positive, it indicates an error code
+            } else if (duration > 0) {
+                return null;
             }
 
             // duration is in 100-nanosecond intervals


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context
https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/e270cd0a-5295-41be-9e89-2c3dc3a39536?redirectedfrom=MSDN

Positive values for nano-duration properties represent error codes.  We can go a step further and filter these values out.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
