### PR TITLE
Fix unhandled exceptions, cache unresolvable entities

### DIFF
--- a/src/CommonLib/ConcurrentHashSet.cs
+++ b/src/CommonLib/ConcurrentHashSet.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace SharpHoundCommonLib;
+
+/// <summary>
+/// A concurrent implementation of a hashset using a ConcurrentDictionary as the backing structure.
+/// </summary>
+public class ConcurrentHashSet : IDisposable{
+    private ConcurrentDictionary<string, byte> _backingDictionary;
+
+    public ConcurrentHashSet() {
+        _backingDictionary = new ConcurrentDictionary<string, byte>();
+    }
+    
+    public ConcurrentHashSet(StringComparer comparison) {
+        _backingDictionary = new ConcurrentDictionary<string, byte>(comparison);
+    }
+
+    /// <summary>
+    /// Attempts to add an item to the set. Returns true if adding was successful, false otherwise
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public bool Add(string item) {
+        return _backingDictionary.TryAdd(item, byte.MinValue);
+    }
+
+    /// <summary>
+    /// Attempts to remove an item from the set. Returns true of removing was successful, false otherwise
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public bool Remove(string item) {
+        return _backingDictionary.TryRemove(item, out _);
+    }
+
+    /// <summary>
+    /// Checks if the given item is in the set
+    /// </summary>
+    /// <param name="item"></param>
+    /// <returns></returns>
+    public bool Contains(string item) {
+        return _backingDictionary.ContainsKey(item);
+    }
+
+    /// <summary>
+    /// Returns all values in the set
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<string> Values() {
+        return _backingDictionary.Keys;
+    }
+
+    public void Dispose() {
+        _backingDictionary = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/CommonLib/ILdapUtils.cs
+++ b/src/CommonLib/ILdapUtils.cs
@@ -169,5 +169,10 @@ namespace SharpHoundCommonLib {
         /// <param name="context">The naming context being retrieved</param>
         /// <returns>A tuple containing success state as well as the resolved distinguished name if successful</returns>
         Task<(bool Success, string Path)> GetNamingContextPath(string domain, NamingContext context);
+
+        /// <summary>
+        /// Resets temporary caches in LDAPUtils
+        /// </summary>
+        void ResetUtils();
     }
 }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -1051,9 +1051,9 @@ namespace SharpHoundCommonLib {
         }
 
         public void ResetUtils() {
-            _unresolvablePrincipals = new ConcurrentHashSet();
+            _unresolvablePrincipals = new ConcurrentHashSet(StringComparer.OrdinalIgnoreCase);
             _domainCache = new ConcurrentDictionary<string, Domain>();
-            _domainControllers = new ConcurrentHashSet();
+            _domainControllers = new ConcurrentHashSet(StringComparer.OrdinalIgnoreCase);
             _connectionPool?.Dispose();
             _connectionPool = new ConnectionPoolManager(_ldapConfig, scanner: _portScanner);
         }

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -107,8 +107,10 @@ namespace SharpHoundCommonLib.Processors
                 }
                 var (resSuccess, resolvedPrincipal) = await GetRegistryPrincipal(new SecurityIdentifier(principalSid), principalDomain, computerName, isDomainController, computerObjectId, machineSid);
                 if (!resSuccess) {
-                    resolvedPrincipal.ObjectType = Label.Base;
-                    resolvedPrincipal.ObjectIdentifier = principalSid;
+                    resolvedPrincipal = new TypedPrincipal {
+                        ObjectType = Label.Base,
+                        ObjectIdentifier = principalSid
+                    };
                 }
                 var isInherited = rule.IsInherited();
 

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -9,7 +9,7 @@
         <PackageDescription>Common library for C# BloodHound enumeration tasks</PackageDescription>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/BloodHoundAD/SharpHoundCommon</RepositoryUrl>
-        <Version>4.0.6</Version>
+        <Version>4.0.7</Version>
         <AssemblyName>SharpHoundCommonLib</AssemblyName>
         <RootNamespace>SharpHoundCommonLib</RootNamespace>
     </PropertyGroup>

--- a/test/unit/Facades/MockLdapUtils.cs
+++ b/test/unit/Facades/MockLdapUtils.cs
@@ -1016,6 +1016,10 @@ namespace CommonLibTest.Facades
             throw new NotImplementedException();
         }
 
+        public void ResetUtils() {
+            throw new NotImplementedException();
+        }
+
         public Domain GetDomain(string domainName = null)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
2 uncaught exceptions were identified in CertAbuseProcessor and LdapPropertyProcessor, this MR addresses them.

Additionally, unresolvable principals were not cached, and where repeatedly looked up which in certain cases could drastically impact performance.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-4822
https://specterops.atlassian.net/browse/BED-4836
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
