### PR TITLE
Incorrect collection of ACE GUIDS from Schema

### DIFF
--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -18,7 +18,7 @@ namespace SharpHoundCommonLib.Processors {
         private static readonly ConcurrentDictionary<string, string> GuidMap = new();
         private readonly ILogger _log;
         private readonly ILdapUtils _utils;
-        private static readonly HashSet<string> BuiltDomainCaches = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentHashSet BuiltDomainCaches = new(StringComparer.OrdinalIgnoreCase);
 
         static ACLProcessor() {
             //Create a dictionary with the base GUIDs of each object type
@@ -50,8 +50,8 @@ namespace SharpHoundCommonLib.Processors {
         ///     LAPS
         /// </summary>
         private async Task BuildGuidCache(string domain) {
-            BuiltDomainCaches.Add(domain);
-            await foreach (var result in _utils.Query(new LdapQueryParameters {
+            _log.LogInformation("Building GUID Cache for {Domain}", domain);
+            await foreach (var result in _utils.PagedQuery(new LdapQueryParameters {
                                DomainName = domain,
                                LDAPFilter = "(schemaIDGUID=*)",
                                NamingContext = NamingContext.Schema,
@@ -59,13 +59,23 @@ namespace SharpHoundCommonLib.Processors {
                            })) {
                 if (result.IsSuccess) {
                     if (!result.Value.TryGetProperty(LDAPProperties.Name, out var name) ||
-                        !result.Value.TryGetGuid(out var guid)) {
+                        !result.Value.TryGetByteProperty(LDAPProperties.SchemaIDGUID, out var schemaGuid)) {
                         continue;
                     }
 
                     name = name.ToLower();
+                    string guid;
+                    try
+                    {
+                        guid = new Guid(schemaGuid).ToString();
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    
                     if (name is LDAPProperties.LAPSPassword or LDAPProperties.LegacyLAPSPassword) {
-                        _log.LogDebug("Found GUID for ACL Right {Name}: {Guid} in domain {Domain}", name, guid, domain);
+                        _log.LogInformation("Found GUID for ACL Right {Name}: {Guid} in domain {Domain}", name, guid, domain);
                         GuidMap.TryAdd(guid, name);
                     }
                 } else {
@@ -218,6 +228,7 @@ namespace SharpHoundCommonLib.Processors {
             Label objectType,
             bool hasLaps, string objectName = "") {
             if (!BuiltDomainCaches.Contains(objectDomain)) {
+                BuiltDomainCaches.Add(objectDomain);
                 await BuildGuidCache(objectDomain);
             }
 

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1019,56 +1019,56 @@ namespace CommonLibTest {
             Assert.Equal(actual.RightName, expectedRightName);
         }
         
-        // [Fact]
-        // public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
-        //     var expectedPrincipalType = Label.Group;
-        //     var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-        //     var expectedRightName = EdgeNames.ReadLAPSPassword;
-        //
-        //     var mockLDAPUtils = new Mock<ILdapUtils>();
-        //     var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-        //     var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-        //     var collection = new List<ActiveDirectoryRuleDescriptor>();
-        //     mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-        //     mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-        //     mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-        //     mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-        //     var lapsGuid = Guid.NewGuid();
-        //     mockRule.Setup(x => x.ObjectType()).Returns(lapsGuid);
-        //     collection.Add(mockRule.Object);
-        //
-        //     mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-        //         .Returns(collection);
-        //     mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-        //     mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        //     mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-        //         .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-        //     
-        //     //Return a directory object from pagedquery for the schemaid to simulate LAPS
-        //     var searchResults = new[]
-        //     {
-        //         LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
-        //             "abc123"
-        //             , new Dictionary<string, object>()
-        //             {
-        //                 {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},
-        //                 {LDAPProperties.Name, LDAPProperties.LegacyLAPSPassword}
-        //             }, null,null)),
-        //     };
-        //     mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-        //         .Returns(searchResults.ToAsyncEnumerable);
-        //
-        //     var processor = new ACLProcessor(mockLDAPUtils.Object);
-        //     var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-        //     var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
-        //
-        //     Assert.Single(result);
-        //     var actual = result.First();
-        //     Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-        //     Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-        //     Assert.False(actual.IsInherited);
-        //     Assert.Equal(actual.RightName, expectedRightName);
-        // }
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.ReadLAPSPassword;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            var lapsGuid = Guid.NewGuid();
+            mockRule.Setup(x => x.ObjectType()).Returns(lapsGuid);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            
+            //Return a directory object from pagedquery for the schemaid to simulate LAPS
+            var searchResults = new[]
+            {
+                LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
+                    "abc123"
+                    , new Dictionary<string, object>()
+                    {
+                        {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},
+                        {LDAPProperties.Name, LDAPProperties.LegacyLAPSPassword}
+                    }, null,null)),
+            };
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(searchResults.ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
 
         [Fact]
         public void GetInheritedAceHashes_NullSD_Empty() {

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -212,8 +212,13 @@ namespace CommonLibTest {
         }
 
         [Fact]
-        public async Task ACLProcessor_ProcessACL_Null_NTSecurityDescriptor() {
-            var processor = new ACLProcessor(new MockLdapUtils());
+        public async Task ACLProcessor_ProcessACL_Null_NTSecurityDescriptor()
+        {
+            var mock = new Mock<MockLdapUtils>();
+            mock.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
+            var processor = new ACLProcessor(mock.Object);
+            
             var result = await processor.ProcessACL(null, _testDomainName, Label.User, false).ToArrayAsync();
 
             Assert.Empty(result);
@@ -261,6 +266,8 @@ namespace CommonLibTest {
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
@@ -279,6 +286,8 @@ namespace CommonLibTest {
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
@@ -300,6 +309,8 @@ namespace CommonLibTest {
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
@@ -322,6 +333,8 @@ namespace CommonLibTest {
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
@@ -345,6 +358,8 @@ namespace CommonLibTest {
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1019,56 +1019,56 @@ namespace CommonLibTest {
             Assert.Equal(actual.RightName, expectedRightName);
         }
         
-        [Fact]
-        public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
-            var expectedPrincipalType = Label.Group;
-            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var expectedRightName = EdgeNames.ReadLAPSPassword;
-
-            var mockLDAPUtils = new Mock<ILdapUtils>();
-            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-            var collection = new List<ActiveDirectoryRuleDescriptor>();
-            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
-            var lapsGuid = Guid.NewGuid();
-            mockRule.Setup(x => x.ObjectType()).Returns(lapsGuid);
-            collection.Add(mockRule.Object);
-
-            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-                .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            
-            //Return a directory object from pagedquery for the schemaid to simulate LAPS
-            var searchResults = new[]
-            {
-                LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
-                    "abc123"
-                    , new Dictionary<string, object>()
-                    {
-                        {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},
-                        {LDAPProperties.Name, LDAPProperties.LegacyLAPSPassword}
-                    }, null,null)),
-            };
-            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-                .Returns(searchResults.ToAsyncEnumerable);
-
-            var processor = new ACLProcessor(mockLDAPUtils.Object);
-            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
-            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
-
-            Assert.Single(result);
-            var actual = result.First();
-            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
-            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
-            Assert.False(actual.IsInherited);
-            Assert.Equal(actual.RightName, expectedRightName);
-        }
+        // [Fact]
+        // public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
+        //     var expectedPrincipalType = Label.Group;
+        //     var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+        //     var expectedRightName = EdgeNames.ReadLAPSPassword;
+        //
+        //     var mockLDAPUtils = new Mock<ILdapUtils>();
+        //     var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+        //     var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+        //     var collection = new List<ActiveDirectoryRuleDescriptor>();
+        //     mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+        //     mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+        //     mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+        //     mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+        //     var lapsGuid = Guid.NewGuid();
+        //     mockRule.Setup(x => x.ObjectType()).Returns(lapsGuid);
+        //     collection.Add(mockRule.Object);
+        //
+        //     mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+        //         .Returns(collection);
+        //     mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+        //     mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+        //     mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+        //         .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+        //     
+        //     //Return a directory object from pagedquery for the schemaid to simulate LAPS
+        //     var searchResults = new[]
+        //     {
+        //         LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
+        //             "abc123"
+        //             , new Dictionary<string, object>()
+        //             {
+        //                 {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},
+        //                 {LDAPProperties.Name, LDAPProperties.LegacyLAPSPassword}
+        //             }, null,null)),
+        //     };
+        //     mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+        //         .Returns(searchResults.ToAsyncEnumerable);
+        //
+        //     var processor = new ACLProcessor(mockLDAPUtils.Object);
+        //     var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+        //     var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
+        //
+        //     Assert.Single(result);
+        //     var actual = result.First();
+        //     Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+        //     Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+        //     Assert.False(actual.IsInherited);
+        //     Assert.Equal(actual.RightName, expectedRightName);
+        // }
 
         [Fact]
         public void GetInheritedAceHashes_NullSD_Empty() {

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -62,7 +62,7 @@ namespace CommonLibTest {
             var mockLdapUtils = new MockLdapUtils();
             var mockUtils = new Mock<ILdapUtils>();
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
             mockUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns((string a, string b) => mockLdapUtils.ResolveIDAndType(a, b));
@@ -236,7 +236,7 @@ namespace CommonLibTest {
                 .ReturnsAsync((true, new TypedPrincipal(expectedSID, expectedPrincipalType)));
 
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -377,7 +377,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -410,7 +410,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -449,7 +449,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -488,7 +488,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -527,7 +527,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -565,7 +565,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -598,7 +598,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -636,7 +636,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -675,9 +675,9 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(mockData.ToAsyncEnumerable());
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -715,7 +715,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -748,7 +748,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -786,7 +786,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -823,7 +823,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -856,7 +856,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -893,7 +893,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -926,7 +926,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -964,7 +964,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
@@ -1004,8 +1004,60 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Computer, true).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+        
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.ReadLAPSPassword;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.ExtendedRight);
+            var lapsGuid = Guid.NewGuid();
+            mockRule.Setup(x => x.ObjectType()).Returns(lapsGuid);
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+
+            
+            var searchResults = new[]
+            {
+                //These first 4 should be filtered by our DN filters
+                LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
+                    "CN=7868d4c8-ac41-4e05-b401-776280e8e9f1,CN=Operations,CN=DomainUpdates,CN=System,DC=testlab,DC=local"
+                    , new Dictionary<string, object>()
+                    {
+                        {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},
+                        {LDAPProperties.Name, LDAPProperties.LegacyLAPSPassword}
+                    }, null,null)),
+            };
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(searchResults.ToAsyncEnumerable);
 
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1043,13 +1043,12 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-
             
+            //Return a directory object from pagedquery for the schemaid to simulate LAPS
             var searchResults = new[]
             {
-                //These first 4 should be filtered by our DN filters
                 LdapResult<IDirectoryObject>.Ok(new MockDirectoryObject(
-                    "CN=7868d4c8-ac41-4e05-b401-776280e8e9f1,CN=Operations,CN=DomainUpdates,CN=System,DC=testlab,DC=local"
+                    "abc123"
                     , new Dictionary<string, object>()
                     {
                         {LDAPProperties.SchemaIDGUID, lapsGuid.ToByteArray()},

--- a/test/unit/CommonLibTest.csproj
+++ b/test/unit/CommonLibTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <CollectCoverage>true</CollectCoverage>
         <CoverletOutput>..\..\docfx\coverage\</CoverletOutput>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
The logic for checking ACE guids in the schema was incorrectly using the guid of the object instead of the SchemaGuid value. Additionally, it was not using a paged query which is required since the schema partition returns tons of objects.

Also switched to a concurrent-aware data structure for storing built domain caches
## Motivation and Context
LAPS edges not being created correctly
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in a local LAPS enabled environment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
