### PR TITLE
[BED-5972] Make Adaptive Timeout time-spike safety valve thread-safe

### DIFF
--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -220,8 +220,12 @@ public sealed class AdaptiveTimeout : IDisposable {
         }
     }
 
+    private bool UseAdaptiveTimeout() {
+        return _useAdaptiveTimeout && _sampler.Count >= _minSamplesForAdaptiveTimeout;
+    }
+
     // AI-generated code
-    // Effects:
+    // Effectively accomplishes:
     // // Interlocked.Add(ref location, -decrement);
     // // Interlocked.Exchange(ref location, Math.Max(floor, location));
     // But since the above doesn't guarnantee atomicity, we need to be more clever.
@@ -231,17 +235,33 @@ public sealed class AdaptiveTimeout : IDisposable {
     // If it fails for any reason (race condition), it does all this again
     // until it wins the race.
     // This is however supposedly still much faster than using lock objects.
-    private void AtomicDecrementWithFloor(ref int location, int decrement, int floor = 0) {
+    // // Example:
+    /*
+        // target == 0
+        // 1: this thread
+        // 2: interceding thread
+        
+        1: do {
+        1: var initialVal = target;
+        2: target = 2;
+        1: var computedVal = Math.Max(0, initialVal - 1);   // computedVal == 0
+        1: } while (target != initialVal);
+
+        // target changed midway thru the op (2 != 0) and so isn't changed by CompareExchange, retry loop:
+
+        1: var initialVal = target; // 2
+        1: var computedVal = Math.Max(0, initialVal - 1);   // computedVal == 1
+        1: } while (target != initialVal);
+
+        // target (2) == initialVal (2), assign target to 1 and exit loop
+    */
+    public static void AtomicDecrementWithFloor(ref int target, int decrement, int floor = 0) {
         int initialValue, computedValue;
         do {
-            initialValue = Volatile.Read(ref location);
+            initialValue = Volatile.Read(ref target);
             computedValue = Math.Max(floor, initialValue - decrement);
         }
-        while (Interlocked.CompareExchange(ref location, computedValue, initialValue) != initialValue);
-    }
-
-
-    private bool UseAdaptiveTimeout() {
-        return _useAdaptiveTimeout && _sampler.Count >= _minSamplesForAdaptiveTimeout;
+        // If target is modified by another thread between initialValue assignment and now, continue loop
+        while (Interlocked.CompareExchange(ref target, computedValue, initialValue) != initialValue);
     }
 }

--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -202,12 +202,11 @@ public sealed class AdaptiveTimeout : IDisposable {
     // so we should create a safety valve in case this happens to reset our data samples
     private void TimeSpikeSafetyValve(bool isSuccess) {
         if (isSuccess) {
-            Interlocked.Add(ref _clearSamplesDecay, -TimeSpikeForgiveness);
-            Interlocked.Exchange(ref _clearSamplesDecay, Math.Max(0, _clearSamplesDecay));
+            AtomicDecrementWithFloor(ref _clearSamplesDecay, TimeSpikeForgiveness);
         }
         else {
             Interlocked.Add(ref _clearSamplesDecay, TimeSpikePenalty);
-            
+
             if (_clearSamplesDecay >= ClearSamplesThreshold) {
                 if (UseAdaptiveTimeout()) {
                     ClearSamples();
@@ -220,6 +219,27 @@ public sealed class AdaptiveTimeout : IDisposable {
             }
         }
     }
+
+    // AI-generated code
+    // Effects:
+    // // Interlocked.Add(ref location, -decrement);
+    // // Interlocked.Exchange(ref location, Math.Max(floor, location));
+    // But since the above doesn't guarnantee atomicity, we need to be more clever.
+    // This method will continually check the very latest value in <location>,
+    // compute the new expected value after the decrement,
+    // and try to replace <location> with this new value.
+    // If it fails for any reason (race condition), it does all this again
+    // until it wins the race.
+    // This is however supposedly still much faster than using lock objects.
+    private void AtomicDecrementWithFloor(ref int location, int decrement, int floor = 0) {
+        int initialValue, computedValue;
+        do {
+            initialValue = Volatile.Read(ref location);
+            computedValue = Math.Max(floor, initialValue - decrement);
+        }
+        while (Interlocked.CompareExchange(ref location, computedValue, initialValue) != initialValue);
+    }
+
 
     private bool UseAdaptiveTimeout() {
         return _useAdaptiveTimeout && _sampler.Count >= _minSamplesForAdaptiveTimeout;

--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -38,7 +38,7 @@ public sealed class AdaptiveTimeout : IDisposable {
     }
 
     public void ClearSamples() {
-        _clearSamplesDecay = 0;
+        Interlocked.Exchange(ref _clearSamplesDecay, 0);
         _sampler.ClearSamples();
     }
 
@@ -198,24 +198,25 @@ public sealed class AdaptiveTimeout : IDisposable {
     // AdaptiveTimeout will not respond well to rapid spikes in execution time
     // imagine the wrapped function very regularly executes in 10ms
     // then suddenly starts taking a regular 100ms
-    // this is fine (if it fits in our max timeout budget), and we shouldn't block
+    // this is fine (if it fits in our max timeout budget), and we shouldn't timeout
     // so we should create a safety valve in case this happens to reset our data samples
     private void TimeSpikeSafetyValve(bool isSuccess) {
         if (isSuccess) {
-            _clearSamplesDecay -= TimeSpikeForgiveness;
-            _clearSamplesDecay = Math.Max(0, _clearSamplesDecay);
+            Interlocked.Add(ref _clearSamplesDecay, -TimeSpikeForgiveness);
+            Interlocked.Exchange(ref _clearSamplesDecay, Math.Max(0, _clearSamplesDecay));
         }
-        else
-            _clearSamplesDecay += TimeSpikePenalty;
-
-
-        if (_clearSamplesDecay >= ClearSamplesThreshold) {
-            if (UseAdaptiveTimeout()) {
-                ClearSamples();
-                _log.LogTrace("Time spike safety valve event at timeout {CurrentTimeout}.", GetAdaptiveTimeout());
-            }
-            else {
-                _log.LogWarning("This call is frequently running over the maximum allowed timeout of {MaxTimeout}.", _maxTimeout);
+        else {
+            Interlocked.Add(ref _clearSamplesDecay, TimeSpikePenalty);
+            
+            if (_clearSamplesDecay >= ClearSamplesThreshold) {
+                if (UseAdaptiveTimeout()) {
+                    ClearSamples();
+                    _log.LogTrace("Time spike safety valve event at timeout {CurrentTimeout}.", GetAdaptiveTimeout());
+                }
+                else {
+                    _log.LogWarning("This call is frequently running over the maximum allowed timeout of {MaxTimeout}.", _maxTimeout);
+                    Interlocked.Exchange(ref _clearSamplesDecay, 0);
+                }
             }
         }
     }

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using SharpHoundCommonLib;
@@ -65,5 +66,25 @@ public class AdaptiveTimeoutTest {
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
         Assert.Equal(maxTimeout, adaptiveTimeoutResult);
+    }
+
+    [Fact]
+    public void AdaptiveTimeout_AtomicDecrementWithFloor_IsThreadSafe()
+    {
+        int value = 1000;
+        int decrement = 1;
+        int threads = 10;
+        int decrementsPerThread = 100;
+        int updated = 0;
+
+        Parallel.For(0, threads, i =>
+        {
+            for (int j = 0; j < decrementsPerThread; j++)
+            {
+                AdaptiveTimeout.AtomicDecrementWithFloor(ref value, decrement, 0);
+            }
+        });
+
+        Assert.Equal(1000 - threads * decrementsPerThread, updated);
     }
 }

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using SharpHoundCommonLib;
@@ -75,7 +74,6 @@ public class AdaptiveTimeoutTest {
         int decrement = 1;
         int threads = 10;
         int decrementsPerThread = 100;
-        int updated = 0;
 
         Parallel.For(0, threads, i =>
         {
@@ -85,6 +83,6 @@ public class AdaptiveTimeoutTest {
             }
         });
 
-        Assert.Equal(1000 - threads * decrementsPerThread, updated);
+        Assert.Equal(1000 - threads * decrementsPerThread, value);
     }
 }


### PR DESCRIPTION
## Description
We're seeing a great number of "This call is frequently running over the maximum allowed timeout" warnings in our logs - far more than expected, and seemingly untethered from recorded data.  I suspect race conditions regarding `_clearSamplesDecay`, so we'll go ahead and make that thread-safe.

## Motivation and Context
BED-5972

## How Has This Been Tested?
Tests, local

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and thread safety in adaptive timeout handling, reducing the risk of race conditions during time spike penalty and forgiveness operations.  
* **Tests**
  * Added a new test to ensure thread safety of the adaptive timeout decrement operation under concurrent conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->