### PR TITLE
BED-5562 changing LDAP InvalidOperationException to debug

### DIFF
--- a/src/CommonLib/Ntlm/LdapTransport.cs
+++ b/src/CommonLib/Ntlm/LdapTransport.cs
@@ -33,7 +33,7 @@ public class LdapTransport(ILogger logger, Uri ldapEndpoint) : INtlmTransport, I
         }
     }
 
-    public void InitializeConnectionAsync(int timeout = -1) {
+    public virtual void InitializeConnectionAsync(int timeout = -1) {
         if (_ldap == null) {
             _ldap = new LdapConnection();
             try {

--- a/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
+++ b/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
@@ -28,7 +28,7 @@ public class NtlmAuthenticationHandler : INtlmAuthenticationHandler {
         };
     }
 
-    public async Task<object> PerformNtlmAuthenticationAsync(INtlmTransport transport) {
+    public virtual async Task<object> PerformNtlmAuthenticationAsync(INtlmTransport transport) {
         using var context = new SspiContext(
             null,
             null,

--- a/src/CommonLib/Processors/DCLdapProcessor.cs
+++ b/src/CommonLib/Processors/DCLdapProcessor.cs
@@ -171,7 +171,7 @@ public class DCLdapProcessor {
     /// <param name="endpoint"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options, NtlmAuthenticationHandler? ntlmAuth = null, LdapTransport? ldapTransport = null) {
+    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options, NtlmAuthenticationHandler ntlmAuth = null, LdapTransport ldapTransport = null) {
         var host = endpoint.Host;
         var auth = ntlmAuth ?? new NtlmAuthenticationHandler($"LDAP/{host.ToUpper()}") {
             Options = options

--- a/src/CommonLib/Processors/DCLdapProcessor.cs
+++ b/src/CommonLib/Processors/DCLdapProcessor.cs
@@ -171,12 +171,12 @@ public class DCLdapProcessor {
     /// <param name="endpoint"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options) {
+    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options, NtlmAuthenticationHandler? ntlmAuth = null, LdapTransport? ldapTransport = null) {
         var host = endpoint.Host;
-        var auth = new NtlmAuthenticationHandler($"LDAP/{host.ToUpper()}") {
+        var auth = ntlmAuth ?? new NtlmAuthenticationHandler($"LDAP/{host.ToUpper()}") {
             Options = options
         };
-        var transport = new LdapTransport(_log, endpoint);
+        var transport = ldapTransport ?? new LdapTransport(_log, endpoint);
 
         try {
             transport.InitializeConnectionAsync(_ldapTimeout);
@@ -216,7 +216,8 @@ public class DCLdapProcessor {
             }
         } catch (InvalidOperationException ex) {
             _log.LogDebug("LDAP InvalidOperationException: {message}", ex.Message);
-        } catch (Exception ex) {
+        } catch (Exception ex)
+        {
             _log.LogError("An unhandled error occurred during the LDAP test: {ex}", ex);
         }
 

--- a/src/CommonLib/Processors/DCLdapProcessor.cs
+++ b/src/CommonLib/Processors/DCLdapProcessor.cs
@@ -214,6 +214,8 @@ public class DCLdapProcessor {
                         ex.ServerErrorMessage);
                     break;
             }
+        } catch (InvalidOperationException ex) {
+            _log.LogDebug("LDAP InvalidOperationException: {message}", ex.Message);
         } catch (Exception ex) {
             _log.LogError("An unhandled error occurred during the LDAP test: {ex}", ex);
         }

--- a/test/unit/DCLdapProcessorTest.cs
+++ b/test/unit/DCLdapProcessorTest.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using CommonLibTest.Facades;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SharpHoundCommonLib;
+using SharpHoundCommonLib.Enums;
+using SharpHoundCommonLib.Ntlm;
 using SharpHoundCommonLib.Processors;
 using SharpHoundRPC;
 using Xunit;
@@ -15,6 +20,8 @@ namespace CommonLibTest {
     public class DCLdapProcessorTest : IDisposable {
 
         private readonly ITestOutputHelper _testOutputHelper;
+        private readonly string SEC_E_UNSUPPORTED_FUNCTION = "80090302";
+        private readonly string SEC_E_BAD_BINDINGS = "80090346";
 
         public DCLdapProcessorTest(ITestOutputHelper testOutputHelper) {
             _testOutputHelper = testOutputHelper;
@@ -27,7 +34,7 @@ namespace CommonLibTest {
         public async Task DCLdapProcessor_Scan() {
             var mockProcessor = new Mock<DCLdapProcessor>(It.IsAny<int>(), "primary.testlab.local", null);
             
-            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>())).ReturnsAsync(false);
+            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>(),null, null)).ReturnsAsync(false);
 
             mockProcessor.Setup(x => x.TestLdapPort()).ReturnsAsync(true);
             mockProcessor.Setup(x => x.TestLdapsPort()).ReturnsAsync(true);
@@ -54,7 +61,7 @@ namespace CommonLibTest {
         public async Task DCLdapProcessor_Scan_Failed() {
             var mockProcessor = new Mock<DCLdapProcessor>(It.IsAny<int>(), "primary.testlab.local", null);
             
-            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>())).Throws(new Exception("Error"));
+            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>(), null, null)).Throws(new Exception("Error"));
 
             mockProcessor.Setup(x => x.TestLdapPort()).ReturnsAsync(true);
             mockProcessor.Setup(x => x.TestLdapsPort()).ReturnsAsync(true);
@@ -83,7 +90,7 @@ namespace CommonLibTest {
         public async Task DCLdapProcessor_CheckScan_Timeout() {
             var mockProcessor = new Mock<DCLdapProcessor>(2, "primary.testlab.local", null);
             
-            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>())).ReturnsAsync(() => {
+            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>(), null, null)).ReturnsAsync(() => {
                 Task.Delay(100).Wait();
                 return false;
             });
@@ -111,7 +118,7 @@ namespace CommonLibTest {
         public async Task DCLdapProcessor_CheckIsNtlmSigningRequired()
         {
             var mockProcessor = new Mock<DCLdapProcessor>(It.IsAny<int>(), "primary.testlab.local", null);
-            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>())).ReturnsAsync(false);
+            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>(),null, null)).ReturnsAsync(false);
             var processor = mockProcessor.Object;
             var result = await processor.CheckIsNtlmSigningRequired();
             Assert.True(result.IsSuccess);
@@ -122,11 +129,146 @@ namespace CommonLibTest {
         public async Task DCLdapProcessor_CheckIsNtlmSigningRequired_Exception()
         {
             var mockProcessor = new Mock<DCLdapProcessor>(It.IsAny<int>(), "primary.testlab.local", null);
-            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>())).Throws(new Exception("Error"));
+            mockProcessor.Setup(x => x.Authenticate(It.IsAny<Uri>(), It.IsAny<LdapAuthOptions>(), null, null)).Throws(new Exception("Error"));
             var processor = mockProcessor.Object;
             var result = await processor.CheckIsNtlmSigningRequired();
             Assert.True(result.IsFailed);
             Assert.Contains("CheckIsNtlmSigningRequired failed: System.Exception: Error", result.Error);
         }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_InvalidCredentialsException_SEC_E_UNSUPPORTED_FUNCTION()
+        {
+            var exception = "ErrorTest";
+            var endpoint = "http://primary.testlab.local/";
+            var expected = $"LDAP endpoint '{endpoint}' does not support NTLM";
+            
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException("Error", (int)LdapErrorCodes.InvalidCredentials, SEC_E_UNSUPPORTED_FUNCTION));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLogContains(LogLevel.Debug, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_InvalidCredentialsException_SEC_E_BAD_BINDINGS()
+        {
+            var exception = "ErrorTest";
+            var endpoint = "http://primary.testlab.local/";
+            var expected = $"Bad bindings with the LDAPS endpoint '{endpoint}'. Server error: {SEC_E_BAD_BINDINGS}";
+            
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException("Error", (int)LdapErrorCodes.InvalidCredentials, SEC_E_BAD_BINDINGS));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLogContains(LogLevel.Debug, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_InvalidCredentialsException_Unhandled()
+        {
+            var exception = "ErrorTest";
+            var endpoint = "http://primary.testlab.local/";
+            var expected = $"Unhandled LDAP InvalidCred error code during LDAP test: SharpHoundCommonLib.Ntlm.LdapNativeException: {exception}. LDAP error code: {(int)LdapErrorCodes.InvalidCredentials}.";
+            
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException(exception, (int)LdapErrorCodes.InvalidCredentials, "80090347"));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLogContains(LogLevel.Error, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_StrongAuthRequiredException()
+        {
+            var exception = "ErrorTest";
+            var endpoint = "http://primary.testlab.local/";
+            var expected = $"LDAP requires signing. Endpoint: {endpoint}";
+            
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException(exception, (int)LdapErrorCodes.StrongAuthRequired, null));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLog(LogLevel.Debug, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_ServerDownException()
+        {
+            var exception = "ErrorTest";
+            var endpoint = "http://primary.testlab.local/";
+            var expected = $"LDAP endpoint '{endpoint}' not accessible";
+            
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException(exception, (int)LdapErrorCodes.ServerDown));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLog(LogLevel.Debug, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_LdapUnhandledException()
+        {
+            var endpoint = "http://primary.testlab.local/";
+            var exception = "ErrorTest";
+            var expected = $"Unhandled LdapException error code during LDAP test: SharpHoundCommonLib.Ntlm.LdapNativeException: {exception}. LDAP error code: {(int)LdapErrorCodes.LocalError}";
+
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Throws(new LdapNativeException(exception, (int)LdapErrorCodes.LocalError));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), null, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLogContains(LogLevel.Error, expected);
+        }
+
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_InvalidOperationException()
+        {
+            var endpoint = "http://primary.testlab.local/";
+            var exception = "Server did return a challenge";
+            var expected = $"LDAP InvalidOperationException: {exception}";
+
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            var mockAuthenticator = new Mock<NtlmAuthenticationHandler>(It.IsAny<string>(), null);
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Verifiable();
+            mockAuthenticator.Setup(x => x.PerformNtlmAuthenticationAsync(It.IsAny<INtlmTransport>()))
+                .Throws(new InvalidOperationException(exception));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), mockAuthenticator.Object, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLog(LogLevel.Debug, expected);
+        }
+        
+        [Fact]
+        public async Task DCLdapProcessor_Authenticate_UnhandledException()
+        {
+            var endpoint = "http://primary.testlab.local/";
+            var exception = "Unhandled exception";
+            var expected = $"An unhandled error occurred during the LDAP test: System.Exception: {exception}";
+
+            var mockLogger = new Mock<ILogger<DCLdapProcessor>>();
+            var mockLdapTransport = new Mock<LdapTransport>(null, It.IsAny<Uri>());
+            var mockAuthenticator = new Mock<NtlmAuthenticationHandler>(It.IsAny<string>(), null);
+            mockLdapTransport.Setup(x => x.InitializeConnectionAsync(It.IsAny<int>())).Verifiable();
+            mockAuthenticator.Setup(x => x.PerformNtlmAuthenticationAsync(It.IsAny<INtlmTransport>()))
+                .Throws(new Exception(exception));
+            var processor = new DCLdapProcessor(It.IsAny<int>(), "primary.testlab.local", mockLogger.Object);
+            var result = await processor.Authenticate(new Uri(endpoint), It.IsAny<LdapAuthOptions>(), mockAuthenticator.Object, mockLdapTransport.Object);
+            Assert.False(result);
+            mockLogger.VerifyLogContains(LogLevel.Error, expected);
+        }
+
     }
 }

--- a/test/unit/Facades/MockExtentions.cs
+++ b/test/unit/Facades/MockExtentions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CommonLibTest.Facades;
+
+public static class MockExtentions
+{
+    public static void VerifyLogContains<T>(this Mock<ILogger<T>> mockLogger, LogLevel logLevel, params string[] expected)
+    {
+        mockLogger.Verify(
+            x => x.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) =>
+                    expected.All(s => o.ToString().Contains(s, StringComparison.OrdinalIgnoreCase))),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+    
+    public static void VerifyLog<T>(this Mock<ILogger<T>> mockLogger, LogLevel logLevel, string expectedMessage)
+    {
+        mockLogger.Verify(
+            x => x.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((o, t) =>
+                    string.Equals(expectedMessage, o.ToString(), StringComparison.InvariantCultureIgnoreCase)),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Description

Changing LDAP InvalidOperationException to debug

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-5562
Resolves SpecterOps/SharpHound#141

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run a SharpHound collection and check the service.log that the error below does not appear
`|ERROR|An unhandled error occurred during the LDAP test: System.InvalidOperationException: Server did return a challenge`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
