### PR TITLE
chore: move group collection to end of our ldap queries

### DIFF
--- a/src/CommonLib/LdapProducerQueryGenerator.cs
+++ b/src/CommonLib/LdapProducerQueryGenerator.cs
@@ -59,11 +59,6 @@ public class LdapProducerQueryGenerator {
             };
         }
 
-        if (methods.HasFlag(CollectionMethod.Group)) {
-            filter = filter.AddGroups();
-            properties.AddRange(CommonProperties.GroupResolutionProps);
-        }
-
         if (methods.IsComputerCollectionSet()) {
             filter = filter.AddComputers();
             properties.AddRange(CommonProperties.ComputerMethodProps);
@@ -87,6 +82,11 @@ public class LdapProducerQueryGenerator {
         if (methods.HasFlag(CollectionMethod.DCRegistry)) {
             filter = filter.AddComputers(CommonFilters.DomainControllers);
             properties.AddRange(CommonProperties.ComputerMethodProps);
+        }
+        
+        if (methods.HasFlag(CollectionMethod.Group)) {
+            filter = filter.AddGroups();
+            properties.AddRange(CommonProperties.GroupResolutionProps);
         }
         
         return new GeneratedLdapParameters {

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -9,7 +9,7 @@
         <PackageDescription>Common library for C# BloodHound enumeration tasks</PackageDescription>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/BloodHoundAD/SharpHoundCommon</RepositoryUrl>
-        <Version>4.0.8</Version>
+        <Version>4.0.9</Version>
         <AssemblyName>SharpHoundCommonLib</AssemblyName>
         <RootNamespace>SharpHoundCommonLib</RootNamespace>
     </PropertyGroup>


### PR DESCRIPTION
## Description
Group collection has the highest incidence of query failure of all of our different collection methods. Move this to the end of collection to allow everything else to collect as best as possible.

<!--- Describe your changes in detail -->

## Motivation and Context
https://specterops.atlassian.net/browse/BED-5061
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
No tests required, this is a simple logic change for ordering
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
