### PR TITLE
fix: switch to SHA1 and add a try/catch block on acl inheritance hashing

### DIFF
--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -270,7 +270,8 @@ namespace SharpHoundCommonLib.Processors {
                         PrincipalType = resolvedOwner.ObjectType,
                         PrincipalSID = resolvedOwner.ObjectIdentifier,
                         RightName = EdgeNames.Owns,
-                        IsInherited = false
+                        IsInherited = false,
+                        InheritanceHash = ""
                     };
                 } else {
                     _log.LogTrace("Failed to resolve owner for {Name}", objectName);
@@ -278,7 +279,8 @@ namespace SharpHoundCommonLib.Processors {
                         PrincipalType = Label.Base,
                         PrincipalSID = ownerSid,
                         RightName = EdgeNames.Owns,
-                        IsInherited = false
+                        IsInherited = false,
+                        InheritanceHash = ""
                     };
                 }
             }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -144,13 +144,7 @@ namespace SharpHoundCommonLib.Processors {
                 using (var sha1 = SHA1.Create())
                 {
                     var bytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(hash));
-                    var builder = new StringBuilder();
-                    foreach (var b in bytes)
-                    {
-                        builder.Append(b.ToString("x2"));
-                    }
-
-                    return builder.ToString();
+                    return BitConverter.ToString(bytes).Replace("-", string.Empty).ToUpper();
                 }
             }
             catch


### PR DESCRIPTION
## Description
MD5 hashing is not FIPS compliant and in environments where compliance is enforced, .net will throw an exception. Switching to SHA1 will solve this issue. Additional try/catch for safety added.
<!--- Describe your changes in detail -->

## Motivation and Context
https://specterops.atlassian.net/browse/BP-988

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested in GOAD w/ FIPS enforcement enabled

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
