### PR TITLE
Fixed time for createdWhen and updated tests

### DIFF
--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -207,7 +207,7 @@ namespace SharpHoundCommonLib {
         /// <returns></returns>
         public static long ConvertTimestampToUnixEpoch(string ldapTime) {
             try {
-                var dt = DateTime.ParseExact(ldapTime, "yyyyMMddHHmmss.0K", CultureInfo.CurrentCulture);
+                var dt = DateTime.ParseExact(ldapTime, "yyyyMMddHHmmss.0K", CultureInfo.CurrentCulture).ToUniversalTime();
                 return (long)dt.Subtract(EpochDiff).TotalSeconds;
             } catch {
                 return 0;

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -197,7 +197,7 @@ namespace CommonLibTest {
         }
 
         [Fact]
-        public void ConvertTimestampToUnixEpoch_ValidTimestamp_ValidUnixEpoch() {
+        public void ConvertFileTimeToUnixEpoch_ValidTimestamp_ValidUnixEpoch() {
             var d = DateTime.Parse("2021-06-21T00:00:00");
             var result =
                 Helpers.ConvertFileTimeToUnixEpoch(d.ToFileTimeUtc().ToString()); // get the epoch
@@ -208,7 +208,7 @@ namespace CommonLibTest {
         }
 
         [Fact]
-        public void ConvertTimestampToUnixEpoch_InvalidTimestamp_FormatException() {
+        public void ConvertFileTimeToUnixEpoch_InvalidTimestamp_FormatException() {
             Exception ex = Assert.Throws<FormatException>(() =>
                 Helpers.ConvertFileTimeToUnixEpoch("-201adsfasf12180244"));
             Assert.Equal("The input string '-201adsfasf12180244' was not in a correct format.", ex.Message);
@@ -229,6 +229,24 @@ namespace CommonLibTest {
             var result = Helpers.DistinguishedNameToDomain(
                 @"DC=..Deleted-_msdcs.testlab.local\0ADEL:af1f072f-28d7-4b86-9b87-a408bfc9cb0d,CN=Deleted Objects,DC=testlab,DC=local");
             Assert.Equal("TESTLAB.LOCAL", result);
+        }
+        
+        [Fact]
+        public void ConvertTimestampToUnixEpoch_ValidTimestamp() {
+            var d = DateTime.Parse("2025-04-07T00:00:00.0000000-07:00");
+            var result =
+                Helpers.ConvertTimestampToUnixEpoch(d.ToString("yyyyMMddHHmmss.0K")); 
+            var dateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(result); 
+
+            Assert.Equal(d.ToUniversalTime(), dateTimeOffset.DateTime);
+        }
+        
+        [Fact]
+        public void ConvertTimestampToUnixEpoch_InvalidTimestamp() {
+            var result =
+                Helpers.ConvertTimestampToUnixEpoch("-201adsfasf12180244"); 
+
+            Assert.Equal(result, 0);
         }
     }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fixed createdWhen timestamp discrepancy

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-5655

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Create AD User
2. Run On Demand Scan
3. Open PowerShell as admin and run command `Get-ADUser -Filter { name -like "<new user>" } -Properties whenCreated, whenChanged, PasswordLastSet`
4. View new user in BHE Explorer and see if 'Created' matches 'whenCreated' property 

## Screenshots (if appropriate):
<img width="646" alt="image" src="https://github.com/user-attachments/assets/105f2957-2035-49b3-b478-1e40bb75e833" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
