### PR TITLE
[BED-6067] Add isReadOnlyDC property to computer objects

### DIFF
--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -19,7 +19,6 @@ namespace SharpHoundCommonLib.OutputTypes {
         public DCRegistryData DCRegistryData { get; set; } = new();
         public ComputerStatus Status { get; set; }
         public bool IsDC { get; set; }
-        public bool IsReadOnlyDC { get; set; }
         public bool UnconstrainedDelegation { get; set; }
         public string DomainSID { get; set; }
 

--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -19,6 +19,7 @@ namespace SharpHoundCommonLib.OutputTypes {
         public DCRegistryData DCRegistryData { get; set; } = new();
         public ComputerStatus Status { get; set; }
         public bool IsDC { get; set; }
+        public bool IsReadOnlyDC { get; set; }
         public bool UnconstrainedDelegation { get; set; }
         public string DomainSID { get; set; }
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -356,6 +356,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("unconstraineddelegation", flags.HasFlag(UacFlags.TrustedForDelegation));
             props.Add("trustedtoauth", flags.HasFlag(UacFlags.TrustedToAuthForDelegation));
             props.Add("isdc", flags.HasFlag(UacFlags.ServerTrustAccount));
+            props.Add("isreadonlydc", flags.HasFlag(UacFlags.PartialSecretsAccount));
             props.Add("encryptedtextpwdallowed", flags.HasFlag(UacFlags.EncryptedTextPwdAllowed));
             props.Add("usedeskeyonly", flags.HasFlag(UacFlags.UseDesKeyOnly));
             props.Add("logonscriptenabled", flags.HasFlag(UacFlags.Script));

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -464,6 +464,7 @@ namespace CommonLibTest
             Assert.Contains("unconstraineddelegation", keys);
             Assert.Contains("trustedtoauth", keys);
             Assert.Contains("isdc", keys);
+            Assert.Contains("isreadonlydc", keys);
             Assert.Contains("lastlogon", keys);
             Assert.Contains("lastlogontimestamp", keys);
             Assert.Contains("pwdlastset", keys);
@@ -471,6 +472,7 @@ namespace CommonLibTest
             Assert.False((bool)props["unconstraineddelegation"]);
             Assert.True((bool)props["trustedtoauth"]);
             Assert.False((bool)props["isdc"]);
+            Assert.False((bool)props["isreadonlydc"]);
 
             Assert.Contains("lastlogon", keys);
             Assert.Equal(1622827514, (long)props["lastlogon"]);


### PR DESCRIPTION
## Description
Add isReadOnlyDC property to Computer objects, determined from UAC attribute.

## Motivation and Context
[BED-6067](https://specterops.atlassian.net/browse/BED-6067)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-6067]: https://specterops.atlassian.net/browse/BED-6067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new property to indicate if a computer is a read-only domain controller.

* **Tests**
  * Updated unit tests to verify the presence and value of the new property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->