### PR TITLE
fix TGTDelegationEnabled

### DIFF
--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -86,8 +86,8 @@ namespace SharpHoundCommonLib.Processors
 
                 trust.TGTDelegationEnabled = 
                     !attributes.HasFlag(TrustAttributes.QuarantinedDomain) &&
-                    (attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation)
-                    || !attributes.HasFlag(TrustAttributes.CrossOrganizationNoTGTDelegation));
+                    attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation));
+
                 trust.TrustType = TrustAttributesToType(attributes);
 
                 yield return trust;

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -86,7 +86,8 @@ namespace SharpHoundCommonLib.Processors
 
                 trust.TGTDelegationEnabled = 
                     !attributes.HasFlag(TrustAttributes.QuarantinedDomain) &&
-                    attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation);
+                    (attributes.HasFlag(TrustAttributes.WithinForest) ||
+                    attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation));
 
                 trust.TrustType = TrustAttributesToType(attributes);
 

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -86,7 +86,7 @@ namespace SharpHoundCommonLib.Processors
 
                 trust.TGTDelegationEnabled = 
                     !attributes.HasFlag(TrustAttributes.QuarantinedDomain) &&
-                    attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation));
+                    attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation);
 
                 trust.TrustType = TrustAttributesToType(attributes);
 


### PR DESCRIPTION
## Description

Do not use CrossOrganizationNoTGTDelegation to calculate TGTDelegationEnabled.

## Motivation and Context

CrossOrganizationNoTGTDelegation being false does not enable TGT delegation. That is what my testing shows. It seems like this flag became meaningless after TGT delegation was disabled by default in 2019.

## How Has This Been Tested?

Locally in my lab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
