### PR TITLE
[BED-5934] First pass to provide better SMB Signing query transparency in logging

### DIFF
--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -260,7 +260,7 @@ namespace SharpHoundCommonLib.SMB
             // Validate structure size of negotiate response
             var negotiateStructureSize = reader.ReadUInt16();
 
-            if (negotiateStructureSize != SMB2Constants.ExpectedNegotiateStructureSizeB)
+            if (negotiateStructureSize != SMB2Constants.ExpectedNegotiateStructureSizeA)
             {
                 _log.LogDebug($"Expected fixed-value SMB2 response structure size {SMB2Constants.ExpectedNegotiateStructureSizeB}, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
                 return (true, false);

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -100,7 +100,8 @@ namespace SharpHoundCommonLib.SMB
                 // signingEnabled and signingRequired must both be True to confirm that SMB signing is required on this computer,
                 // so if we only collect one registry and it's False, we can conclude that SMB signing is not required
                 // but if it's True, we can't conclude either way and will return a Fail result
-                if ((requireRegistryValue == null && signingEnabled) || (enableRegistryValue == null && signingRequired))
+                // Note however that signingRequired implies signingEnabled
+                if (requireRegistryValue == null && signingEnabled)
                     return SharpHoundRPC.Result<SmbScanInfo>.Fail("Could not acquire enough registries to determine SMB Signing info");
 
                 return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 using SharpHoundCommonLib.SMB.SMB1;
 using SharpHoundCommonLib.SMB.SMB2;
 using SharpHoundCommonLib.SMB.NetBIOS;
-using System.CodeDom;
 using Microsoft.Extensions.Logging;
-using SharpHoundRPC;
 using SharpHoundRPC.Registry;
 using Microsoft.Win32;
 
@@ -45,35 +43,42 @@ namespace SharpHoundCommonLib.SMB
         /// <summary>
         /// Scans SMB on the remote server by sending an SMB negotiate message
         /// and analyzing the response. It will attempt to elicit a response using 
-        /// an SMB1 message and then SMB2 (if SMB1 fails).
+        /// an SMB1 message and then SMB2.
         /// </summary>
         /// <param name="host">The hostname or IP address to check</param>
         /// <param name="port">The port to connect to (default SMB port is 445)</param>
         /// <returns>Result object containing SMB signing information</returns>
         public async Task<SharpHoundRPC.Result<SmbScanInfo>> ScanHost(string host, int port = 445)
         {
-
-            var isLocalMachine = NativeUtils.IsCurrentMachineFqdn(host);
-            if (isLocalMachine)
+            if (NativeUtils.IsCurrentMachineFqdn(host))
             {
                 // When accessing the SMB directly port from localhost, it'll disconnect. 
                 // Side step that by just collecting the data from the registry.
                 _log.LogTrace($"Checking SMB registry on host {host}");
-                return CheckRegistrySigningRequired(host);
+                var registryResult = CheckRegistrySigningRequired(host);
+
+                // If registry check succeeds that's all we need, otherwise we'll follow up with SMB Negotiate
+                if (registryResult.IsSuccess)
+                    return registryResult;
             }
 
-
-
-            // Try SMB1 negotiate first as it'll elicit an SMB1 or SMB2 response (if either is enabled)
+            // Try SMB1 negotiate first
             _log.LogTrace($"Negotiating SMB1 request to host {host}");
             var smb1result = await TrySMBNegotiate(host, port, true);
 
-            if (smb1result.IsSuccess)
+            // If it's enabled and signing isn't required, we can exit here
+            if (smb1result.IsSuccess && !smb1result.Value.SigningRequired)
                 return smb1result;
 
-            // SMB1 failed, so try an SMB2 negotiate in case SMB1 is disabled or the SMB3 dialect is required
+            // SMB1 failed or requires signing, so try an SMB2 negotiate in case it's vulnerable
             _log.LogTrace($"Negotiating SMB2 request to host {host}");
-            return await TrySMBNegotiate(host, port, false);
+            var smb2result = await TrySMBNegotiate(host, port, false);
+
+            // Return SMB2 result, unless SMB1 is the only successful response
+            if (smb2result.IsSuccess || smb1result.IsFailed)
+                return smb2result;
+            else
+                return smb1result;
         }
 
         /// <summary>
@@ -81,7 +86,7 @@ namespace SharpHoundCommonLib.SMB
         /// </summary>
         private SharpHoundRPC.Result<SmbScanInfo> CheckRegistrySigningRequired(string host)
         {
-            const string keyPath = @"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters";
+            const string keyPath = @"SYSTEM\CurrentControlSet\Services\LanManServer\Parameters";
             const string requireValueName = "RequireSecuritySignature";
             const string enableValueName = "EnableSecuritySignature";
 
@@ -90,18 +95,13 @@ namespace SharpHoundCommonLib.SMB
                 var requireRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", requireValueName, null);
                 var enableRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", enableValueName, null);
 
-                bool signingRequired = false;
-                bool signingEnabled = false;
-
-                if (requireRegistryValue != null)
+                if (requireRegistryValue == null || enableRegistryValue == null)
                 {
-                    signingRequired = Convert.ToInt32(requireRegistryValue) != 0;
+                    return SharpHoundRPC.Result<SmbScanInfo>.Fail($"Could not acquire one or both of registries {requireValueName} or {enableValueName}");
                 }
 
-                if (enableRegistryValue != null)
-                {
-                    signingEnabled = Convert.ToInt32(enableRegistryValue) != 0;
-                }
+                var signingRequired = Convert.ToInt32(requireRegistryValue) != 0;
+                var signingEnabled = Convert.ToInt32(enableRegistryValue) != 0;
 
                 return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)
                 {

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -262,7 +262,7 @@ namespace SharpHoundCommonLib.SMB
 
             if (negotiateStructureSize != SMB2Constants.ExpectedNegotiateStructureSizeB)
             {
-                _log.LogDebug($"Expected fixed-value SMB2 response structure size, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
+                _log.LogDebug($"Expected fixed-value SMB2 response structure size {SMB2Constants.ExpectedNegotiateStructureSizeB}, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
                 return (true, false);
             }
 

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -58,18 +58,21 @@ namespace SharpHoundCommonLib.SMB
             {
                 // When accessing the SMB directly port from localhost, it'll disconnect. 
                 // Side step that by just collecting the data from the registry.
+                _log.LogTrace($"Checking SMB registry on host {host}");
                 return CheckRegistrySigningRequired(host);
             }
 
 
 
             // Try SMB1 negotiate first as it'll elicit an SMB1 or SMB2 response (if either is enabled)
+            _log.LogTrace($"Negotiating SMB1 request to host {host}");
             var smb1result = await TrySMBNegotiate(host, port, true);
 
             if (smb1result.IsSuccess)
                 return smb1result;
 
             // SMB1 failed, so try an SMB2 negotiate in case SMB1 is disabled or the SMB3 dialect is required
+            _log.LogTrace($"Negotiating SMB2 request to host {host}");
             return await TrySMBNegotiate(host, port, false);
         }
 
@@ -256,7 +259,12 @@ namespace SharpHoundCommonLib.SMB
 
             // Validate structure size of negotiate response
             var negotiateStructureSize = reader.ReadUInt16();
-            
+
+            if (negotiateStructureSize != SMB2Constants.ExpectedNegotiateStructureSizeB)
+            {
+                _log.LogDebug($"Expected fixed-value SMB2 response structure size, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
+                return (true, false);
+            }
 
             // Read security mode, which contains signing information
             var securityMode = reader.ReadUInt16();

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -86,28 +86,30 @@ namespace SharpHoundCommonLib.SMB
                 var requireRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", requireValueName, null);
                 var enableRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", enableValueName, null);
 
-                if (requireRegistryValue == null && enableRegistryValue == null)
-                    return SharpHoundRPC.Result<SmbScanInfo>.Fail($"Could not acquire either of registries {requireValueName} and {enableValueName}");
+                bool required = false;
 
-                bool signingRequired = false;
-                bool signingEnabled = false;
-
+                // RequireSecuritySignature is enough to tell us whether or not signing is required
                 if (requireRegistryValue != null)
-                    signingRequired = Convert.ToInt32(requireRegistryValue) != 0;
-                if (enableRegistryValue != null)
-                    signingEnabled = Convert.ToInt32(enableRegistryValue) != 0;
-
-                // signingEnabled and signingRequired must both be True to confirm that SMB signing is required on this computer,
-                // so if we only collect one registry and it's False, we can conclude that SMB signing is not required
-                // but if it's True, we can't conclude either way and will return a Fail result
-                // Note however that signingRequired implies signingEnabled
-                if (requireRegistryValue == null && signingEnabled)
-                    return SharpHoundRPC.Result<SmbScanInfo>.Fail("Could not acquire enough registries to determine SMB Signing info");
-
-                return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)
                 {
-                    SigningRequired = signingEnabled && signingRequired
-                });
+                    required = Convert.ToInt32(requireRegistryValue) != 0;
+                    return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)
+                    {
+                        SigningRequired = required,
+                    });
+                }
+                // But if it doesn't exist, we can know that signing ISN'T required if EnableSecuritySignature is False
+                else if (enableRegistryValue != null)
+                {
+                    required = Convert.ToInt32(enableRegistryValue) != 0;
+                    if (!required)
+                        return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)
+                        {
+                            SigningRequired = false,
+                        });
+                }
+
+                // But if EnableSecuritySignature is also missing or is True, we can't conclude anything
+                return SharpHoundRPC.Result<SmbScanInfo>.Fail("Could not acquire enough registries to determine SMB Signing info");
             }
             catch (Exception ex)
             {

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -263,7 +263,7 @@ namespace SharpHoundCommonLib.SMB
 
             if (negotiateStructureSize != SMB2Constants.ExpectedNegotiateStructureSizeA)
             {
-                _log.LogDebug($"Expected fixed-value SMB2 response structure size {SMB2Constants.ExpectedNegotiateStructureSizeB}, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
+                _log.LogDebug($"Expected fixed-value SMB2 response structure size {SMB2Constants.ExpectedNegotiateStructureSizeA}, got {negotiateStructureSize}. Packet: {Convert.ToBase64String(responsePacket)}");
                 return (true, false);
             }
 

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -95,13 +95,22 @@ namespace SharpHoundCommonLib.SMB
                 var requireRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", requireValueName, null);
                 var enableRegistryValue = Registry.GetValue($@"HKEY_LOCAL_MACHINE\{keyPath}", enableValueName, null);
 
-                if (requireRegistryValue == null || enableRegistryValue == null)
-                {
-                    return SharpHoundRPC.Result<SmbScanInfo>.Fail($"Could not acquire one or both of registries {requireValueName} or {enableValueName}");
-                }
+                if (requireRegistryValue == null && enableRegistryValue == null)
+                    return SharpHoundRPC.Result<SmbScanInfo>.Fail($"Could not acquire either of registries {requireValueName} and {enableValueName}");
 
-                var signingRequired = Convert.ToInt32(requireRegistryValue) != 0;
-                var signingEnabled = Convert.ToInt32(enableRegistryValue) != 0;
+                bool signingRequired = false;
+                bool signingEnabled = false;
+
+                if (requireRegistryValue != null)
+                    signingRequired = Convert.ToInt32(requireRegistryValue) != 0;
+                if (enableRegistryValue != null)
+                    signingEnabled = Convert.ToInt32(enableRegistryValue) != 0;
+
+                // signingEnabled and signingRequired must both be True to confirm that SMB signing is required on this computer,
+                // so if we only collect one registry and it's False, we can conclude that SMB signing is not required
+                // but if it's True, we can't conclude either way and will return a Fail result
+                if ((requireRegistryValue == null && signingEnabled) || (enableRegistryValue == null && signingRequired))
+                    return SharpHoundRPC.Result<SmbScanInfo>.Fail("Could not acquire enough registries to determine SMB Signing info");
 
                 return SharpHoundRPC.Result<SmbScanInfo>.Ok(new SmbScanInfo(host)
                 {

--- a/src/CommonLib/SMB/SmbScanner.cs
+++ b/src/CommonLib/SMB/SmbScanner.cs
@@ -62,23 +62,14 @@ namespace SharpHoundCommonLib.SMB
                     return registryResult;
             }
 
-            // Try SMB1 negotiate first
-            _log.LogTrace($"Negotiating SMB1 request to host {host}");
+            // Try SMB1 negotiate first as it'll elicit an SMB1 or SMB2 response (if either is enabled)
             var smb1result = await TrySMBNegotiate(host, port, true);
 
-            // If it's enabled and signing isn't required, we can exit here
-            if (smb1result.IsSuccess && !smb1result.Value.SigningRequired)
+            if (smb1result.IsSuccess)
                 return smb1result;
 
-            // SMB1 failed or requires signing, so try an SMB2 negotiate in case it's vulnerable
-            _log.LogTrace($"Negotiating SMB2 request to host {host}");
-            var smb2result = await TrySMBNegotiate(host, port, false);
-
-            // Return SMB2 result, unless SMB1 is the only successful response
-            if (smb2result.IsSuccess || smb1result.IsFailed)
-                return smb2result;
-            else
-                return smb1result;
+            // SMB1 failed, so try an SMB2 negotiate in case SMB1 is disabled or the SMB3 dialect is required
+            return await TrySMBNegotiate(host, port, false);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
Provide trace logging for SMB info scanning to provide more visibility into query paths taken to get this data.
Add additional safety check to SMB2 response parsing to add further confidence that the packet returned is properly composed.

## Motivation and Context
BED-5934

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
