### PR TITLE
TrustedBy replacement related changes

### DIFF
--- a/src/CommonLib/Enums/LDAPProperties.cs
+++ b/src/CommonLib/Enums/LDAPProperties.cs
@@ -94,5 +94,6 @@
         public const string LockoutDuration = "lockoutduration";
         public const string LockoutThreshold = "lockoutthreshold";
         public const string LockOutObservationWindow = "lockoutobservationwindow";
+        public const string GroupType = "grouptype";
     }
 }

--- a/src/CommonLib/Enums/TrustType.cs
+++ b/src/CommonLib/Enums/TrustType.cs
@@ -2,10 +2,12 @@
 {
     public enum TrustType
     {
+        TreeRoot,
         ParentChild,
         CrossLink,
-        Forest,
         External,
+        Forest,
+        Kerberos,
         Unknown
     }
 }

--- a/src/CommonLib/LdapQueries/CommonProperties.cs
+++ b/src/CommonLib/LdapQueries/CommonProperties.cs
@@ -60,7 +60,7 @@
             LDAPProperties.SupportedEncryptionTypes, LDAPProperties.DSHeuristics,
             LDAPProperties.MinPwdLength, LDAPProperties.PwdProperties, LDAPProperties.MinPwdAge, 
             LDAPProperties.MaxPwdAge, LDAPProperties.PwdHistoryLength, LDAPProperties.LockoutDuration, 
-            LDAPProperties.LockoutThreshold, LDAPProperties.LockOutObservationWindow
+            LDAPProperties.LockoutThreshold, LDAPProperties.LockOutObservationWindow, LDAPProperties.GroupType
         };
 
         public static readonly string[] ContainerProps =

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
+using System.Linq;
 using System.Security.Principal;
 using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
@@ -27,6 +28,25 @@ namespace SharpHoundCommonLib.Processors
         public async IAsyncEnumerable<DomainTrust> EnumerateDomainTrusts(string domain)
         {
             _log.LogDebug("Running trust enumeration for {Domain}", domain);
+
+            // Attempt to get trust type
+            var trustInfoList = new List<(string TargetName, System.DirectoryServices.ActiveDirectory.TrustType TrustType)>();
+            try
+            {
+                using (System.DirectoryServices.ActiveDirectory.Domain ADDomainObj = 
+                    System.DirectoryServices.ActiveDirectory.Domain.GetDomain(
+                        new System.DirectoryServices.ActiveDirectory.DirectoryContext(
+                            System.DirectoryServices.ActiveDirectory.DirectoryContextType.Domain, domain)))
+                {
+                    trustInfoList.AddRange(from System.DirectoryServices.ActiveDirectory.TrustRelationshipInformation trust in ADDomainObj.GetAllTrustRelationships()
+                                           select (trust.TargetName, trust.TrustType));
+                }
+            }
+            catch 
+            {
+                _log.LogWarning("Trust type enumeration using non-LDAP for {Domain} faild", domain);
+            }
+
             await foreach (var result in _utils.Query(new LdapQueryParameters {
                                    LDAPFilter = CommonFilters.TrustedDomains,
                                    Attributes = CommonProperties.DomainTrustProps,
@@ -90,7 +110,9 @@ namespace SharpHoundCommonLib.Processors
                     (attributes.HasFlag(TrustAttributes.WithinForest) ||
                     attributes.HasFlag(TrustAttributes.CrossOrganizationEnableTGTDelegation));
 
-                trust.TrustType = TrustAttributesToType(attributes);
+                var match = trustInfoList.FirstOrDefault(t => 
+                    t.TargetName.ToUpper().Equals(trust.TargetDomainName));
+                trust.TrustType = !string.IsNullOrEmpty(match.TargetName) ? (TrustType) match.TrustType : TrustAttributesToType(attributes);
 
                 yield return trust;
             }

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -39,7 +39,7 @@ namespace SharpHoundCommonLib.Processors
             }
             catch 
             {
-                _log.LogWarning("Trust type enumeration using non-LDAP for {Domain} faild", domain);
+                _log.LogWarning("Trust type enumeration using non-LDAP for {Domain} failed", domain);
             }
 
             await foreach (var result in _utils.Query(new LdapQueryParameters {

--- a/src/CommonLib/Processors/DomainTrustProcessor.cs
+++ b/src/CommonLib/Processors/DomainTrustProcessor.cs
@@ -33,14 +33,9 @@ namespace SharpHoundCommonLib.Processors
             var trustInfoList = new List<(string TargetName, System.DirectoryServices.ActiveDirectory.TrustType TrustType)>();
             try
             {
-                using (System.DirectoryServices.ActiveDirectory.Domain ADDomainObj = 
-                    System.DirectoryServices.ActiveDirectory.Domain.GetDomain(
-                        new System.DirectoryServices.ActiveDirectory.DirectoryContext(
-                            System.DirectoryServices.ActiveDirectory.DirectoryContextType.Domain, domain)))
-                {
-                    trustInfoList.AddRange(from System.DirectoryServices.ActiveDirectory.TrustRelationshipInformation trust in ADDomainObj.GetAllTrustRelationships()
-                                           select (trust.TargetName, trust.TrustType));
-                }
+                _utils.GetDomain(domain, out var domainObject);
+                trustInfoList.AddRange(from System.DirectoryServices.ActiveDirectory.TrustRelationshipInformation trust in domainObject.GetAllTrustRelationships()
+                select (trust.TargetName, trust.TrustType));
             }
             catch 
             {

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -179,6 +179,9 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
             entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
             props.Add("admincount", ac != 0);
+            entry.TryGetLongProperty(LDAPProperties.GroupType, out var groupType);
+            props.Add("groupscope", GetGroupScope(groupType));
+
             return props;
         }
 
@@ -850,6 +853,31 @@ namespace SharpHoundCommonLib.Processors {
 
                 return "";
             } catch (Exception) {
+                return "Unknown";
+            }
+        }
+
+        private static string GetGroupScope(long groupType)
+        {
+            // Constants from ADS_GROUP_TYPE_ENUM in Active Directory
+            const int ADS_GROUP_TYPE_GLOBAL_GROUP = 0x00000002;
+            const int ADS_GROUP_TYPE_DOMAIN_LOCAL_GROUP = 0x00000004;
+            const int ADS_GROUP_TYPE_UNIVERSAL_GROUP = 0x00000008;
+
+            if ((groupType & ADS_GROUP_TYPE_UNIVERSAL_GROUP) == ADS_GROUP_TYPE_UNIVERSAL_GROUP)
+            {
+                return "Universal";
+            }
+            else if ((groupType & ADS_GROUP_TYPE_DOMAIN_LOCAL_GROUP) == ADS_GROUP_TYPE_DOMAIN_LOCAL_GROUP)
+            {
+                return "DomainLocal";
+            }
+            else if ((groupType & ADS_GROUP_TYPE_GLOBAL_GROUP) == ADS_GROUP_TYPE_GLOBAL_GROUP)
+            {
+                return "Global";
+            }
+            else
+            {
                 return "Unknown";
             }
         }


### PR DESCRIPTION
## Description

- Added GroupScope property for groups
- Added new way of collecting trust type with fallback to the existing logic

## Motivation and Context

The group scope is useful to have for cross forest attacks.
The new way of collecting trust types should ensure SharpHound is correct in cases where it is currently not.
Tickets: BED-4531, BP-1253

## How Has This Been Tested?

Tested locally in lab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
