### PR TITLE
BED-4965 - Owns/Owner Rework

### DIFF
--- a/src/CommonLib/OutputTypes/OutputBase.cs
+++ b/src/CommonLib/OutputTypes/OutputBase.cs
@@ -14,6 +14,5 @@ namespace SharpHoundCommonLib.OutputTypes
         public bool IsDeleted { get; set; }
         public bool IsACLProtected { get; set; }
         public TypedPrincipal ContainedBy { get; set; }
-        public bool DoesAnyAceGrantOwnerRights { get; set; }
     }
 }

--- a/src/CommonLib/OutputTypes/OutputBase.cs
+++ b/src/CommonLib/OutputTypes/OutputBase.cs
@@ -14,5 +14,6 @@ namespace SharpHoundCommonLib.OutputTypes
         public bool IsDeleted { get; set; }
         public bool IsACLProtected { get; set; }
         public TypedPrincipal ContainedBy { get; set; }
+        public bool DoesAnyAceGrantOwnerRights { get; set; }
     }
 }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -2,13 +2,10 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.DirectoryServices;
-using System.Linq;
-using System.Net.Configuration;
 using System.Security.AccessControl;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.DirectoryObjects;
@@ -126,31 +123,6 @@ namespace SharpHoundCommonLib.Processors {
             return descriptor.AreAccessRulesProtected();
         }
 
-        /// <summary>
-        ///     Helper function to use common lib types and pass appropriate vars to ProcessACL
-        /// </summary>
-        /// <param name="result"></param>
-        /// <param name="searchResult"></param>
-        /// <returns></returns>
-        public async Task<(ACE[], bool, bool)> ProcessACL(ResolvedSearchResult result, IDirectoryObject searchResult, bool checkForOwnerRights) {
-            if (!searchResult.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var descriptor)) {
-                return ([], false, false);
-            }
-
-            var domain = result.Domain;
-            var type = result.ObjectType;
-            var hasLaps = searchResult.HasLAPS();
-            var name = result.DisplayName;
-
-            if (!checkForOwnerRights)
-            {
-                var aces = ProcessACL(descriptor, domain, type, hasLaps, name);
-                // Convert to array for return
-                return (await aces.ToArrayAsync(), false, false);
-            }
-            return await ProcessACL(descriptor, domain, type, hasLaps, name, checkForOwnerRights);
-        }
-
         internal static string CalculateInheritanceHash(string identityReference, ActiveDirectoryRights rights,
             string aceType, string inheritedObjectType) {
             var hash = identityReference + rights + aceType + inheritedObjectType;
@@ -243,6 +215,30 @@ namespace SharpHoundCommonLib.Processors {
         }
 
         /// <summary>
+        ///     Helper functions to use common lib types and pass appropriate vars to ProcessACL
+        /// </summary>
+        /// <param name="result"></param>
+        /// <param name="searchResult"></param>
+        /// <returns></returns>
+        public IAsyncEnumerable<ACE> ProcessACL(ResolvedSearchResult result, IDirectoryObject searchResult)
+        {
+            if (!searchResult.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var descriptor))
+            {
+                return AsyncEnumerable.Empty<ACE>();
+            }
+            return ProcessACL(descriptor, result.Domain, result.ObjectType, searchResult.HasLAPS(), result.DisplayName);
+        }
+
+        public async Task<(ACE[], bool, bool)> ProcessACL(ResolvedSearchResult result, IDirectoryObject searchResult, bool checkForOwnerRights)
+        {
+            if (!searchResult.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var descriptor))
+            {
+                return (Array.Empty<ACE>(), false, false);
+            }
+            return await ProcessACL(descriptor, result.Domain, result.ObjectType, searchResult.HasLAPS(), result.DisplayName, checkForOwnerRights);
+        }
+
+        /// <summary>
         ///     Read's a raw ntSecurityDescriptor and processes the ACEs in the ACL, filtering out ACEs that
         ///     BloodHound is not interested in as well as principals we don't care about
         /// </summary>
@@ -253,362 +249,12 @@ namespace SharpHoundCommonLib.Processors {
         /// <param name="hasLaps"></param>
         /// <returns></returns>
         public async IAsyncEnumerable<ACE> ProcessACL(byte[] ntSecurityDescriptor, string objectDomain,
-            Label objectType,
-            bool hasLaps, string objectName = "") {
-            await BuildGuidCache(objectDomain);
-
-            if (ntSecurityDescriptor == null) {
-                _log.LogDebug("Security Descriptor is null for {Name}", objectName);
-                yield break;
-            }
-
-            var descriptor = _utils.MakeSecurityDescriptor();
-            try {
-                descriptor.SetSecurityDescriptorBinaryForm(ntSecurityDescriptor);
-            } catch (OverflowException) {
-                _log.LogWarning(
-                    "Security descriptor on object {Name} exceeds maximum allowable length. Unable to process",
-                    objectName);
-                yield break;
-            }
-            
-            _log.LogDebug("Processing ACL for {ObjectName}", objectName);
-            var ownerSid = Helpers.PreProcessSID(descriptor.GetOwner(typeof(SecurityIdentifier)));
-
-            if (ownerSid != null) {
-                if (await _utils.ResolveIDAndType(ownerSid, objectDomain) is (true, var resolvedOwner)) {
-                    yield return new ACE {
-                        PrincipalType = resolvedOwner.ObjectType,
-                        PrincipalSID = resolvedOwner.ObjectIdentifier,
-                        RightName = EdgeNames.Owns,
-                        IsInherited = false,
-                        InheritanceHash = ""
-                    };
-                } else {
-                    _log.LogTrace("Failed to resolve owner for {Name}", objectName);
-                    yield return new ACE {
-                        PrincipalType = Label.Base,
-                        PrincipalSID = ownerSid,
-                        RightName = EdgeNames.Owns,
-                        IsInherited = false,
-                        InheritanceHash = ""
-                    };
-                }
-            }
-            
-            foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier))) {
-                if (ace == null || ace.AccessControlType() == AccessControlType.Deny || !ace.IsAceInheritedFrom(BaseGuids[objectType])) {
-                    continue;
-                }
-
-                var ir = ace.IdentityReference();
-                var principalSid = Helpers.PreProcessSID(ir);
-
-                //Preprocess returns null if this is an ignored sid
-                if (principalSid == null) {
-                    continue;
-                }
-
-                var (success, resolvedPrincipal) = await _utils.ResolveIDAndType(principalSid, objectDomain);
-                if (!success) {
-                    _log.LogTrace("Failed to resolve type for principal {Sid} on ACE for {Object}", principalSid, objectName);
-                    resolvedPrincipal.ObjectIdentifier = principalSid;
-                    resolvedPrincipal.ObjectType = Label.Base;
-                }
-
-                var aceRights = ace.ActiveDirectoryRights();
-                //Lowercase this just in case. As far as I know it should always come back that way anyways, but better safe than sorry
-                var aceType = ace.ObjectType().ToString().ToLower();
-                var inherited = ace.IsInherited();
-
-                var aceInheritanceHash = "";
-                if (inherited) {
-                    aceInheritanceHash = CalculateInheritanceHash(ir, aceRights, aceType, ace.InheritedObjectType());
-                }
-
-                _log.LogTrace("Processing ACE with rights {Rights} and guid {GUID} on object {Name}", aceRights,
-                    aceType, objectName);
-
-                //GenericAll applies to every object
-                if (aceRights.HasFlag(ActiveDirectoryRights.GenericAll)) {
-                    if (aceType is ACEGuids.AllGuid or "")
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.GenericAll,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    //This is a special case. If we don't continue here, every other ACE will match because GenericAll includes all other permissions
-                    continue;
-                }
-
-                //WriteDACL and WriteOwner are always useful no matter what the object type is as well because they enable all other attacks
-                if (aceRights.HasFlag(ActiveDirectoryRights.WriteDacl))
-                    yield return new ACE {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.WriteDacl,
-                        InheritanceHash = aceInheritanceHash
-                    };
-
-                if (aceRights.HasFlag(ActiveDirectoryRights.WriteOwner))
-                    yield return new ACE {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.WriteOwner,
-                        InheritanceHash = aceInheritanceHash
-                    };
-
-                //Cool ACE courtesy of @rookuu. Allows a principal to add itself to a group and no one else
-                if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
-                    !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
-                    !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                    aceType == ACEGuids.WriteMember)
-                    yield return new ACE {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.AddSelf,
-                        InheritanceHash = aceInheritanceHash
-                    };
-
-                //Process object type specific ACEs. Extended rights apply to users, domains, computers, and cert templates
-                if (aceRights.HasFlag(ActiveDirectoryRights.ExtendedRight)) {
-                    if (objectType == Label.Domain) {
-                        if (aceType == ACEGuids.DSReplicationGetChanges)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChanges,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType == ACEGuids.DSReplicationGetChangesAll)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChangesAll,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType == ACEGuids.DSReplicationGetChangesInFilteredSet)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChangesInFilteredSet,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType is ACEGuids.AllGuid or "")
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                    } else if (objectType == Label.User) {
-                        if (aceType == ACEGuids.UserForceChangePassword)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.ForceChangePassword,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType is ACEGuids.AllGuid or "")
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                    } else if (objectType == Label.Computer) {
-                        //ReadLAPSPassword is only applicable if the computer actually has LAPS. Check the world readable property ms-mcs-admpwdexpirationtime
-                        if (hasLaps) {
-                            if (aceType is ACEGuids.AllGuid or "")
-                                yield return new ACE {
-                                    PrincipalType = resolvedPrincipal.ObjectType,
-                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                    IsInherited = inherited,
-                                    RightName = EdgeNames.AllExtendedRights,
-                                    InheritanceHash = aceInheritanceHash
-                                };
-                            else if (_guidMap.TryGetValue(aceType, out var lapsAttribute))
-                            {
-                                // Compare the retrieved attribute name against LDAPProperties values
-                                if (lapsAttribute == LDAPProperties.LegacyLAPSPassword ||
-                                    lapsAttribute == LDAPProperties.LAPSPlaintextPassword ||
-                                    lapsAttribute == LDAPProperties.LAPSEncryptedPassword)
-                                {
-                                    yield return new ACE
-                                    {
-                                        PrincipalType = resolvedPrincipal.ObjectType,
-                                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                        IsInherited = inherited,
-                                        RightName = EdgeNames.ReadLAPSPassword,
-                                        InheritanceHash = aceInheritanceHash
-                                    };
-                                }
-                            }
-                        }
-                    } else if (objectType == Label.CertTemplate) {
-                        if (aceType is ACEGuids.AllGuid or "")
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType is ACEGuids.Enroll)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.Enroll,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                    }
-                }
-
-                //GenericWrite encapsulates WriteProperty, so process them in tandem to avoid duplicate edges
-                if (aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) ||
-                    aceRights.HasFlag(ActiveDirectoryRights.WriteProperty)) {
-                    if (objectType is Label.User 
-                        or Label.Group 
-                        or Label.Computer 
-                        or Label.GPO 
-                        or Label.OU 
-                        or Label.Domain
-                        or Label.CertTemplate 
-                        or Label.RootCA 
-                        or Label.EnterpriseCA 
-                        or Label.AIACA 
-                        or Label.NTAuthStore 
-                        or Label.IssuancePolicy)
-                        if (aceType is ACEGuids.AllGuid or "")
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GenericWrite,
-                                InheritanceHash = aceInheritanceHash
-                            };
-
-                    if (objectType == Label.User && aceType == ACEGuids.WriteSPN)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteSPN,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddAllowedToAct,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType == Label.Computer && aceType == ACEGuids.UserAccountRestrictions)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteAccountRestrictions,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType is Label.OU or Label.Domain && aceType == ACEGuids.WriteGPLink)
-                        yield return new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteGPLink,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddMember,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType is Label.User or Label.Computer && aceType == ACEGuids.AddKeyPrincipal)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddKeyCredentialLink,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    else if (objectType is Label.CertTemplate) {
-                        if (aceType == ACEGuids.PKIEnrollmentFlag)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.WritePKIEnrollmentFlag,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                        else if (aceType == ACEGuids.PKINameFlag)
-                            yield return new ACE {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.WritePKINameFlag,
-                                InheritanceHash = aceInheritanceHash
-                            };
-                    }
-                }
-
-                // EnterpriseCA rights
-                if (objectType == Label.EnterpriseCA) {
-                    if (aceType is ACEGuids.Enroll)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.Enroll,
-                            InheritanceHash = aceInheritanceHash
-                        };
-
-                    var cARights = (CertificationAuthorityRights)aceRights;
-
-                    // TODO: These if statements are also present in ProcessRegistryEnrollmentPermissions. Move to shared location.               
-                    if ((cARights & CertificationAuthorityRights.ManageCA) != 0)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.ManageCA,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                    if ((cARights & CertificationAuthorityRights.ManageCertificates) != 0)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.ManageCertificates,
-                            InheritanceHash = aceInheritanceHash
-                        };
-
-                    if ((cARights & CertificationAuthorityRights.Enroll) != 0)
-                        yield return new ACE {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.Enroll,
-                            InheritanceHash = aceInheritanceHash
-                        };
-                }
+           Label objectType, bool hasLaps, string objectName = "")
+        {
+            var (aces, _, _) = await ProcessACL(ntSecurityDescriptor, objectDomain, objectType, hasLaps, objectName, true);
+            foreach (var ace in aces)
+            {
+                yield return ace;
             }
         }
 

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -235,7 +235,7 @@ namespace SharpHoundCommonLib.Processors {
             {
                 return (Array.Empty<ACE>(), false, false);
             }
-            return await ProcessACL(descriptor, result.Domain, result.ObjectType, searchResult.HasLAPS(), result.DisplayName, checkForOwnerRights);
+            return await ProcessACL(descriptor, result.Domain, result.ObjectType, searchResult.HasLAPS(), checkForOwnerRights, result.DisplayName);
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace SharpHoundCommonLib.Processors {
         public async IAsyncEnumerable<ACE> ProcessACL(byte[] ntSecurityDescriptor, string objectDomain,
            Label objectType, bool hasLaps, string objectName = "")
         {
-            var (aces, _, _) = await ProcessACL(ntSecurityDescriptor, objectDomain, objectType, hasLaps, objectName, true);
+            var (aces, _, _) = await ProcessACL(ntSecurityDescriptor, objectDomain, objectType, hasLaps, true, objectName);
             foreach (var ace in aces)
             {
                 yield return ace;
@@ -259,7 +259,7 @@ namespace SharpHoundCommonLib.Processors {
         }
 
         public async Task<(ACE[], bool, bool)> ProcessACL(byte[] ntSecurityDescriptor, string objectDomain,
-            Label objectType, bool hasLaps, string objectName = "", bool checkForOwnerRights = true)
+            Label objectType, bool hasLaps, bool checkForOwnerRights, string objectName)
         {
             var aces = new List<ACE>();
             bool isAnyPermissionForOwnerRightsSid = false;

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -271,217 +271,249 @@ namespace SharpHoundCommonLib.Processors {
             {
                 _log.LogDebug("Security Descriptor is null for {Name}", objectName);
             }
-
-            var descriptor = _utils.MakeSecurityDescriptor();
-            try
+            else
             {
-                descriptor.SetSecurityDescriptorBinaryForm(ntSecurityDescriptor);
-            }
-            catch (OverflowException)
-            {
-                _log.LogWarning(
-                    "Security descriptor on object {Name} exceeds maximum allowable length. Unable to process",
-                    objectName);
-            }
 
-            _log.LogDebug("Processing ACL for {ObjectName}", objectName);
-            var ownerSid = Helpers.PreProcessSID(descriptor.GetOwner(typeof(SecurityIdentifier)));
-
-            if (ownerSid != null)
-            {
-                if (await _utils.ResolveIDAndType(ownerSid, objectDomain) is (true, var resolvedOwner))
+                var descriptor = _utils.MakeSecurityDescriptor();
+                try
                 {
-                    aces.Add(new ACE
+                    descriptor.SetSecurityDescriptorBinaryForm(ntSecurityDescriptor);
+                }
+                catch (OverflowException)
+                {
+                    _log.LogWarning(
+                        "Security descriptor on object {Name} exceeds maximum allowable length. Unable to process",
+                        objectName);
+                }
+
+                _log.LogDebug("Processing ACL for {ObjectName}", objectName);
+                var ownerSid = Helpers.PreProcessSID(descriptor.GetOwner(typeof(SecurityIdentifier)));
+
+                if (ownerSid != null)
+                {
+                    if (await _utils.ResolveIDAndType(ownerSid, objectDomain) is (true, var resolvedOwner))
                     {
-                        PrincipalType = resolvedOwner.ObjectType,
-                        PrincipalSID = resolvedOwner.ObjectIdentifier,
-                        RightName = EdgeNames.Owns,
-                        IsInherited = false,
-                        InheritanceHash = ""
-                    });
-                }
-                else
-                {
-                    _log.LogTrace("Failed to resolve owner for {Name}", objectName);
-                    aces.Add(new ACE
+                        aces.Add(new ACE
+                        {
+                            PrincipalType = resolvedOwner.ObjectType,
+                            PrincipalSID = resolvedOwner.ObjectIdentifier,
+                            RightName = EdgeNames.Owns,
+                            IsInherited = false,
+                            InheritanceHash = ""
+                        });
+                    }
+                    else
                     {
-                        PrincipalType = Label.Base,
-                        PrincipalSID = ownerSid,
-                        RightName = EdgeNames.Owns,
-                        IsInherited = false,
-                        InheritanceHash = ""
-                    });
-                }
-            }
-
-            foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier)))
-            {
-                if (ace == null || ace.AccessControlType() == AccessControlType.Deny || !ace.IsAceInheritedFrom(BaseGuids[objectType]))
-                {
-                    continue;
-                }
-
-                var ir = ace.IdentityReference();
-                var principalSid = Helpers.PreProcessSID(ir);
-
-                //Preprocess returns null if this is an ignored sid
-                if (principalSid == null)
-                {
-                    continue;
-                }
-
-                var (success, resolvedPrincipal) = await _utils.ResolveIDAndType(principalSid, objectDomain);
-                if (!success)
-                {
-                    _log.LogTrace("Failed to resolve type for principal {Sid} on ACE for {Object}", principalSid, objectName);
-                    resolvedPrincipal.ObjectIdentifier = principalSid;
-                    resolvedPrincipal.ObjectType = Label.Base;
-                }
-
-                //Check if any rights are explicitly defined for the OWNER RIGHTS SID
-                if (checkForOwnerRights && resolvedPrincipal.ObjectIdentifier.EndsWith("S-1-3-4"))
-                {
-                    isAnyPermissionForOwnerRightsSid = true;
-                }
-
-                var aceRights = ace.ActiveDirectoryRights();
-                //Lowercase this just in case. As far as I know it should always come back that way anyways, but better safe than sorry
-                var aceType = ace.ObjectType().ToString().ToLower();
-                var inherited = ace.IsInherited();
-
-                var aceInheritanceHash = "";
-                if (inherited)
-                {
-                    aceInheritanceHash = CalculateInheritanceHash(ir, aceRights, aceType, ace.InheritedObjectType());
-
-                    //Check if any rights that are explicitly defined for the OWNER RIGHTS SID are inherited
-                    if (checkForOwnerRights && resolvedPrincipal.ObjectIdentifier.EndsWith("S-1-3-4"))
-                    {
-                        isAnyPermissionForOwnerRightsSidInherited = true;
+                        _log.LogTrace("Failed to resolve owner for {Name}", objectName);
+                        aces.Add(new ACE
+                        {
+                            PrincipalType = Label.Base,
+                            PrincipalSID = ownerSid,
+                            RightName = EdgeNames.Owns,
+                            IsInherited = false,
+                            InheritanceHash = ""
+                        });
                     }
                 }
 
-                _log.LogTrace("Processing ACE with rights {Rights} and guid {GUID} on object {Name}", aceRights,
-                    aceType, objectName);
-
-                //GenericAll applies to every object
-                if (aceRights.HasFlag(ActiveDirectoryRights.GenericAll))
+                foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier)))
                 {
-                    if (aceType is ACEGuids.AllGuid or "")
+                    if (ace == null || ace.AccessControlType() == AccessControlType.Deny || !ace.IsAceInheritedFrom(BaseGuids[objectType]))
+                    {
+                        continue;
+                    }
+
+                    var ir = ace.IdentityReference();
+                    var principalSid = Helpers.PreProcessSID(ir);
+
+                    //Preprocess returns null if this is an ignored sid
+                    if (principalSid == null)
+                    {
+                        continue;
+                    }
+
+                    var (success, resolvedPrincipal) = await _utils.ResolveIDAndType(principalSid, objectDomain);
+                    if (!success)
+                    {
+                        _log.LogTrace("Failed to resolve type for principal {Sid} on ACE for {Object}", principalSid, objectName);
+                        resolvedPrincipal.ObjectIdentifier = principalSid;
+                        resolvedPrincipal.ObjectType = Label.Base;
+                    }
+
+                    //Check if any rights are explicitly defined for the OWNER RIGHTS SID
+                    if (checkForOwnerRights && resolvedPrincipal.ObjectIdentifier.EndsWith("S-1-3-4"))
+                    {
+                        isAnyPermissionForOwnerRightsSid = true;
+                    }
+
+                    var aceRights = ace.ActiveDirectoryRights();
+                    //Lowercase this just in case. As far as I know it should always come back that way anyways, but better safe than sorry
+                    var aceType = ace.ObjectType().ToString().ToLower();
+                    var inherited = ace.IsInherited();
+
+                    var aceInheritanceHash = "";
+                    if (inherited)
+                    {
+                        aceInheritanceHash = CalculateInheritanceHash(ir, aceRights, aceType, ace.InheritedObjectType());
+
+                        //Check if any rights that are explicitly defined for the OWNER RIGHTS SID are inherited
+                        if (checkForOwnerRights && resolvedPrincipal.ObjectIdentifier.EndsWith("S-1-3-4"))
+                        {
+                            isAnyPermissionForOwnerRightsSidInherited = true;
+                        }
+                    }
+
+                    _log.LogTrace("Processing ACE with rights {Rights} and guid {GUID} on object {Name}", aceRights,
+                        aceType, objectName);
+
+                    //GenericAll applies to every object
+                    if (aceRights.HasFlag(ActiveDirectoryRights.GenericAll))
+                    {
+                        if (aceType is ACEGuids.AllGuid or "")
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.GenericAll,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        //This is a special case. If we don't continue here, every other ACE will match because GenericAll includes all other permissions
+                        continue;
+                    }
+
+                    //WriteDACL and WriteOwner are always useful no matter what the object type is as well because they enable all other attacks
+                    if (aceRights.HasFlag(ActiveDirectoryRights.WriteDacl))
                         aces.Add(new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,
                             IsInherited = inherited,
-                            RightName = EdgeNames.GenericAll,
+                            RightName = EdgeNames.WriteDacl,
                             InheritanceHash = aceInheritanceHash
                         });
-                    //This is a special case. If we don't continue here, every other ACE will match because GenericAll includes all other permissions
-                    continue;
-                }
 
-                //WriteDACL and WriteOwner are always useful no matter what the object type is as well because they enable all other attacks
-                if (aceRights.HasFlag(ActiveDirectoryRights.WriteDacl))
-                    aces.Add(new ACE
-                    {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.WriteDacl,
-                        InheritanceHash = aceInheritanceHash
-                    });
+                    if (aceRights.HasFlag(ActiveDirectoryRights.WriteOwner))
+                        aces.Add(new ACE
+                        {
+                            PrincipalType = resolvedPrincipal.ObjectType,
+                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                            IsInherited = inherited,
+                            RightName = EdgeNames.WriteOwner,
+                            InheritanceHash = aceInheritanceHash
+                        });
 
-                if (aceRights.HasFlag(ActiveDirectoryRights.WriteOwner))
-                    aces.Add(new ACE
-                    {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.WriteOwner,
-                        InheritanceHash = aceInheritanceHash
-                    });
+                    //Cool ACE courtesy of @rookuu. Allows a principal to add itself to a group and no one else
+                    if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
+                        !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
+                        !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
+                        aceType == ACEGuids.WriteMember)
+                        aces.Add(new ACE
+                        {
+                            PrincipalType = resolvedPrincipal.ObjectType,
+                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                            IsInherited = inherited,
+                            RightName = EdgeNames.AddSelf,
+                            InheritanceHash = aceInheritanceHash
+                        });
 
-                //Cool ACE courtesy of @rookuu. Allows a principal to add itself to a group and no one else
-                if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
-                    !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
-                    !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                    aceType == ACEGuids.WriteMember)
-                    aces.Add(new ACE
+                    //Process object type specific ACEs. Extended rights apply to users, domains, computers, and cert templates
+                    if (aceRights.HasFlag(ActiveDirectoryRights.ExtendedRight))
                     {
-                        PrincipalType = resolvedPrincipal.ObjectType,
-                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                        IsInherited = inherited,
-                        RightName = EdgeNames.AddSelf,
-                        InheritanceHash = aceInheritanceHash
-                    });
-
-                //Process object type specific ACEs. Extended rights apply to users, domains, computers, and cert templates
-                if (aceRights.HasFlag(ActiveDirectoryRights.ExtendedRight))
-                {
-                    if (objectType == Label.Domain)
-                    {
-                        if (aceType == ACEGuids.DSReplicationGetChanges)
-                            aces.Add(new ACE
+                        if (objectType == Label.Domain)
+                        {
+                            if (aceType == ACEGuids.DSReplicationGetChanges)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.GetChanges,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                            else if (aceType == ACEGuids.DSReplicationGetChangesAll)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.GetChangesAll,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                            else if (aceType == ACEGuids.DSReplicationGetChangesInFilteredSet)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.GetChangesInFilteredSet,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                            else if (aceType is ACEGuids.AllGuid or "")
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.AllExtendedRights,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                        }
+                        else if (objectType == Label.User)
+                        {
+                            if (aceType == ACEGuids.UserForceChangePassword)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.ForceChangePassword,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                            else if (aceType is ACEGuids.AllGuid or "")
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.AllExtendedRights,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                        }
+                        else if (objectType == Label.Computer)
+                        {
+                            //ReadLAPSPassword is only applicable if the computer actually has LAPS. Check the world readable property ms-mcs-admpwdexpirationtime
+                            if (hasLaps)
                             {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChanges,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                        else if (aceType == ACEGuids.DSReplicationGetChangesAll)
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChangesAll,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                        else if (aceType == ACEGuids.DSReplicationGetChangesInFilteredSet)
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GetChangesInFilteredSet,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                        else if (aceType is ACEGuids.AllGuid or "")
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                    }
-                    else if (objectType == Label.User)
-                    {
-                        if (aceType == ACEGuids.UserForceChangePassword)
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.ForceChangePassword,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                        else if (aceType is ACEGuids.AllGuid or "")
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                    }
-                    else if (objectType == Label.Computer)
-                    {
-                        //ReadLAPSPassword is only applicable if the computer actually has LAPS. Check the world readable property ms-mcs-admpwdexpirationtime
-                        if (hasLaps)
+                                if (aceType is ACEGuids.AllGuid or "")
+                                    aces.Add(new ACE
+                                    {
+                                        PrincipalType = resolvedPrincipal.ObjectType,
+                                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                        IsInherited = inherited,
+                                        RightName = EdgeNames.AllExtendedRights,
+                                        InheritanceHash = aceInheritanceHash
+                                    });
+                                else if (_guidMap.TryGetValue(aceType, out var lapsAttribute))
+                                {
+                                    // Compare the retrieved attribute name against LDAPProperties values
+                                    if (lapsAttribute == LDAPProperties.LegacyLAPSPassword ||
+                                        lapsAttribute == LDAPProperties.LAPSPlaintextPassword ||
+                                        lapsAttribute == LDAPProperties.LAPSEncryptedPassword)
+                                    {
+                                        aces.Add(new ACE
+                                        {
+                                            PrincipalType = resolvedPrincipal.ObjectType,
+                                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                            IsInherited = inherited,
+                                            RightName = EdgeNames.ReadLAPSPassword,
+                                            InheritanceHash = aceInheritanceHash
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        else if (objectType == Label.CertTemplate)
                         {
                             if (aceType is ACEGuids.AllGuid or "")
                                 aces.Add(new ACE
@@ -492,37 +524,157 @@ namespace SharpHoundCommonLib.Processors {
                                     RightName = EdgeNames.AllExtendedRights,
                                     InheritanceHash = aceInheritanceHash
                                 });
-                            else if (_guidMap.TryGetValue(aceType, out var lapsAttribute))
-                            {
-                                // Compare the retrieved attribute name against LDAPProperties values
-                                if (lapsAttribute == LDAPProperties.LegacyLAPSPassword ||
-                                    lapsAttribute == LDAPProperties.LAPSPlaintextPassword ||
-                                    lapsAttribute == LDAPProperties.LAPSEncryptedPassword)
+                            else if (aceType is ACEGuids.Enroll)
+                                aces.Add(new ACE
                                 {
-                                    aces.Add(new ACE
-                                    {
-                                        PrincipalType = resolvedPrincipal.ObjectType,
-                                        PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                        IsInherited = inherited,
-                                        RightName = EdgeNames.ReadLAPSPassword,
-                                        InheritanceHash = aceInheritanceHash
-                                    });
-                                }
-                            }
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.Enroll,
+                                    InheritanceHash = aceInheritanceHash
+                                });
                         }
                     }
-                    else if (objectType == Label.CertTemplate)
+
+                    //GenericWrite encapsulates WriteProperty, so process them in tandem to avoid duplicate edges
+                    if (aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) ||
+                        aceRights.HasFlag(ActiveDirectoryRights.WriteProperty))
                     {
-                        if (aceType is ACEGuids.AllGuid or "")
+                        if (objectType is Label.User
+                            or Label.Group
+                            or Label.Computer
+                            or Label.GPO
+                            or Label.OU
+                            or Label.Domain
+                            or Label.CertTemplate
+                            or Label.RootCA
+                            or Label.EnterpriseCA
+                            or Label.AIACA
+                            or Label.NTAuthStore
+                            or Label.IssuancePolicy)
+                            if (aceType is ACEGuids.AllGuid or "")
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.GenericWrite,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+
+                        if (objectType == Label.User && aceType == ACEGuids.WriteSPN)
                             aces.Add(new ACE
                             {
                                 PrincipalType = resolvedPrincipal.ObjectType,
                                 PrincipalSID = resolvedPrincipal.ObjectIdentifier,
                                 IsInherited = inherited,
-                                RightName = EdgeNames.AllExtendedRights,
+                                RightName = EdgeNames.WriteSPN,
                                 InheritanceHash = aceInheritanceHash
                             });
-                        else if (aceType is ACEGuids.Enroll)
+                        else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.AddAllowedToAct,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        else if (objectType == Label.Computer && aceType == ACEGuids.UserAccountRestrictions)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.WriteAccountRestrictions,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        else if (objectType is Label.OU or Label.Domain && aceType == ACEGuids.WriteGPLink)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.WriteGPLink,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.AddMember,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        else if (objectType is Label.User or Label.Computer && aceType == ACEGuids.AddKeyPrincipal)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.AddKeyCredentialLink,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        else if (objectType is Label.CertTemplate)
+                        {
+                            if (aceType == ACEGuids.PKIEnrollmentFlag)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.WritePKIEnrollmentFlag,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                            else if (aceType == ACEGuids.PKINameFlag)
+                                aces.Add(new ACE
+                                {
+                                    PrincipalType = resolvedPrincipal.ObjectType,
+                                    PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                    IsInherited = inherited,
+                                    RightName = EdgeNames.WritePKINameFlag,
+                                    InheritanceHash = aceInheritanceHash
+                                });
+                        }
+                    }
+
+                    // EnterpriseCA rights
+                    if (objectType == Label.EnterpriseCA)
+                    {
+                        if (aceType is ACEGuids.Enroll)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.Enroll,
+                                InheritanceHash = aceInheritanceHash
+                            });
+
+                        var cARights = (CertificationAuthorityRights)aceRights;
+
+                        // TODO: These if statements are also present in ProcessRegistryEnrollmentPermissions. Move to shared location.               
+                        if ((cARights & CertificationAuthorityRights.ManageCA) != 0)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.ManageCA,
+                                InheritanceHash = aceInheritanceHash
+                            });
+                        if ((cARights & CertificationAuthorityRights.ManageCertificates) != 0)
+                            aces.Add(new ACE
+                            {
+                                PrincipalType = resolvedPrincipal.ObjectType,
+                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                                IsInherited = inherited,
+                                RightName = EdgeNames.ManageCertificates,
+                                InheritanceHash = aceInheritanceHash
+                            });
+
+                        if ((cARights & CertificationAuthorityRights.Enroll) != 0)
                             aces.Add(new ACE
                             {
                                 PrincipalType = resolvedPrincipal.ObjectType,
@@ -532,155 +684,6 @@ namespace SharpHoundCommonLib.Processors {
                                 InheritanceHash = aceInheritanceHash
                             });
                     }
-                }
-
-                //GenericWrite encapsulates WriteProperty, so process them in tandem to avoid duplicate edges
-                if (aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) ||
-                    aceRights.HasFlag(ActiveDirectoryRights.WriteProperty))
-                {
-                    if (objectType is Label.User
-                        or Label.Group
-                        or Label.Computer
-                        or Label.GPO
-                        or Label.OU
-                        or Label.Domain
-                        or Label.CertTemplate
-                        or Label.RootCA
-                        or Label.EnterpriseCA
-                        or Label.AIACA
-                        or Label.NTAuthStore
-                        or Label.IssuancePolicy)
-                        if (aceType is ACEGuids.AllGuid or "")
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.GenericWrite,
-                                InheritanceHash = aceInheritanceHash
-                            });
-
-                    if (objectType == Label.User && aceType == ACEGuids.WriteSPN)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteSPN,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddAllowedToAct,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType == Label.Computer && aceType == ACEGuids.UserAccountRestrictions)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteAccountRestrictions,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType is Label.OU or Label.Domain && aceType == ACEGuids.WriteGPLink)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.WriteGPLink,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddMember,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType is Label.User or Label.Computer && aceType == ACEGuids.AddKeyPrincipal)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.AddKeyCredentialLink,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    else if (objectType is Label.CertTemplate)
-                    {
-                        if (aceType == ACEGuids.PKIEnrollmentFlag)
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.WritePKIEnrollmentFlag,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                        else if (aceType == ACEGuids.PKINameFlag)
-                            aces.Add(new ACE
-                            {
-                                PrincipalType = resolvedPrincipal.ObjectType,
-                                PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                                IsInherited = inherited,
-                                RightName = EdgeNames.WritePKINameFlag,
-                                InheritanceHash = aceInheritanceHash
-                            });
-                    }
-                }
-
-                // EnterpriseCA rights
-                if (objectType == Label.EnterpriseCA)
-                {
-                    if (aceType is ACEGuids.Enroll)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.Enroll,
-                            InheritanceHash = aceInheritanceHash
-                        });
-
-                    var cARights = (CertificationAuthorityRights)aceRights;
-
-                    // TODO: These if statements are also present in ProcessRegistryEnrollmentPermissions. Move to shared location.               
-                    if ((cARights & CertificationAuthorityRights.ManageCA) != 0)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.ManageCA,
-                            InheritanceHash = aceInheritanceHash
-                        });
-                    if ((cARights & CertificationAuthorityRights.ManageCertificates) != 0)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.ManageCertificates,
-                            InheritanceHash = aceInheritanceHash
-                        });
-
-                    if ((cARights & CertificationAuthorityRights.Enroll) != 0)
-                        aces.Add(new ACE
-                        {
-                            PrincipalType = resolvedPrincipal.ObjectType,
-                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
-                            IsInherited = inherited,
-                            RightName = EdgeNames.Enroll,
-                            InheritanceHash = aceInheritanceHash
-                        });
                 }
             }
             return (aces.ToArray(), isAnyPermissionForOwnerRightsSid, isAnyPermissionForOwnerRightsSidInherited);


### PR DESCRIPTION
## Description

Updated SharpHound to collect two new properties for every domain object:

- DoesAnyAceGrantOwnerRights
- DoesAnyInheritedAceGrantOwnerRights

## Motivation and Context

https://specterops.atlassian.net/browse/BED-4965

During ingest, BloodHound will use this information to determine whether any benign, non-abusable ACEs granted permissions to the OWNER RIGHTS SID (S-1-3-4), and whether or not any such ACEs were inherited. These properties allow ingest to determine whether any Owns and WriteOwner permissions granted are abusable or not.

## How Has This Been Tested?

Please refer to https://specterops.atlassian.net/wiki/spaces/BE/pages/750157858/Owns+WriteOwner for detailed testing information.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
