### PR TITLE
Prep for CoerceToTGT

### DIFF
--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -20,6 +20,7 @@ namespace SharpHoundCommonLib.OutputTypes
         public DCRegistryData DCRegistryData { get; set; } = new();
         public ComputerStatus Status { get; set; }
         public bool IsDC { get; set; }
+        public bool UnconstrainedDelegation { get; set; }
         public string DomainSID { get; set; }
     }
 

--- a/src/CommonLib/OutputTypes/User.cs
+++ b/src/CommonLib/OutputTypes/User.cs
@@ -8,5 +8,7 @@ namespace SharpHoundCommonLib.OutputTypes
         public string PrimaryGroupSID { get; set; }
         public TypedPrincipal[] HasSIDHistory { get; set; } = Array.Empty<TypedPrincipal>();
         public SPNPrivilege[] SPNTargets { get; set; } = Array.Empty<SPNPrivilege>();
+        public bool UnconstrainedDelegation { get; set; }
+        public string DomainSID { get; set; }
     }
 }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -206,6 +206,8 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("passwordcantchange", uacFlags.HasFlag(UacFlags.PasswordCantChange));
             props.Add("passwordexpired", uacFlags.HasFlag(UacFlags.PasswordExpired));
 
+            userProps.UnconstrainedDelegation = uacFlags.HasFlag(UacFlags.TrustedForDelegation);
+
             var comps = new List<TypedPrincipal>();
             if (uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
                 entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
@@ -320,6 +322,8 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("logonscriptenabled", flags.HasFlag(UacFlags.Script));
             props.Add("lockedout", flags.HasFlag(UacFlags.Lockout));
             props.Add("passwordexpired", flags.HasFlag(UacFlags.PasswordExpired));
+
+            compProps.UnconstrainedDelegation = flags.HasFlag(UacFlags.TrustedForDelegation);
 
             var encryptionTypes = ConvertEncryptionTypes(entry.GetProperty(LDAPProperties.SupportedEncryptionTypes));
             props.Add("supportedencryptiontypes", encryptionTypes);
@@ -908,6 +912,7 @@ namespace SharpHoundCommonLib.Processors {
         public Dictionary<string, object> Props { get; set; } = new();
         public TypedPrincipal[] AllowedToDelegate { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] SidHistory { get; set; } = Array.Empty<TypedPrincipal>();
+        public bool UnconstrainedDelegation { get; set; }
     }
 
     public class ComputerProperties {
@@ -916,6 +921,7 @@ namespace SharpHoundCommonLib.Processors {
         public TypedPrincipal[] AllowedToAct { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] SidHistory { get; set; } = Array.Empty<TypedPrincipal>();
         public TypedPrincipal[] DumpSMSAPassword { get; set; } = Array.Empty<TypedPrincipal>();
+        public bool UnconstrainedDelegation { get; set; }
     }
 
     public class IssuancePolicyProperties {


### PR DESCRIPTION
## Description

Add the UnconstrainedDelegation and DomainSID as properties outside the Properties output object for users and computers.

## Motivation and Context

This is required for the CoerceToTGT edge - a new traversable edge from computers and users configured with unconstrained delegation to the domain.

Ticket: BP-982

## How Has This Been Tested?

Collected in my lab: 
[20241016080901_BloodHound.zip](https://github.com/user-attachments/files/17398017/20241016080901_BloodHound.zip)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
