### PR TITLE
[BP-1232] Add test coverage for LdapConnectionPool excluded domains

### DIFF
--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -972,7 +972,7 @@ namespace SharpHoundCommonLib {
                     await GetDomainSidFromDomainName(forestName) is (true, var forestDomainSid)) {
                     forestSidToName.TryAdd(forestDomainSid, forestName);
                     if (!grouped.ContainsKey(forestDomainSid)) {
-                        grouped[forestDomainSid] = [];
+                        grouped[forestDomainSid] = new();
                     }
 
                     foreach (var k in domainSid) {

--- a/test/unit/LdapConnectionPoolTest.cs
+++ b/test/unit/LdapConnectionPoolTest.cs
@@ -1,0 +1,45 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SharpHoundCommonLib;
+using Xunit;
+
+public class LdapConnectionPoolTest
+{
+    private static void AddExclusionDomain(string identifier) {
+        var excludedDomainsField = typeof(LdapConnectionPool)
+            .GetField("_excludedDomains", BindingFlags.Static | BindingFlags.NonPublic);
+
+        var excludedDomains = (ConcurrentHashSet)excludedDomainsField.GetValue(null);
+
+        excludedDomains.Add(identifier);
+    }
+
+    [Fact]
+    public async Task LdapConnectionPool_ExcludedDomains_ShouldExitEarly()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var ldapConfig = new LdapConfig();
+        var connectionPool = new ConnectionPoolManager(ldapConfig, mockLogger.Object);
+
+        AddExclusionDomain("excludedDomain.com");
+        var connectAttempt = await connectionPool.TestDomainConnection("excludedDomain.com", false);
+
+        Assert.False(connectAttempt.Success);
+        Assert.Contains("excluded for connection attempt", connectAttempt.Message);
+    }
+
+    [Fact]
+    public async Task LdapConnectionPool_ExcludedDomains_NonExcludedShouldntExit()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var ldapConfig = new LdapConfig();
+        var connectionPool = new ConnectionPoolManager(ldapConfig, mockLogger.Object);
+
+        AddExclusionDomain("excludedDomain.com");
+        var connectAttempt = await connectionPool.TestDomainConnection("perfectlyValidDomain.com", false);
+
+        Assert.DoesNotContain("excluded for connection attempt", connectAttempt.Message);
+    }
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
And correct use of dotnet preview feature use on LdapUtils

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BP-1232

Adding test coverage for excluded domains, and correcting the use of a preview feature in LdapUtils that can cause build trouble.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
