### PR TITLE
Alter ReadGroupProperties to Add HasSIDHistory +Minor Version

### DIFF
--- a/src/CommonLib/OutputTypes/Group.cs
+++ b/src/CommonLib/OutputTypes/Group.cs
@@ -5,5 +5,6 @@ namespace SharpHoundCommonLib.OutputTypes
     public class Group : OutputBase
     {
         public TypedPrincipal[] Members { get; set; } = Array.Empty<TypedPrincipal>();
+        public TypedPrincipal[] HasSIDHistory { get; set; } = Array.Empty<TypedPrincipal>();
     }
 }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -177,20 +177,47 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
             return props;
         }
+        
+        public Task<GroupProperties> ReadGroupProperties(IDirectoryObject entry,
+            ResolvedSearchResult searchResult) {
+            return ReadGroupProperties(entry, searchResult.Domain);
+        }
 
         /// <summary>
         ///     Reads specific LDAP properties related to Groups
         /// </summary>
         /// <param name="entry"></param>
+        /// <param name="domain"></param>
         /// <returns></returns>
-        public static Dictionary<string, object> ReadGroupProperties(IDirectoryObject entry) {
+        public async Task<GroupProperties> ReadGroupProperties(IDirectoryObject entry, string domain)
+        {
+            var groupProperties = new GroupProperties();
             var props = GetCommonProps(entry);
             entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
             props.Add("admincount", ac != 0);
             entry.TryGetLongProperty(LDAPProperties.GroupType, out var groupType);
             props.Add("groupscope", GetGroupScope(groupType));
+            entry.TryGetByteArrayProperty(LDAPProperties.SIDHistory, out var sh);
+            var sidHistoryList = new List<string>();
+            var sidHistoryPrincipals = new List<TypedPrincipal>();
+            foreach (var sid in sh) {
+                string sSid;
+                try {
+                    sSid = new SecurityIdentifier(sid, 0).Value;
+                } catch {
+                    continue;
+                }
 
-            return props;
+                sidHistoryList.Add(sSid);
+
+                if (await _utils.ResolveIDAndType(sSid, domain) is (true, var res))
+                    sidHistoryPrincipals.Add(res);
+            }
+            groupProperties.SidHistory = sidHistoryPrincipals.Distinct().ToArray();
+            props.Add("sidhistory", sidHistoryList.ToArray());
+            groupProperties.Props = props;
+
+            return groupProperties;
         }
 
         /// <summary>
@@ -981,6 +1008,12 @@ namespace SharpHoundCommonLib.Processors {
                 }
             }
         }
+    }
+
+    public class GroupProperties
+    {
+        public Dictionary<string, object> Props { get; set; } = new();
+        public TypedPrincipal[] SidHistory { get; set; } = Array.Empty<TypedPrincipal>();
     }
 
     public class UserProperties {

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -178,9 +178,9 @@ namespace SharpHoundCommonLib.Processors {
             return props;
         }
         
-        public Task<GroupProperties> ReadGroupProperties(IDirectoryObject entry,
+        public Task<GroupProperties> ReadGroupPropertiesAsync(IDirectoryObject entry,
             ResolvedSearchResult searchResult) {
-            return ReadGroupProperties(entry, searchResult.Domain);
+            return ReadGroupPropertiesAsync(entry, searchResult.Domain);
         }
 
         /// <summary>
@@ -189,7 +189,7 @@ namespace SharpHoundCommonLib.Processors {
         /// <param name="entry"></param>
         /// <param name="domain"></param>
         /// <returns></returns>
-        public async Task<GroupProperties> ReadGroupProperties(IDirectoryObject entry, string domain)
+        public async Task<GroupProperties> ReadGroupPropertiesAsync(IDirectoryObject entry, string domain)
         {
             var groupProperties = new GroupProperties();
             var props = GetCommonProps(entry);

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -198,23 +198,9 @@ namespace SharpHoundCommonLib.Processors {
             entry.TryGetLongProperty(LDAPProperties.GroupType, out var groupType);
             props.Add("groupscope", GetGroupScope(groupType));
             entry.TryGetByteArrayProperty(LDAPProperties.SIDHistory, out var sh);
-            var sidHistoryList = new List<string>();
-            var sidHistoryPrincipals = new List<TypedPrincipal>();
-            foreach (var sid in sh) {
-                string sSid;
-                try {
-                    sSid = new SecurityIdentifier(sid, 0).Value;
-                } catch {
-                    continue;
-                }
-
-                sidHistoryList.Add(sSid);
-
-                if (await _utils.ResolveIDAndType(sSid, domain) is (true, var res))
-                    sidHistoryPrincipals.Add(res);
-            }
-            groupProperties.SidHistory = sidHistoryPrincipals.Distinct().ToArray();
-            props.Add("sidhistory", sidHistoryList.ToArray());
+            var (sidHistoryStrings, sidHistoryPrincipals) = await ProcessSidHistory(sh, domain);
+            groupProperties.SidHistory = sidHistoryPrincipals;
+            props.Add("sidhistory", sidHistoryStrings);
             groupProperties.Props = props;
 
             return groupProperties;
@@ -334,25 +320,9 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("supportedencryptiontypes", encryptionTypes);
 
             entry.TryGetByteArrayProperty(LDAPProperties.SIDHistory, out var sh);
-            var sidHistoryList = new List<string>();
-            var sidHistoryPrincipals = new List<TypedPrincipal>();
-            foreach (var sid in sh) {
-                string sSid;
-                try {
-                    sSid = new SecurityIdentifier(sid, 0).Value;
-                } catch {
-                    continue;
-                }
-
-                sidHistoryList.Add(sSid);
-
-                if (await _utils.ResolveIDAndType(sSid, domain) is (true, var res))
-                    sidHistoryPrincipals.Add(res);
-            }
-
-            userProps.SidHistory = sidHistoryPrincipals.Distinct().ToArray();
-
-            props.Add("sidhistory", sidHistoryList.ToArray());
+            var (sidHistoryStrings, sidHistoryPrincipals) = await ProcessSidHistory(sh, domain);
+            userProps.SidHistory = sidHistoryPrincipals;
+            props.Add("sidhistory", sidHistoryStrings);
 
             userProps.Props = props;
 
@@ -450,25 +420,9 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("operatingsystem", os);
 
             entry.TryGetByteArrayProperty(LDAPProperties.SIDHistory, out var sh);
-            var sidHistoryList = new List<string>();
-            var sidHistoryPrincipals = new List<TypedPrincipal>();
-            foreach (var sid in sh) {
-                string sSid;
-                try {
-                    sSid = new SecurityIdentifier(sid, 0).Value;
-                } catch {
-                    continue;
-                }
-
-                sidHistoryList.Add(sSid);
-
-                if (await _utils.ResolveIDAndType(sSid, domain) is (true, var res))
-                    sidHistoryPrincipals.Add(res);
-            }
-
-            compProps.SidHistory = sidHistoryPrincipals.ToArray();
-
-            props.Add("sidhistory", sidHistoryList.ToArray());
+            var (sidHistoryStrings, sidHistoryPrincipals) = await ProcessSidHistory(sh, domain);
+            compProps.SidHistory = sidHistoryPrincipals;
+            props.Add("sidhistory", sidHistoryStrings);
 
             var smsaPrincipals = new List<TypedPrincipal>();
             if (entry.TryGetArrayProperty(LDAPProperties.HostServiceAccount, out var hsa)) {
@@ -814,6 +768,30 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             return supportedEncryptionTypes;
+        }
+        
+        private async Task<(string[] sidHistoryStrings, TypedPrincipal[] sidHistoryPrincipals)> 
+            ProcessSidHistory(byte[][] sidHistory, string domain) {
+            var sidHistoryList = new List<string>();
+            var sidHistoryPrincipals = new List<TypedPrincipal>();
+                
+            if (sidHistory == null) return ([], []);
+                
+            foreach (var sid in sidHistory) {
+                string sSid;
+                try { 
+                    sSid = new SecurityIdentifier(sid, 0).Value;
+                } catch {
+                    continue;
+                }
+                        
+                sidHistoryList.Add(sSid);
+                        
+                if (await _utils.ResolveIDAndType(sSid, domain) is (true, var res))
+                    sidHistoryPrincipals.Add(res);
+            }
+                
+            return (sidHistoryList.ToArray(), sidHistoryPrincipals.Distinct().ToArray());
         }
 
         private static string ConvertNanoDuration(long duration) {

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.DirectoryServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -173,6 +172,26 @@ namespace CommonLibTest
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
             Assert.False((bool)test["admincount"]);
+        }
+
+        [WindowsOnlyFact]
+        public async Task LDAPPropertyProcessor_ReadGroupProperties_Returns_HasSIDHistory()
+        {
+            var sid = new SecurityIdentifier("S-1-5-21-3130019616-2776909439-2417379446-519");
+            byte[] bytes = new byte[sid.BinaryLength];
+            sid.GetBinaryForm(bytes, 0);
+            var mock = new MockDirectoryObject("CN\u003dDomain Admins,CN\u003dUsers,DC\u003dtestlab,DC\u003dlocal",
+                new Dictionary<string, object>
+                {
+                    {"description", "Test"},
+                    {LDAPProperties.SIDHistory, new byte[][] { bytes }},
+                }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
+            var processor = new LdapPropertyProcessor(new MockLdapUtils());
+
+            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            Assert.NotEmpty(groupProperties.SidHistory);
+            Assert.Equal("S-1-5-21-3130019616-2776909439-2417379446-519", groupProperties.SidHistory[0].ObjectIdentifier);
+            Assert.Equal(Label.Group, groupProperties.SidHistory[0].ObjectType);
         }
 
         [Fact]

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -120,7 +120,7 @@ namespace CommonLibTest
         }
 
         [Fact]
-        public void LDAPPropertyProcessor_ReadGroupProperties_TestGoodData()
+        public async Task LDAPPropertyProcessor_ReadGroupProperties_TestGoodData()
         {
             var mock = new MockDirectoryObject("CN\u003dDomain Admins,CN\u003dUsers,DC\u003dtestlab,DC\u003dlocal",
                 new Dictionary<string, object>
@@ -128,8 +128,10 @@ namespace CommonLibTest
                     {"description", "Test"},
                     {"admincount", "1"}
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
+            var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var test = LdapPropertyProcessor.ReadGroupProperties(mock);
+            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
@@ -137,7 +139,7 @@ namespace CommonLibTest
         }
 
         [Fact]
-        public void LDAPPropertyProcessor_ReadGroupProperties_TestGoodData_FalseAdminCount()
+        public async Task LDAPPropertyProcessor_ReadGroupProperties_TestGoodData_FalseAdminCount()
         {
             var mock = new MockDirectoryObject("CN\u003dDomain Admins,CN\u003dUsers,DC\u003dtestlab,DC\u003dlocal",
                 new Dictionary<string, object>
@@ -145,8 +147,10 @@ namespace CommonLibTest
                     {"description", "Test"},
                     {"admincount", "0"}
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
+            var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var test = LdapPropertyProcessor.ReadGroupProperties(mock);
+            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);
@@ -154,15 +158,17 @@ namespace CommonLibTest
         }
 
         [Fact]
-        public void LDAPPropertyProcessor_ReadGroupProperties_NullAdminCount()
+        public async Task LDAPPropertyProcessor_ReadGroupProperties_NullAdminCount()
         {
             var mock = new MockDirectoryObject("CN\u003dDomain Admins,CN\u003dUsers,DC\u003dtestlab,DC\u003dlocal",
                 new Dictionary<string, object>
                 {
                     {"description", "Test"}
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
+            var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var test = LdapPropertyProcessor.ReadGroupProperties(mock);
+            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
             Assert.Contains("admincount", test.Keys);

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -129,7 +129,7 @@ namespace CommonLibTest
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var groupProperties = await processor.ReadGroupPropertiesAsync(mock, "domain");
             var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
@@ -148,7 +148,7 @@ namespace CommonLibTest
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var groupProperties = await processor.ReadGroupPropertiesAsync(mock, "domain");
             var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
@@ -166,7 +166,7 @@ namespace CommonLibTest
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var groupProperties = await processor.ReadGroupPropertiesAsync(mock, "domain");
             var test = groupProperties.Props;
             Assert.Contains("description", test.Keys);
             Assert.Equal("Test", test["description"] as string);
@@ -188,7 +188,7 @@ namespace CommonLibTest
                 }, "S-1-5-21-3130019616-2776909439-2417379446-512","");
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
 
-            var groupProperties = await processor.ReadGroupProperties(mock, "domain");
+            var groupProperties = await processor.ReadGroupPropertiesAsync(mock, "domain");
             Assert.NotEmpty(groupProperties.SidHistory);
             Assert.Equal("S-1-5-21-3130019616-2776909439-2417379446-519", groupProperties.SidHistory[0].ObjectIdentifier);
             Assert.Equal(Label.Group, groupProperties.SidHistory[0].ObjectType);


### PR DESCRIPTION
## Description

This change alters the interface for ReadGroupProperties causing a breaking change. However, this change alters the method return type to include sidhistory as well as the array HasSIDHistory, both newly collected information for groups.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves [BED-4881](https://specterops.atlassian.net/browse/BED-4881)

## How Has This Been Tested?

This has been tested by compiling this and running collection on a lab that has a group with SidHistory. This value was collected and the array HasSIDHistory was populated.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-4881]: https://specterops.atlassian.net/browse/BED-4881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying SID history for groups, allowing users to view previous security identifiers associated with a group.

* **Bug Fixes**
  * Improved group property retrieval to handle SID history and related attributes more robustly.

* **Tests**
  * Updated and added new tests to validate retrieval and display of SID history for groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->