### PR TITLE
feat: Publish git-dev nuget package on push to v4

### DIFF
--- a/.github/workflows/git-dev.yml
+++ b/.github/workflows/git-dev.yml
@@ -3,7 +3,7 @@ name: Publish Git-Dev
 on:
   push:
     branches:
-        - v4
+      - v4
 
 jobs:
   nuget:
@@ -52,7 +52,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
-          sleet push ./pkgs
+          sleet push ./pkgs --force
         
   ghpages:
     name: ghpages

--- a/.github/workflows/git-dev.yml
+++ b/.github/workflows/git-dev.yml
@@ -1,0 +1,80 @@
+name: Publish Git-Dev
+
+on:
+  push:
+    branches:
+        - v4
+
+jobs:
+  nuget:
+    name: nuget
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+              7.0.x
+              5.0.x
+
+      - name: Restore Dependencies
+        run: dotnet restore
+
+      - name: Generate Coverage Report
+        run: dotnet test # coverage happens by default
+
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: docfx/coverage/report/
+
+      - name: Pack
+        run: | 
+          mkdir pkgs
+          dotnet pack --no-restore -c Release -p:PackageVersion=git-dev -o ./pkgs
+        
+#      - name: Prep Packages
+#        run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/BloodHoundAD/index.json"
+
+#      - name: Publish to GitHub Packages
+#        run: dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source "github"
+#
+#      - name: Publish NuGet
+#        run: dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_TOKEN }} --skip-duplicate
+        
+      - name: Publish to SpecterOps Packages
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
+        run: |
+          dotnet tool install -g sleet
+          sleet push ./pkgs
+        
+  ghpages:
+    name: ghpages
+    needs: nuget
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Download Coverage Report
+        uses: actions/download-artifact@v4
+        with:
+          name: report
+          path: docfx/coverage/report
+
+      - name: Build Documentation
+        uses: nikeee/docfx-action@v1.0.0
+        with:
+          args: docfx/docfx.json
+
+      - name: Deploy GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/git-dev.yml
+++ b/.github/workflows/git-dev.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Pack
         run: | 
           mkdir pkgs
-          dotnet pack --no-restore -c Release -p:PackageVersion=git-dev -o ./pkgs
+          dotnet pack --no-restore -c Release -p:PackageVersion=0.0.0-git-dev -o ./pkgs
         
 #      - name: Prep Packages
 #        run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/BloodHoundAD/index.json"


### PR DESCRIPTION
## Description
Right now SH and SHE PRs are tightly coupled to SHC latest stable, and so may not build if there are changes in SHC that haven't yet been published.  With more devs on Sharphound now, this lockstep is starting to show us pain.  So let's publish a 'git-dev' nuget package to reflect SHC main (that is, `v4`) that SH and SHE pipeline checks can build against

## Motivation and Context


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Introduced a new automated workflow triggered on the v4 branch that runs tests, generates coverage reports, packages and publishes updates, and deploys documentation to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->