### PR TITLE
Fixed LAPS attributes

### DIFF
--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -36,7 +36,8 @@
         public const string ServicePack = "operatingsystemservicepack";
         public const string DNSHostName = "dnshostname";
         public const string LAPSExpirationTime = "mslaps-passwordexpirationtime";
-        public const string LAPSPassword = "mslaps-password";
+        public const string LAPSPlaintextPassword = "ms-laps-password";
+        public const string LAPSEncryptedPassword = "ms-laps-encryptedpassword";
         public const string LegacyLAPSExpirationTime = "ms-mcs-admpwdexpirationtime";
         public const string LegacyLAPSPassword = "ms-mcs-admpwd";
         public const string Members = "member";

--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -35,7 +35,7 @@
         public const string OperatingSystem = "operatingsystem";
         public const string ServicePack = "operatingsystemservicepack";
         public const string DNSHostName = "dnshostname";
-        public const string LAPSExpirationTime = "mslaps-passwordexpirationtime";
+        public const string LAPSExpirationTime = "ms-laps-passwordexpirationtime";
         public const string LAPSPlaintextPassword = "ms-laps-password";
         public const string LAPSEncryptedPassword = "ms-laps-encryptedpassword";
         public const string LegacyLAPSExpirationTime = "ms-mcs-admpwdexpirationtime";

--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -35,7 +35,7 @@
         public const string OperatingSystem = "operatingsystem";
         public const string ServicePack = "operatingsystemservicepack";
         public const string DNSHostName = "dnshostname";
-        public const string LAPSExpirationTime = "ms-laps-passwordexpirationtime";
+        public const string LAPSExpirationTime = "mslaps-passwordexpirationtime";
         public const string LAPSPlaintextPassword = "ms-laps-password";
         public const string LAPSEncryptedPassword = "ms-laps-encryptedpassword";
         public const string LegacyLAPSExpirationTime = "ms-mcs-admpwdexpirationtime";

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -402,7 +402,7 @@ namespace SharpHoundCommonLib.Processors {
                                     RightName = EdgeNames.AllExtendedRights,
                                     InheritanceHash = aceInheritanceHash
                                 };
-                            else if (mappedGuid is LDAPProperties.LegacyLAPSPassword or LDAPProperties.LAPSPassword)
+                            else if (mappedGuid is LDAPProperties.LegacyLAPSPassword or LDAPProperties.LAPSPlaintextPassword or LDAPProperties.LAPSEncryptedPassword)
                                 yield return new ACE {
                                     PrincipalType = resolvedPrincipal.ObjectType,
                                     PrincipalSID = resolvedPrincipal.ObjectIdentifier,

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -64,7 +64,7 @@ namespace SharpHoundCommonLib.Processors {
                     }
 
                     name = name.ToLower();
-                    if (name is LDAPProperties.LAPSPassword or LDAPProperties.LegacyLAPSPassword) {
+                    if (name is LDAPProperties.LAPSPlaintextPassword or LDAPProperties.LAPSEncryptedPassword or LDAPProperties.LegacyLAPSPassword) {
                         _log.LogDebug("Found GUID for ACL Right {Name}: {Guid} in domain {Domain}", name, guid, domain);
                         GuidMap.TryAdd(guid, name);
                     }


### PR DESCRIPTION
## Description

As discussed with @rvazarkar attributes for "new" LAPS were not being captured due to typos

## Motivation and Context

ReadLAPSPassword edges were not being created as the password attributes were not captured in the GUID map

## How Has This Been Tested?

This has not been tested, just sanity checked by matching up the names in the AD schema

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e05d644a-b53c-40f6-a545-de03a66133e1)

Example of the ms-LAPS-EncryptedPassword GUID

![image](https://github.com/user-attachments/assets/2c3ee62c-6c68-402c-a44c-0261a72ae1c2)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
