### PR TITLE
fix: BED-6026 adding the domainSid to _unresolvablePrincipals cache to prevent repeated resolving

### DIFF
--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -383,6 +383,8 @@ namespace SharpHoundCommonLib {
 
         private async Task<(bool Success, string DomainName)> ConvertDomainSidToDomainNameFromLdap(string domainSid) {
             if (!GetDomain(out var domain) || domain?.Name == null) {
+                // fix: BED-6026 adding the domainSid to _unresolvablePrincipals cache to prevent repeated resolving
+                _unresolvablePrincipals.Add(domainSid);
                 return (false, string.Empty);
             }
 


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->
SH tries to repeatedly resolve unresolvable SIDs from a non-domain-joined Windows machine.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://specterops.atlassian.net/browse/BED-6026
https://github.com/SpecterOps/SharpHoundCommon/issues/203

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.
