### PR TITLE
BED-5435 AddSelf, BED-5988 Mandatory Filters

### DIFF
--- a/src/CommonLib/LdapQueries/LdapFilter.cs
+++ b/src/CommonLib/LdapQueries/LdapFilter.cs
@@ -255,8 +255,21 @@ namespace SharpHoundCommonLib.LDAPQueries {
             return filterPartsDistinct;
         }
 
+        private string MergeFilter(string filterA, string filterB) {
+            return $"(&{filterA}{filterB})";
+        }
+
         public IEnumerable<string> GetFilterList() {
-            return _filterParts.Distinct();
+            foreach (var filter in _filterParts.Distinct())
+            {
+                if (_mandatory.Count > 0) {
+                    foreach (var mandatory in _mandatory) {
+                        yield return MergeFilter(filter, mandatory);
+                    }
+                } else {
+                    yield return filter;
+                }
+            }
         }
     }
 }

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -407,7 +407,7 @@ namespace SharpHoundCommonLib.Processors {
                     if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
                         !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
                         !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                        aceType == ACEGuids.WriteMember)
+                        aceType is ACEGuids.WriteMember or ACEGuids.AllGuid)
                         aces.Add(new ACE
                         {
                             PrincipalType = resolvedPrincipal.ObjectType,

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -734,6 +734,78 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
+        
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_Self_AllGuid() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.AddSelf;
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.Self);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, false).ToArrayAsync();
+
+            Assert.Single(result);
+            var actual = result.First();
+            Assert.Equal(actual.PrincipalType, expectedPrincipalType);
+            Assert.Equal(actual.PrincipalSID, expectedPrincipalSID);
+            Assert.False(actual.IsInherited);
+            Assert.Equal(actual.RightName, expectedRightName);
+        }
+        
+        [Fact]
+        public async Task ACLProcessor_ProcessACL_NoAddSelfEdge() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.Self);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteAllowedToAct));
+            collection.Add(mockRule.Object);
+
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            var mockData = new[] { LdapResult<IDirectoryObject>.Fail() };
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockData.ToAsyncEnumerable());
+
+            var processor = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AddMemberSecurityDescriptor);
+            var result = await processor.ProcessACL(bytes, _testDomainName, Label.Group, false).ToArrayAsync();
+
+            Assert.Empty(result);
+        }
 
         [Fact]
         public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_Unmatched() {

--- a/test/unit/LDAPFilterTest.cs
+++ b/test/unit/LDAPFilterTest.cs
@@ -73,6 +73,28 @@ namespace CommonLibTest
                  i++;
             }
         }
+        
+        [Fact]
+        public void LDAPFilter_GetFilterList_MergeFilter()
+        {
+            var test = new LdapFilter();
+            test.AddUsers();
+            test.AddComputers();
+            string mergeFilter = "(objectclass=*)";
+            test.AddFilter(mergeFilter, true);
+            
+            IEnumerable<string> filters = test.GetFilterList();
+            
+            int i = 0;
+            string computerFilter = "(samaccounttype=805306369)";
+            string userFilter = "(|(samaccounttype=805306368)(samaccounttype=805306370))";
+            string[] expected = {$"(&{userFilter}{mergeFilter})", $"(&{computerFilter}{mergeFilter})"};
+
+            foreach (var filter in filters) {
+                Assert.Equal(expected[i], filter);
+                i++;
+            }
+        }
 
         #endregion
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
BED-5435:
AddSelf edge creation was happening when user has ACE GUID WriteMember but another way AddSelf can be used is when a user has an ACE GUID 00000000-0000-0000-0000-000000000000 (AllGuid)

BED-5988:
Include mandatory filters in each filter retrieved from GetFilterList()

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-5435
https://specterops.atlassian.net/browse/BED-5988

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
BED-5435:
Set up user to have ACE GUID 00000000-0000-0000-0000-000000000000 and give them `Add/Remove self as member` to a group. Run a collection and search in BH/BHE and see that `AddSelf` edge is shown from user to group.

BED-5988:


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.
