### PR TITLE
BED-5152: Fix to filter out domains that are "."

### DIFF
--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -121,6 +121,11 @@ namespace SharpHoundCommonLib.Processors {
                     username.Equals("anonymous logon", StringComparison.CurrentCultureIgnoreCase)) {
                     continue;
                 }
+                
+                //Filter out domains that are "."
+                if (computerDomain.Equals(".")) {
+                    continue;
+                }
 
                 // Remove leading slashes for unc paths
                 computerSessionName = computerSessionName.TrimStart('\\');
@@ -237,6 +242,11 @@ namespace SharpHoundCommonLib.Processors {
 
                 //Filter out empty usernames and computer sessions
                 if (string.IsNullOrWhiteSpace(username) || username.EndsWith("$", StringComparison.Ordinal)) {
+                    continue;
+                }
+                
+                //Filter out domains that are "."
+                if (domain.Equals(".")) {
                     continue;
                 }
 

--- a/test/unit/ComputerSessionProcessorTest.cs
+++ b/test/unit/ComputerSessionProcessorTest.cs
@@ -49,6 +49,21 @@ namespace CommonLibTest {
             Assert.True(result.Collected);
             Assert.Empty(result.Results);
         }
+        
+        [Fact]
+        public async Task ComputerSessionProcessor_ReadUserSessions_FilteringDomainWorks() {
+            var mockNativeMethods = new Mock<NativeMethods>();
+
+            var apiResult = new NetSessionEnumResults[] {
+                new("temp", "\\\\192.168.92.110")
+            };
+            mockNativeMethods.Setup(x => x.NetSessionEnum(It.IsAny<string>())).Returns(apiResult);
+
+            var processor = new ComputerSessionProcessor(new MockLdapUtils(), mockNativeMethods.Object,null, "dfm");
+            var result = await processor.ReadUserSessions("win10", _computerSid, ".");
+            Assert.True(result.Collected);
+            Assert.Empty(result.Results);
+        }
 
         [Fact]
         public async Task ComputerSessionProcessor_ReadUserSessions_ResolvesHost() {
@@ -178,7 +193,8 @@ namespace CommonLibTest {
                 new("WIN10$", "TESTLAB"),
                 new("JOHN", "WIN10"),
                 new("SYSTEM", "NT AUTHORITY"),
-                new("ABC", "TESTLAB")
+                new("ABC", "TESTLAB"),
+                new("XYZ", ".")
             };
             mockNativeMethods.Setup(x => x.NetWkstaUserEnum(It.IsAny<string>())).Returns(apiResults);
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Ingest timeouts hung up on domains that are "."

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-5152

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test to check that domain is being filtered out

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
