### PR TITLE
BED-5718 Caching unresolved sids to avoid time out

### DIFF
--- a/src/CommonLib/Processors/LocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/LocalGroupProcessor.cs
@@ -17,6 +17,7 @@ namespace SharpHoundCommonLib.Processors
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         private readonly ILogger _log;
         private readonly ILdapUtils _utils;
+        private static ConcurrentHashSet _unresolvablePrincipals = new(StringComparer.OrdinalIgnoreCase);
 
         public LocalGroupProcessor(ILdapUtils utils, ILogger log = null)
         {
@@ -233,6 +234,9 @@ namespace SharpHoundCommonLib.Processors
                             continue;
 
                         var sidValue = securityIdentifier.Value;
+                        
+                        if (_unresolvablePrincipals.Contains(sidValue)) 
+                            continue;
 
                         if (isDomainController)
                         {
@@ -274,6 +278,7 @@ namespace SharpHoundCommonLib.Processors
                             var lookupUserResult = server.LookupPrincipalBySid(securityIdentifier);
                             if (lookupUserResult.IsFailed)
                             {
+                                _unresolvablePrincipals.Add(sidValue);
                                 _log.LogTrace("Unable to resolve local sid {SID}: {Error}", sidValue, lookupUserResult.SError);
                                 continue;
                             }

--- a/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCAliasAdministrators_UnresolvedSid.cs
+++ b/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCAliasAdministrators_UnresolvedSid.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Principal;
+using SharpHoundRPC;
+using SharpHoundRPC.Wrappers;
+
+namespace CommonLibTest.Facades
+{
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+    public class MockDCAliasAdministrators_UnresolvedSid : ISAMAlias
+    {
+        public Result<IEnumerable<SecurityIdentifier>> GetMembers()
+        {
+            return new List<SecurityIdentifier>
+            {
+                new("S-1-5-21-321011808-3761883066-353627080"),
+                new("S-1-5-21-4243161961-3815211218-2888324771-519"),
+                new("S-1-5-21-4243161961-3815211218-2888324771-512")
+            };
+        }
+
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCAliasUsers_UnresolvedSid.cs
+++ b/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCAliasUsers_UnresolvedSid.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Principal;
+using SharpHoundRPC;
+using SharpHoundRPC.Wrappers;
+
+namespace CommonLibTest.Facades
+{
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+    public class MockDCAliasUsers_UnresolvedSid : ISAMAlias
+    {
+        public Result<IEnumerable<SecurityIdentifier>> GetMembers()
+        {
+            return new List<SecurityIdentifier>
+            {
+                new("S-1-5-21-321011808-3761883066-353627080"),
+                new("S-1-5-11"),
+                new("S-1-5-21-4243161961-3815211218-2888324771-513"),
+            };
+        }
+
+        public void Dispose()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCDomainBuiltIn_UnresolvedSid.cs
+++ b/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockDCDomainBuiltIn_UnresolvedSid.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using SharpHoundRPC;
+using SharpHoundRPC.SAMRPCNative;
+using SharpHoundRPC.Shared;
+using SharpHoundRPC.Wrappers;
+
+namespace CommonLibTest.Facades
+{
+    public class MockDCDomainBuiltIn_UnresolvedSid : ISAMDomain
+    {
+        public Result<(string Name, SharedEnums.SidNameUse Type)> LookupPrincipalByRid(int rid)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Result<IEnumerable<(string Name, int Rid)>> GetAliases()
+        {
+            var results = new List<(string, int)>
+            {
+                ("Administrators", 544),
+                ("Users", 545)
+            };
+            return results;
+        }
+
+        public Result<ISAMAlias> OpenAlias(int rid, SAMEnums.AliasOpenFlags desiredAccess = SAMEnums.AliasOpenFlags.ListMembers)
+        {
+            switch (rid)
+            {
+                case 544:
+                    return new MockDCAliasAdministrators_UnresolvedSid();
+                case 545:
+                    return new MockDCAliasUsers_UnresolvedSid();
+                default:
+                    throw new IndexOutOfRangeException();
+            }
+        }
+
+        public Result<ISAMAlias> OpenAlias(string name)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockSAMServer_UnresolvedSid.cs
+++ b/test/unit/Facades/SAMMocks/UnresolvedSidMocks/MockSAMServer_UnresolvedSid.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Principal;
+using SharpHoundRPC;
+using SharpHoundRPC.SAMRPCNative;
+using SharpHoundRPC.Shared;
+using SharpHoundRPC.Wrappers;
+
+namespace CommonLibTest.Facades
+{
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility")]
+    public class MockSAMServer_UnresolvedSid : ISAMServer
+    {
+        public bool IsNull { get; }
+        public Result<IEnumerable<(string Name, int Rid)>> GetDomains()
+        {
+            var domains = new List<(string, int)>
+            {
+                ("BUILTIN", 1)
+            };
+            return domains;
+            
+        }
+
+        public virtual Result<SecurityIdentifier> LookupDomain(string name)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Result<SecurityIdentifier> GetMachineSid(string testName = null)
+        {
+            var securityIdentifier = new SecurityIdentifier(Consts.MockWorkstationMachineSid);
+            return Result<SecurityIdentifier>.Ok(securityIdentifier);
+        }
+
+        public Result<(string Name, SharedEnums.SidNameUse Type)> LookupPrincipalBySid(SecurityIdentifier securityIdentifier)
+        {
+            return Result<(string, SharedEnums.SidNameUse)>.Fail($"OpenDomain returned {NtStatus.StatusSuccess}");
+        }
+
+        public Result<ISAMDomain> OpenDomain(string domainName,
+            SAMEnums.DomainAccessMask requestedDomainAccess = SAMEnums.DomainAccessMask.ListAccounts | SAMEnums.DomainAccessMask.Lookup)
+        {
+            if (domainName.Equals("builtin", StringComparison.OrdinalIgnoreCase))
+            {
+                return new MockDCDomainBuiltIn_UnresolvedSid();
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public Result<ISAMDomain> OpenDomain(SecurityIdentifier securityIdentifier,
+            SAMEnums.DomainAccessMask requestedDomainAccess = SAMEnums.DomainAccessMask.ListAccounts | SAMEnums.DomainAccessMask.Lookup)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/test/unit/LocalGroupProcessorTest.cs
+++ b/test/unit/LocalGroupProcessorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Enums;
@@ -384,6 +385,22 @@ namespace CommonLibTest
                     Assert.Equal($"{machineDomainSid}-544", principal.ObjectIdentifier);
                     Assert.Equal(Label.LocalGroup, principal.ObjectType);
                 });
+        }
+        
+        [Fact]
+        public async Task LocalGroupProcessor_GetLocalGroups_UnresolvableSid()
+        {
+            var mockLogger = new Mock<ILogger<LocalGroupProcessor>>();
+            var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), mockLogger.Object);
+            var mockSamServer = new MockSAMServer_UnresolvedSid();
+            mockProcessor.Setup(x => x.OpenSamServer(It.IsAny<string>())).Returns(mockSamServer);
+            var processor = mockProcessor.Object;
+            var machineDomainSid = $"{Consts.MockWorkstationMachineSid}-1000";
+            var results = await processor.GetLocalGroups("primary.testlab.local", machineDomainSid, "TESTLAB.LOCAL", false)
+                .ToArrayAsync();
+            
+            Assert.Equal(2, results.Length);
+            mockLogger.VerifyLog(LogLevel.Trace, $"Unable to resolve local sid {Consts.MockWorkstationMachineSid}: OpenDomain returned StatusSuccess");
         }
     }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Added `_unresolvablePrincipals` to cache the SIDs that were unresolved so Sharphound doesn't continuously try to resolve them.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-5718

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit test.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
