### PR TITLE
[BED-5988] Update MergeFilter to accomodate more than 1 mandatory filter

### DIFF
--- a/src/CommonLib/LdapQueries/LdapFilter.cs
+++ b/src/CommonLib/LdapQueries/LdapFilter.cs
@@ -255,17 +255,19 @@ namespace SharpHoundCommonLib.LDAPQueries {
             return filterPartsDistinct;
         }
 
-        private string MergeFilter(string filterA, string filterB) {
-            return $"(&{filterA}{filterB})";
+        private string MergeFilters(params string[] filters) {
+            return $"(&{string.Join("", filters)})";
         }
 
         public IEnumerable<string> GetFilterList() {
             foreach (var filter in _filterParts.Distinct())
             {
                 if (_mandatory.Count > 0) {
-                    foreach (var mandatory in _mandatory) {
-                        yield return MergeFilter(filter, mandatory);
-                    }
+                    var filters = new List<string>(_mandatory)
+                    {
+                        filter
+                    };
+                    yield return MergeFilters(filters.ToArray());
                 } else {
                     yield return filter;
                 }

--- a/test/unit/LDAPFilterTest.cs
+++ b/test/unit/LDAPFilterTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using SharpHoundCommonLib.LDAPQueries;
 using Xunit;
 using Xunit.Abstractions;
@@ -73,27 +74,34 @@ namespace CommonLibTest
                  i++;
             }
         }
-        
+
         [Fact]
         public void LDAPFilter_GetFilterList_MergeFilter()
         {
             var test = new LdapFilter();
             test.AddUsers();
             test.AddComputers();
-            string mergeFilter = "(objectclass=*)";
-            test.AddFilter(mergeFilter, true);
-            
+            string mandatoryFilter1 = "(objectclass=*)";
+            string mandatoryFilter2 = "(iamamandatoryfilter=1)";
+            test.AddFilter(mandatoryFilter1, true);
+            test.AddFilter(mandatoryFilter2, true);
+
             IEnumerable<string> filters = test.GetFilterList();
-            
-            int i = 0;
+
             string computerFilter = "(samaccounttype=805306369)";
             string userFilter = "(|(samaccounttype=805306368)(samaccounttype=805306370))";
-            string[] expected = {$"(&{userFilter}{mergeFilter})", $"(&{computerFilter}{mergeFilter})"};
 
-            foreach (var filter in filters) {
-                Assert.Equal(expected[i], filter);
-                i++;
+            // Check that each filter includes all mandatory filters
+            foreach (var filter in filters)
+            {
+                Assert.StartsWith("(&", filter);
+                Assert.Contains(mandatoryFilter1, filter);
+                Assert.Contains(mandatoryFilter2, filter);
             }
+
+            // Check that each of userFilter and computerFilter are accounted for
+            Assert.Single(filters.Where(f => f.Contains(userFilter)));
+            Assert.Single(filters.Where(f => f.Contains(computerFilter)));
         }
 
         #endregion

--- a/test/unit/LDAPFilterTest.cs
+++ b/test/unit/LDAPFilterTest.cs
@@ -102,6 +102,8 @@ namespace CommonLibTest
             // Check that each of userFilter and computerFilter are accounted for
             Assert.Single(filters.Where(f => f.Contains(userFilter)));
             Assert.Single(filters.Where(f => f.Contains(computerFilter)));
+
+            Assert.Equal(2, filters.Count());
         }
 
         #endregion


### PR DESCRIPTION
## Description
Mandatory filters hadn't been accommodated at all.  We'd fixed that behavior, but only when a single mandatory filter is specified.  This change should accommodate multiple mandatory filters.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-5988

## How Has This Been Tested?
Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.
