### PR TITLE
[BP-1232] Connectionpool blacklist

### DIFF
--- a/src/CommonLib/ConnectionPoolManager.cs
+++ b/src/CommonLib/ConnectionPoolManager.cs
@@ -73,14 +73,14 @@ namespace SharpHoundCommonLib {
         }
 
         private bool GetPool(string identifier, out LdapConnectionPool pool) {
-            if (string.IsNullOrWhiteSpace(identifier) || identifier == ".") {
+            if (string.IsNullOrWhiteSpace(identifier)) {
                 pool = default;
                 return false;
             }
 
             var resolved = ResolveIdentifier(identifier);
             if (!_pools.TryGetValue(resolved, out pool)) {
-                pool = new LdapConnectionPool(identifier, resolved, _ldapConfig,scanner: _portScanner);
+                pool = new LdapConnectionPool(identifier, resolved, _ldapConfig, scanner: _portScanner);
                 _pools.TryAdd(resolved, pool);
             }
 
@@ -96,6 +96,7 @@ namespace SharpHoundCommonLib {
             if (globalCatalog) {
                 return await pool.GetGlobalCatalogConnectionAsync();
             }
+
             return await pool.GetConnectionAsync();
         }
     

--- a/src/CommonLib/ConnectionPoolManager.cs
+++ b/src/CommonLib/ConnectionPoolManager.cs
@@ -73,7 +73,7 @@ namespace SharpHoundCommonLib {
         }
 
         private bool GetPool(string identifier, out LdapConnectionPool pool) {
-            if (identifier == null) {
+            if (string.IsNullOrWhiteSpace(identifier) || identifier == ".") {
                 pool = default;
                 return false;
             }

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -31,6 +31,8 @@ namespace SharpHoundCommonLib {
         private const int BackoffDelayMultiplier = 2;
         private const int MaxRetries = 3;
         private static readonly ConcurrentDictionary<string, NetAPIStructs.DomainControllerInfo?> DCInfoCache = new();
+
+        // Tracks domains we know we've determined we shouldn't try to connect to
         private static readonly ConcurrentHashSet _excludedDomains = new();
 
         public LdapConnectionPool(string identifier, string poolIdentifier, LdapConfig config, PortScanner scanner = null, NativeMethods nativeMethods = null, ILogger log = null) {

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -618,6 +618,10 @@ namespace SharpHoundCommonLib {
         }
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)> GetGlobalCatalogConnectionAsync() {
+            if (_blacklistedDomains.Contains(_identifier)) {
+                return (false, null, $"Identifier {_identifier} blacklisted for connection attempt");
+            }
+            
             if (!_globalCatalogConnection.TryTake(out var connectionWrapper)) {
                 var (success, connection, message) = await CreateNewConnection(true);
                 if (!success) {

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -31,7 +31,7 @@ namespace SharpHoundCommonLib {
         private const int BackoffDelayMultiplier = 2;
         private const int MaxRetries = 3;
         private static readonly ConcurrentDictionary<string, NetAPIStructs.DomainControllerInfo?> DCInfoCache = new();
-        private static readonly ConcurrentHashSet _blacklistedDomains = new();
+        private static readonly ConcurrentHashSet _excludedDomains = new();
 
         public LdapConnectionPool(string identifier, string poolIdentifier, LdapConfig config, PortScanner scanner = null, NativeMethods nativeMethods = null, ILogger log = null) {
             _connections = new ConcurrentBag<LdapConnectionWrapper>();
@@ -596,8 +596,8 @@ namespace SharpHoundCommonLib {
         }
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)> GetConnectionAsync() {
-            if (_blacklistedDomains.Contains(_identifier)) {
-                return (false, null, $"Identifier {_identifier} blacklisted for connection attempt");
+            if (_excludedDomains.Contains(_identifier)) {
+                return (false, null, $"Identifier {_identifier} excluded for connection attempt");
             }
 
             if (!_connections.TryTake(out var connectionWrapper)) {
@@ -618,10 +618,10 @@ namespace SharpHoundCommonLib {
         }
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)> GetGlobalCatalogConnectionAsync() {
-            if (_blacklistedDomains.Contains(_identifier)) {
-                return (false, null, $"Identifier {_identifier} blacklisted for connection attempt");
+            if (_excludedDomains.Contains(_identifier)) {
+                return (false, null, $"Identifier {_identifier} excluded for connection attempt");
             }
-            
+
             if (!_globalCatalogConnection.TryTake(out var connectionWrapper)) {
                 var (success, connection, message) = await CreateNewConnection(true);
                 if (!success) {
@@ -700,7 +700,7 @@ namespace SharpHoundCommonLib {
                     _log.LogDebug(
                         "Could not get domain object from GetDomain, unable to create ldap connection for domain {Domain}",
                         _identifier);
-                    _blacklistedDomains.Add(_identifier);
+                    _excludedDomains.Add(_identifier);
                     return (false, null, "Unable to get domain object for further strategies");
                 }
                 tempDomainName = domainObject.Name.ToUpper().Trim();
@@ -735,7 +735,7 @@ namespace SharpHoundCommonLib {
                 }
             } catch (Exception e) {
                 _log.LogInformation(e, "We will not be able to connect to domain {Domain} by any strategy, leaving it.", _identifier);
-                _blacklistedDomains.Add(_identifier);
+                _excludedDomains.Add(_identifier);
             }
 
             return (false, null, "All attempted connections failed");

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -31,6 +31,7 @@ namespace SharpHoundCommonLib {
         private const int BackoffDelayMultiplier = 2;
         private const int MaxRetries = 3;
         private static readonly ConcurrentDictionary<string, NetAPIStructs.DomainControllerInfo?> DCInfoCache = new();
+        private static readonly ConcurrentHashSet _blacklistedDomains = new();
 
         public LdapConnectionPool(string identifier, string poolIdentifier, LdapConfig config, PortScanner scanner = null, NativeMethods nativeMethods = null, ILogger log = null) {
             _connections = new ConcurrentBag<LdapConnectionWrapper>();
@@ -595,6 +596,10 @@ namespace SharpHoundCommonLib {
         }
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)> GetConnectionAsync() {
+            if (_blacklistedDomains.Contains(_identifier)) {
+                return (false, null, $"Identifier {_identifier} blacklisted for connection attempt");
+            }
+
             if (!_connections.TryTake(out var connectionWrapper)) {
                 var (success, connection, message) = await CreateNewConnection();
                 if (!success) {
@@ -691,6 +696,7 @@ namespace SharpHoundCommonLib {
                     _log.LogDebug(
                         "Could not get domain object from GetDomain, unable to create ldap connection for domain {Domain}",
                         _identifier);
+                    _blacklistedDomains.Add(_identifier);
                     return (false, null, "Unable to get domain object for further strategies");
                 }
                 tempDomainName = domainObject.Name.ToUpper().Trim();
@@ -725,6 +731,7 @@ namespace SharpHoundCommonLib {
                 }
             } catch (Exception e) {
                 _log.LogInformation(e, "We will not be able to connect to domain {Domain} by any strategy, leaving it.", _identifier);
+                _blacklistedDomains.Add(_identifier);
             }
 
             return (false, null, "All attempted connections failed");


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add domain blacklist to LdapConnectionPool to try to alleviate pain from repeated query attempts to a domain we can't reach.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-1232

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
