### PR TITLE
feat: AdminSDHolder hash functions - BED-6242

### DIFF
--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -320,7 +320,7 @@ public sealed class AdaptiveTimeout : IDisposable {
         // target == 0
         // 1: this thread
         // 2: interceding thread
-        
+
         1: do {
         1: var initialVal = target;
         2: target = 2;

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -157,7 +157,7 @@ namespace SharpHoundCommonLib.Processors {
                 return IsAdminSDHolderProtected(ntSecurityDescriptor, adminSdHolderHash, objectName);
             }
 
-            return false;
+            return null;
         }
 
         /// <summary>
@@ -309,7 +309,9 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             // Concatenate all ACE strings & DaclProtected status using pure StringBuilder for performance on large DACLs
-            var stringBuilder = new StringBuilder(sortedAces.Count * 50); // Pre-allocate with estimated capacity  TODO: is this a good estimate?
+            // Calculate more accurate capacity based on first ACE or use a conservative estimate
+            var estimatedCapacity = sortedAces.Count > 0 ? sortedAces[0].ToString().Length * sortedAces.Count * 1.2 : 1024;
+            var stringBuilder = new StringBuilder((int)estimatedCapacity);
             bool first = true;
             foreach (var ace in sortedAces)
             {

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -42,6 +42,12 @@ namespace SharpHoundCommonLib.Processors {
             };
         }
 
+        public ACLProcessor(ILdapUtils utils, ILogger log = null)
+        {
+            _utils = utils;
+            _log = log ?? Logging.LogProvider.CreateLogger("ACLProc");
+        }
+
         /// Represents a lightweight Access Control Entry (ACE) used to compute hash values
         /// for AdminSDHolder purposes
         internal class ACEForHashing {
@@ -60,13 +66,6 @@ namespace SharpHoundCommonLib.Processors {
             public override string ToString() {
                 return $"{IdentityReference}|{Rights}|{AccessControlType}|{ObjectType}|{InheritedObjectType}|{InheritanceFlags}";
             }
-        }
-
-
-        public ACLProcessor(ILdapUtils utils, ILogger log = null)
-        {
-            _utils = utils;
-            _log = log ?? Logging.LogProvider.CreateLogger("ACLProc");
         }
 
         /// <summary>

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -173,7 +173,7 @@ namespace SharpHoundCommonLib.Processors {
         public bool? IsAdminSDHolderProtected(byte[] ntSecurityDescriptor, string adminSdHolderHash = null, string objectName = "") {
             bool? isAdminSdHolderProtected = null;
 
-            if (ntSecurityDescriptor == null || string.IsNullOrEmpty(adminSdHolderHash)) {
+            if (ntSecurityDescriptor == null || ntSecurityDescriptor.Length == 0 || string.IsNullOrEmpty(adminSdHolderHash)) {
                 _log.LogDebug("Required input(s) missing for AdminSDHolder hash comparison for object: {Name}", objectName);
                 return isAdminSdHolderProtected;
             }
@@ -246,7 +246,7 @@ namespace SharpHoundCommonLib.Processors {
                 return string.Empty;
             }
 
-            _log.LogDebug("Calculating hash of implicit ACEs for {Name}", objectName);
+            _log.LogInformation("Calculating hash of implicit ACEs for {Name}", objectName);
             var descriptor = _utils.MakeSecurityDescriptor();
 
             try
@@ -263,7 +263,7 @@ namespace SharpHoundCommonLib.Processors {
 
             // Check if DACL is protected
             bool isDaclProtected = descriptor.AreAccessRulesProtected();
-            _log.LogDebug("DACL Protection status for {Name}: {IsProtected}", objectName, isDaclProtected);
+            _log.LogInformation("DACL Protection status for {Name}: {IsProtected}", objectName, isDaclProtected);
 
             // Get all ACEs, including Deny ACEs, but skip inherited ones
             var aceList = new List<ACEForHashing>();

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.DirectoryObjects;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
+using System.Linq;
 
 namespace SharpHoundCommonLib.Processors {
     public class ACLProcessor {
@@ -41,7 +42,29 @@ namespace SharpHoundCommonLib.Processors {
             };
         }
 
-        public ACLProcessor(ILdapUtils utils, ILogger log = null) {
+        /// Represents a lightweight Access Control Entry (ACE) used to compute hash values
+        /// for AdminSDHolder purposes
+        internal class ACEForHashing {
+            public string IdentityReference { get; set; }
+            public ActiveDirectoryRights Rights { get; set; }
+            public AccessControlType AccessControlType { get; set; }
+            public string ObjectType { get; set; }
+            public string InheritedObjectType { get; set; }
+            public InheritanceFlags InheritanceFlags { get; set; }
+            /// <summary>
+            /// Converts the object to its string representation, providing a meaningful representation for debugging or display purposes.
+            /// </summary>
+            /// <returns>
+            /// A string that represents the current object.
+            /// </returns>
+            public override string ToString() {
+                return $"{IdentityReference}|{Rights}|{AccessControlType}|{ObjectType}|{InheritedObjectType}|{InheritanceFlags}";
+            }
+        }
+
+
+        public ACLProcessor(ILdapUtils utils, ILogger log = null)
+        {
             _utils = utils;
             _log = log ?? Logging.LogProvider.CreateLogger("ACLProc");
         }
@@ -123,8 +146,58 @@ namespace SharpHoundCommonLib.Processors {
             return descriptor.AreAccessRulesProtected();
         }
 
+        /// <summary>
+        ///     Helper function to use commonlib types in IsAdminSDHolderProtected
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns></returns>
+        public bool? IsAdminSDHolderProtected(IDirectoryObject entry, string adminSdHolderHash = null) {
+            if (entry.TryGetByteProperty(LDAPProperties.SecurityDescriptor, out var ntSecurityDescriptor)) {
+                entry.TryGetDistinguishedName(out var objectName);
+                return IsAdminSDHolderProtected(ntSecurityDescriptor, adminSdHolderHash, objectName);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Determines if the security descriptor is protected by AdminSDHolder by comparing its hash
+        ///     with the AdminSDHolder hash.
+        /// </summary>
+        /// <param name="ntSecurityDescriptor">The security descriptor to check</param>
+        /// <param name="adminSdHolderHash">The AdminSDHolder hash to compare against</param>
+        /// <param name="objectName">The name of the object being checked (for logging)</param>
+        /// <returns>
+        ///     True if protected by AdminSDHolder, False if not protected, or null if the check couldn't be performed
+        /// </returns>
+        public bool? IsAdminSDHolderProtected(byte[] ntSecurityDescriptor, string adminSdHolderHash = null, string objectName = "") {
+            bool? isAdminSdHolderProtected = null;
+
+            if (ntSecurityDescriptor == null || string.IsNullOrEmpty(adminSdHolderHash)) {
+                _log.LogDebug("Required input(s) missing for AdminSDHolder hash comparison for object: {Name}", objectName);
+                return isAdminSdHolderProtected;
+            }
+
+            // Calculate the implicit ACL hash for the current object
+            string currentObjectHash = CalculateImplicitACLHash(ntSecurityDescriptor, objectName);
+
+            // If we got a valid hash, check if it matches this domain's AdminSDHolder hash
+            if (!string.IsNullOrEmpty(currentObjectHash)) {
+                _log.LogDebug("Comparing ACL hash {Hash} with AdminSDHolder hashes for {Name}",
+                    currentObjectHash, objectName);
+                isAdminSdHolderProtected = adminSdHolderHash.Equals(currentObjectHash, StringComparison.OrdinalIgnoreCase);
+
+                if (isAdminSdHolderProtected == true) {
+                    _log.LogDebug("Object {Name} is protected by AdminSDHolder", objectName);
+                }
+            }
+
+            return isAdminSdHolderProtected;
+        }
+
         internal static string CalculateInheritanceHash(string identityReference, ActiveDirectoryRights rights,
-            string aceType, string inheritedObjectType) {
+            string aceType, string inheritedObjectType)
+        {
             var hash = identityReference + rights + aceType + inheritedObjectType;
             /*
              * We're using SHA1 because its fast and this data isn't cryptographically important.
@@ -161,30 +234,147 @@ namespace SharpHoundCommonLib.Processors {
         }
 
         /// <summary>
+        /// Calculates a hash of all implicit (non-inherited) ACEs in the security descriptor and the ACL protection status
+        /// </summary>
+        /// <param name="ntSecurityDescriptor">The raw security descriptor bytes</param>
+        /// <param name="objectName">Optional name for logging purposes</param>
+        /// <returns>A SHA1 hash of the concatenated implicit ACEs + IsACLProtected, or empty string if error</returns>
+        public string CalculateImplicitACLHash(byte[] ntSecurityDescriptor, string objectName = "")
+        {
+            if (ntSecurityDescriptor == null) {
+                _log.LogDebug("Security Descriptor is null for {Name}", objectName);
+                return string.Empty;
+            }
+
+            _log.LogDebug("Calculating hash of implicit ACEs for {Name}", objectName);
+            var descriptor = _utils.MakeSecurityDescriptor();
+
+            try
+            {
+                descriptor.SetSecurityDescriptorBinaryForm(ntSecurityDescriptor);
+            }
+            catch (OverflowException)
+            {
+                _log.LogWarning(
+                    "Security descriptor on object {Name} exceeds maximum allowable length. Unable to process",
+                    objectName);
+                return string.Empty;
+            }
+
+            // Check if DACL is protected
+            bool isDaclProtected = descriptor.AreAccessRulesProtected();
+            _log.LogDebug("DACL Protection status for {Name}: {IsProtected}", objectName, isDaclProtected);
+
+            // Get all ACEs, including Deny ACEs, but skip inherited ones
+            var aceList = new List<ACEForHashing>();
+
+            foreach (var ace in descriptor.GetAccessRules(true, false, typeof(SecurityIdentifier))) {
+                if (ace == null) {
+                    continue; // Skip null ACEs
+                }
+
+                var ir = ace.IdentityReference();
+                if (ir == null) {
+                    _log.LogDebug("Skipping ACE with null identity reference for {Name}", objectName);
+                    continue;
+                }
+
+                // Create a simplified representation of the ACE for consistent ordering and hashing
+                // No filtering of principals - include all principals in the hash calculation
+                aceList.Add(new ACEForHashing
+                {
+                    IdentityReference = ir,
+                    Rights = ace.ActiveDirectoryRights(),
+                    AccessControlType = ace.AccessControlType(),
+                    ObjectType = ace.ObjectType().ToString().ToLower(),
+                    InheritedObjectType = ace.InheritedObjectType().ToString().ToLower(),
+                    InheritanceFlags = ace.InheritanceFlags,
+                });
+            }
+            // TODO: From here through the end of the method I'm not sure this is the most efficient path forward.
+            // Using an IComparer to sort and then instead of string comparison consider serializing data to a byte array
+
+            // Sort the ACEs to ensure consistent ordering
+            var sortedAces = aceList.OrderBy(a => a.AccessControlType)
+                                   .ThenBy(a => a.IdentityReference)
+                                   .ThenBy(a => a.Rights)
+                                   .ThenBy(a => a.ObjectType)
+                                   .ThenBy(a => a.InheritedObjectType)
+                                   .ThenBy(a => a.InheritanceFlags)
+                                   .ToList();
+
+            if (sortedAces.Count == 0) {
+                _log.LogDebug("No implicit ACEs found for {Name}", objectName);
+                return string.Empty;
+            }
+
+            // Concatenate all ACE strings & DaclProtected status using pure StringBuilder for performance on large DACLs
+            var stringBuilder = new StringBuilder(sortedAces.Count * 50); // Pre-allocate with estimated capacity  TODO: is this a good estimate?
+            bool first = true;
+            foreach (var ace in sortedAces)
+            {
+                if (!first)
+                    stringBuilder.Append(';');
+                else
+                    first = false;
+                stringBuilder.Append(ace.ToString());
+            }
+            stringBuilder.Append("|DaclProtected:");
+            stringBuilder.Append(isDaclProtected);
+            var concatenatedAces = stringBuilder.ToString();
+
+
+            // Calculate SHA1 hash of the concatenated string
+            try
+            {
+                /*
+                * We're using SHA1 because its fast and this data isn't cryptographically important.
+                * Additionally, the chances of a collision in our data size is miniscule and irrelevant.
+                * We cannot use MD5 as it is not FIPS compliant and environments can enforce this setting
+                */
+                using var sha1 = SHA1.Create();
+                var bytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(concatenatedAces));
+                return BitConverter.ToString(bytes).Replace("-", string.Empty).ToUpper();
+            }
+            catch (Exception ex)
+            {
+                _log.LogWarning("Error calculating SHA1 hash for {Name}: {Error}", objectName, ex.Message);
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
         /// Gets the hashes for all aces that are pushing inheritance down the tree for later comparison
         /// </summary>
         /// <param name="ntSecurityDescriptor"></param>
         /// <param name="objectName"></param>
         /// <returns></returns>
-        public IEnumerable<string> GetInheritedAceHashes(byte[] ntSecurityDescriptor, string objectName = "") {
-            if (ntSecurityDescriptor == null) {
+        public IEnumerable<string> GetInheritedAceHashes(byte[] ntSecurityDescriptor, string objectName = "")
+        {
+            if (ntSecurityDescriptor == null)
+            {
                 yield break;
             }
-            
+
             _log.LogDebug("Processing Inherited ACE hashes for {Name}", objectName);
             var descriptor = _utils.MakeSecurityDescriptor();
-            try {
+            try
+            {
                 descriptor.SetSecurityDescriptorBinaryForm(ntSecurityDescriptor);
-            } catch (OverflowException) {
+            }
+            catch (OverflowException)
+            {
                 _log.LogWarning(
                     "Security descriptor on object {Name} exceeds maximum allowable length. Unable to process",
                     objectName);
                 yield break;
             }
 
-            foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier))) {
+            foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier)))
+            {
                 //Skip all null/deny/inherited aces
-                if (ace == null || ace.AccessControlType() == AccessControlType.Deny || ace.IsInherited()) {
+                if (ace == null || ace.AccessControlType() == AccessControlType.Deny || ace.IsInherited())
+                {
                     continue;
                 }
 
@@ -192,12 +382,14 @@ namespace SharpHoundCommonLib.Processors {
                 var principalSid = Helpers.PreProcessSID(ir);
 
                 //Skip aces for filtered principals
-                if (principalSid == null) {
+                if (principalSid == null)
+                {
                     continue;
                 }
 
                 var iFlags = ace.InheritanceFlags;
-                if (iFlags == InheritanceFlags.None) {
+                if (iFlags == InheritanceFlags.None)
+                {
                     continue;
                 }
 
@@ -652,7 +844,7 @@ namespace SharpHoundCommonLib.Processors {
 
                     var cARights = (CertificationAuthorityRights)aceRights;
 
-                    // TODO: These if statements are also present in ProcessRegistryEnrollmentPermissions. Move to shared location.               
+                    // TODO: These if statements are also present in ProcessRegistryEnrollmentPermissions. Move to shared location.
                     if ((cARights & CertificationAuthorityRights.ManageCA) != 0)
                         yield return new ACE {
                             PrincipalType = resolvedPrincipal.ObjectType,
@@ -740,7 +932,7 @@ namespace SharpHoundCommonLib.Processors {
                     objectName);
                 yield break;
             }
-            
+
             _log.LogDebug("Processing GMSA Readers for {ObjectName}", objectName);
             foreach (var ace in descriptor.GetAccessRules(true, true, typeof(SecurityIdentifier))) {
                 if (ace == null || ace.AccessControlType() == AccessControlType.Deny) {

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -120,7 +120,7 @@ namespace SharpHoundCommonLib.Processors {
             }
             props.Add("functionallevel", FunctionalLevelToString((int)functionalLevel));
 
-            if (entry.TryGetProperty(LDAPProperties.PrincipalName, out var principalname)) {          
+            if (entry.TryGetProperty(LDAPProperties.PrincipalName, out var principalname)) {
                 if (!string.IsNullOrEmpty(principalname) && principalname.IndexOf('\\') > 0) {
                     var netBios = principalname.Split('\\')[0];
                     props.Add("netbios", netBios);
@@ -364,6 +364,9 @@ namespace SharpHoundCommonLib.Processors {
 
             var encryptionTypes = ConvertEncryptionTypes(entry.GetProperty(LDAPProperties.SupportedEncryptionTypes));
             props.Add("supportedencryptiontypes", encryptionTypes);
+
+            entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);
+            props.Add("admincount", ac != 0);
 
             var comps = new List<TypedPrincipal>();
             if (flags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
@@ -939,7 +942,7 @@ namespace SharpHoundCommonLib.Processors {
             IS_TEXT_UNICODE_NOT_UNICODE_MASK = 0x0F00,
             IS_TEXT_UNICODE_NOT_ASCII_MASK = 0xF000
         }
-        
+
         private async Task SendComputerStatus(CSVComputerStatus status) {
             if (ComputerStatusEvent is not null) await ComputerStatusEvent.Invoke(status);
         }

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.DirectoryServices;
 using System.Linq;
@@ -1392,25 +1391,33 @@ namespace CommonLibTest {
 
         [Fact]
         public void Test_ACLProcessor_IsACLProtected_Protected() {
+            // Setup
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(true);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
+            // Act
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var result = processor.IsACLProtected(Array.Empty<byte>());
+
+            // Assert
             Assert.True(result);
         }
 
         [Fact]
         public void Test_ACLProcessor_IsACLProtected_NotProtected() {
+            // Setup
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(false);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
 
+            // Act
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var result = processor.IsACLProtected(Array.Empty<byte>());
+
+            // Assert
             Assert.False(result);
         }
 
@@ -1436,16 +1443,9 @@ namespace CommonLibTest {
         public void ACLProcessor_CalculateImplicitACLHash_DifferentInputs_ProducesUniqueHashes()
         {
             // Setup
-            var expectedPrincipalType = Label.CertTemplate;
-            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var expectedRightName = EdgeNames.WritePKINameFlag;
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
-            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
             var proc = new ACLProcessor(mockLDAPUtils.Object);
 
             // Act
@@ -1458,49 +1458,31 @@ namespace CommonLibTest {
             Assert.NotEqual(protectedResult, adminsdResult);
         }
 
-        [Fact]
-        public async Task ACLProcessor_NullAdminSDHolderHash_Returns_Null_Bool()
+        [WindowsOnlyFact]
+        public void ACLProcessor_NullAdminSDHolderHash_Returns_Null_Bool()
         {
             // Setup
-            var expectedPrincipalType = Label.CertTemplate;
-            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var expectedRightName = EdgeNames.WritePKINameFlag;
             var mockLDAPUtils = new Mock<ILdapUtils>();
-            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
-            var collection = new List<ActiveDirectoryRuleDescriptor>();
-            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
-            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
-            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
-            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
-            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.PKINameFlag));
-            collection.Add(mockRule.Object);
-            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-                .Returns(collection);
-            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
-            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
             var proc = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(AdminSDHolderSecurityDescriptor);
 
             // Act
             bool? isAdminSdHolderProtected = proc.IsAdminSDHolderProtected(bytes, null, "");
+
             // Assert
             Assert.Null(isAdminSdHolderProtected);
         }
 
 
         [WindowsOnlyFact]
-        public async Task ACLProcessor_AdminSDHolderHash_Returns_Match()
+        public void ACLProcessor_AdminSDHolderHash_Returns_Match()
         {
             // Setup
             const string hash = "EA7A6279E3018DE6A19EE5554850292F92B293AE";
             var expectedPrincipalType = Label.CertTemplate;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var expectedRightName = EdgeNames.WritePKINameFlag;
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
@@ -1513,6 +1495,7 @@ namespace CommonLibTest {
 
             // Act
             bool? isAdminSdHolderProtected = proc.IsAdminSDHolderProtected(bytes, hash, "");
+
             // Assert
             Assert.True(isAdminSdHolderProtected);
         }

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.DirectoryServices;
 using System.Linq;
@@ -30,6 +31,9 @@ namespace CommonLibTest {
 
         private const string AddMemberSecurityDescriptor =
             "AQAEjGADAAAAAAAAAAAAABQAAAAEAEwDFQAAAAUAOAAIAAAAAQAAAMB5lr/mDdARooUAqgAwSeIBBQAAAAAABRUAAAAgT5C6f0aEpXZIFpAuCgAABQA4ACAAAAABAAAAwHmWv+YN0BGihQCqADBJ4gEFAAAAAAAFFQAAACBPkLp/RoSldkgWkEcIAAAFACwAEAAAAAEAAAAdsalGrmBaQLfo/4pY1FbSAQIAAAAAAAUgAAAAMAIAAAUAKAAAAQAAAQAAAFUacqsvHtARmBkAqgBAUpsBAQAAAAAABQsAAAAAACQA/wEPAAEFAAAAAAAFFQAAACBPkLp/RoSldkgWkAACAAAAABgA/wEPAAECAAAAAAAFIAAAACQCAAAAABQAlAACAAEBAAAAAAAFCgAAAAAAFACUAAIAAQEAAAAAAAULAAAAAAAUAP8BDwABAQAAAAAABRIAAAAFGjgAEAAAAAMAAABtnsa3xyzSEYVOAKDJg/YIhnqWv+YN0BGihQCqADBJ4gEBAAAAAAAFCQAAAAUSOAAQAAAAAwAAAG2exrfHLNIRhU4AoMmD9gicepa/5g3QEaKFAKoAMEniAQEAAAAAAAUJAAAABRo4ABAAAAADAAAAbZ7Gt8cs0hGFTgCgyYP2CLp6lr/mDdARooUAqgAwSeIBAQAAAAAABQkAAAAFGjgAIAAAAAMAAACTexvqSF7VRrxsTfT9p4o1hnqWv+YN0BGihQCqADBJ4gEBAAAAAAAFCgAAAAUaLACUAAIAAgAAABTMKEg3FLxFmwetbwFeXygBAgAAAAAABSAAAAAqAgAABRIsAJQAAgACAAAAnHqWv+YN0BGihQCqADBJ4gECAAAAAAAFIAAAACoCAAAFGiwAlAACAAIAAAC6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUSKAAwAAAAAQAAAOXDeD+a971GoLidGBFt3HkBAQAAAAAABQoAAAAFEigAMAEAAAEAAADeR+aRb9lwS5VX1j/088zYAQEAAAAAAAUKAAAAABIkAP8BDwABBQAAAAAABRUAAAAgT5C6f0aEpXZIFpAHAgAAABIYAAQAAAABAgAAAAAABSAAAAAqAgAAABIYAL0BDwABAgAAAAAABSAAAAAgAgAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAA==";
+
+        private const string AdminSDHolderSecurityDescriptor =
+            "AQAEnIgEAAAAAAAAAAAAABQAAAAEAHQEGAAAAAUAPAAQAAAAAwAAAABCFkzAINARp2gAqgBuBSkUzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAABCFkzAINARp2gAqgBuBSm6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAABAgIF+ledARkCAAwE/C1M8UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAABAgIF+ledARkCAAwE/C1M+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEDCCrypedARkCAAwE/C1M8UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEDCCrypedARkCAAwE/C1M+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEIvulmiedARkCAAwE/C088UzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAEIvulmiedARkCAAwE/C08+6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAPiIcAPhCtIRtCIAoMlo+TkUzChINxS8RZsHrW8BXl8oAQIAAAAAAAUgAAAAKgIAAAUAPAAQAAAAAwAAAPiIcAPhCtIRtCIAoMlo+Tm6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAOAAwAAAAAQAAAH96lr/mDdARooUAqgAwSeIBBQAAAAAABRUAAAA3CBKblDpjlFZfZz8FAgAABQAsABAAAAABAAAAHbGpRq5gWkC36P+KWNRW0gECAAAAAAAFIAAAADACAAAFACwAMAAAAAEAAAAcmrZtIpTREa69AAD4A2fBAQIAAAAAAAUgAAAAMQIAAAUALAAwAAAAAQAAAGK8BVjJvShEpeKFag9MGF4BAgAAAAAABSAAAAAxAgAABQAsAJQAAgACAAAAFMwoSDcUvEWbB61vAV5fKAECAAAAAAAFIAAAACoCAAAFACwAlAACAAIAAAC6epa/5g3QEaKFAKoAMEniAQIAAAAAAAUgAAAAKgIAAAUAKAAAAQAAAQAAAFMacqsvHtARmBkAqgBAUpsBAQAAAAAAAQAAAAAFACgAAAEAAAEAAABTGnKrLx7QEZgZAKoAQFKbAQEAAAAAAAUKAAAABQIoADABAAABAAAA3kfmkW/ZcEuVV9Y/9PPM2AEBAAAAAAAFCgAAAAAAJAC/AQ4AAQUAAAAAAAUVAAAANwgSm5Q6Y5RWX2c/AAIAAAAAJAC/AQ4AAQUAAAAAAAUVAAAANwgSm5Q6Y5RWX2c/BwIAAAAAGAC/AQ8AAQIAAAAAAAUgAAAAIAIAAAAAFACUAAIAAQEAAAAAAAULAAAAAAAUAP8BDwABAQAAAAAABRIAAAABBQAAAAAABRUAAAA3CBKblDpjlFZfZz8AAgAA";
 
         private readonly ACLProcessor _baseProcessor;
 
@@ -218,7 +222,7 @@ namespace CommonLibTest {
             mock.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(AsyncEnumerable.Empty<LdapResult<IDirectoryObject>>());
             var processor = new ACLProcessor(mock.Object);
-            
+
             var result = await processor.ProcessACL(null, _testDomainName, Label.User, false).ToArrayAsync();
 
             Assert.Empty(result);
@@ -530,7 +534,7 @@ namespace CommonLibTest {
             mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
             mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
             mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(expectedRightName);
-            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteTitle)); 
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.WriteTitle));
             collection.Add(mockRule.Object);
 
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
@@ -734,7 +738,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_Self_AllGuid() {
             var expectedPrincipalType = Label.Group;
@@ -773,7 +777,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_NoAddSelfEdge() {
             var expectedPrincipalType = Label.Group;
@@ -1283,7 +1287,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_LAPS_Computer() {
             var expectedPrincipalType = Label.Group;
@@ -1308,7 +1312,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            
+
             //Return a directory object from pagedquery for the schemaid to simulate LAPS
             var searchResults = new[]
             {
@@ -1373,7 +1377,7 @@ namespace CommonLibTest {
             var result = processor.GetInheritedAceHashes(Array.Empty<byte>()).ToArray();
             Assert.Single(result);
         }
-        
+
         [Fact]
         public void Test_ACLInheritanceHashSame() {
             const string expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
@@ -1382,55 +1386,158 @@ namespace CommonLibTest {
                 ActiveDirectoryRights.GenericWrite, new Guid(ACEGuids.WriteAllowedToAct).ToString(), g);
             var result2 = ACLProcessor.CalculateInheritanceHash(expectedPrincipalSID,
                 ActiveDirectoryRights.GenericWrite, new Guid(ACEGuids.WriteAllowedToAct).ToString(), g);
-            
+
             Assert.Equal(result1, result2);
         }
-        
+
         [Fact]
         public void Test_ACLProcessor_IsACLProtected_Protected() {
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(true);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-            
+
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var result = processor.IsACLProtected(Array.Empty<byte>());
             Assert.True(result);
         }
-        
+
         [Fact]
         public void Test_ACLProcessor_IsACLProtected_NotProtected() {
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             mockSecurityDescriptor.Setup(x => x.AreAccessRulesProtected()).Returns(false);
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-            
+
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var result = processor.IsACLProtected(Array.Empty<byte>());
             Assert.False(result);
         }
-        
+
+        [WindowsOnlyFact]
+        public void ACLProcessor_CalculateImplicitACLHash_ValidInput_ReturnsCorrectHash()
+        {
+            // Setup
+            const string expectedHash = "EA7A6279E3018DE6A19EE5554850292F92B293AE";
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
+            var proc = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AdminSDHolderSecurityDescriptor);
+
+            // Act
+            var result = proc.CalculateImplicitACLHash(bytes);
+
+            // Assert
+            Assert.Equal(expectedHash, result);
+        }
+
+        [WindowsOnlyFact]
+        public void ACLProcessor_CalculateImplicitACLHash_DifferentInputs_ProducesUniqueHashes()
+        {
+            // Setup
+            var expectedPrincipalType = Label.CertTemplate;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.WritePKINameFlag;
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var proc = new ACLProcessor(mockLDAPUtils.Object);
+
+            // Act
+            var protectedBytes = Utils.B64ToBytes(ProtectedUserNTSecurityDescriptor);
+            var protectedResult = proc.CalculateImplicitACLHash(protectedBytes, "testProtectedUser");
+            var adminsdBytes = Utils.B64ToBytes(AdminSDHolderSecurityDescriptor);
+            var adminsdResult = proc.CalculateImplicitACLHash(adminsdBytes, "testUnprotectedUser");
+
+            // Assert
+            Assert.NotEqual(protectedResult, adminsdResult);
+        }
+
+        [Fact]
+        public async Task ACLProcessor_NullAdminSDHolderHash_Returns_Null_Bool()
+        {
+            // Setup
+            var expectedPrincipalType = Label.CertTemplate;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.WritePKINameFlag;
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
+            var collection = new List<ActiveDirectoryRuleDescriptor>();
+            mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Allow);
+            mockRule.Setup(x => x.IsAceInheritedFrom(It.IsAny<string>())).Returns(true);
+            mockRule.Setup(x => x.IdentityReference()).Returns(expectedPrincipalSID);
+            mockRule.Setup(x => x.ActiveDirectoryRights()).Returns(ActiveDirectoryRights.GenericWrite);
+            mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.PKINameFlag));
+            collection.Add(mockRule.Object);
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns(collection);
+            mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var proc = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AdminSDHolderSecurityDescriptor);
+
+            // Act
+            bool? isAdminSdHolderProtected = proc.IsAdminSDHolderProtected(bytes, null, "");
+            // Assert
+            Assert.Null(isAdminSdHolderProtected);
+        }
+
+
+        [WindowsOnlyFact]
+        public async Task ACLProcessor_AdminSDHolderHash_Returns_Match()
+        {
+            // Setup
+            const string hash = "EA7A6279E3018DE6A19EE5554850292F92B293AE";
+            var expectedPrincipalType = Label.CertTemplate;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var expectedRightName = EdgeNames.WritePKINameFlag;
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
+            mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
+            mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var proc = new ACLProcessor(mockLDAPUtils.Object);
+            var bytes = Utils.B64ToBytes(AdminSDHolderSecurityDescriptor);
+
+            // Act
+            bool? isAdminSdHolderProtected = proc.IsAdminSDHolderProtected(bytes, hash, "");
+            // Assert
+            Assert.True(isAdminSdHolderProtected);
+        }
+
         [Fact]
         public async Task ACLProcessor_ProcessGMSAReaders_SetSecurityDescriptorBinaryForm_Catch() {
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
             var collection = new List<ActiveDirectoryRuleDescriptor>();
-        
+
             mockRule.Setup(x => x.AccessControlType()).Returns(AccessControlType.Deny);
             collection.Add(mockRule.Object);
-        
+
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.SetSecurityDescriptorBinaryForm(It.IsAny<byte[]>())).Throws(new OverflowException());
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-        
+
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(GMSAProperty);
             var result = await processor.ProcessGMSAReaders(bytes, _testDomainName).ToArrayAsync();
             Assert.Empty(result);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_CertTemplate_PKINameFlag()
         {
@@ -1469,7 +1576,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_ExtendedRight_Domain_DSReplicationGetChangesInFilteredSet() {
             var expectedPrincipalType = Label.Group;
@@ -1510,7 +1617,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_User_WriteSPN()
         {
@@ -1627,7 +1734,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_OU_WriteGPLink()
         {
@@ -1705,7 +1812,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_Computer_AddKeyPrincipal()
         {
@@ -1744,7 +1851,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_CertTemplate_PKIEnrollmentFlag()
         {
@@ -1783,14 +1890,14 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_LAPS_CertTemplate_AllGuid()
         {
             var expectedPrincipalType = Label.Group;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
             var expectedRightName = EdgeNames.AllExtendedRights;
-            
+
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
@@ -1808,7 +1915,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            
+
             //Return a directory object from pagedquery for the schemaid to simulate LAPS
             var searchResults = new[]
             {
@@ -1840,7 +1947,7 @@ namespace CommonLibTest {
             var expectedPrincipalType = Label.Group;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
             var expectedRightName = EdgeNames.Enroll;
-            
+
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
@@ -1858,7 +1965,7 @@ namespace CommonLibTest {
             mockLDAPUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
             mockLDAPUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            
+
             //Return a directory object from pagedquery for the schemaid to simulate LAPS
             var searchResults = new[]
             {
@@ -1883,7 +1990,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_GenericWrite_EnterpriseCA()
         {
@@ -1922,7 +2029,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_EnterpriseCA_ManageCA()
         {
@@ -1961,7 +2068,7 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_EnterpriseCA_ManageCertificates()
         {
@@ -2000,14 +2107,14 @@ namespace CommonLibTest {
             Assert.False(actual.IsInherited);
             Assert.Equal(actual.RightName, expectedRightName);
         }
-        
+
         [Fact]
         public async Task ACLProcessor_ProcessACL_EnterpriseCA_Enroll()
         {
             var expectedPrincipalType = Label.EnterpriseCA;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
             var expectedRightName = EdgeNames.Enroll;
-        
+
             var mockLDAPUtils = new Mock<ILdapUtils>();
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
             var mockRule = new Mock<ActiveDirectoryRuleDescriptor>(MockBehavior.Loose, null);
@@ -2018,7 +2125,7 @@ namespace CommonLibTest {
             mockRule.Setup(x => x.ActiveDirectoryRights()).Returns((ActiveDirectoryRights)CertificationAuthorityRights.Enroll);
             mockRule.Setup(x => x.ObjectType()).Returns(new Guid(ACEGuids.AllGuid));
             collection.Add(mockRule.Object);
-        
+
             mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
                 .Returns(collection);
             mockSecurityDescriptor.Setup(m => m.GetOwner(It.IsAny<Type>())).Returns((string)null);
@@ -2027,11 +2134,11 @@ namespace CommonLibTest {
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             mockLDAPUtils.Setup(x => x.PagedQuery(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
                 .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
-        
+
             var processor = new ACLProcessor(mockLDAPUtils.Object);
             var bytes = Utils.B64ToBytes(UnProtectedUserNtSecurityDescriptor);
             var result = await processor.ProcessACL(bytes, _testDomainName, Label.EnterpriseCA, true).ToArrayAsync();
-        
+
             Assert.Single(result);
             var actual = result.First();
             Assert.Equal(actual.PrincipalType, expectedPrincipalType);


### PR DESCRIPTION
- Add class to represent ACE for hashing
- Add method to calculate SHA1 hash of authoritative SD
- Add method to determine if the SD hash of the provided object matches the AdminSDHolder SD hash and set 'adminsdholderprotected' if true
- Add adminCount property to Computer nodes
- Add mock tests

Resolves BED-6221

## Description

These SharpHoundCommon feature updates implement features required by SharpHound and SharpHoundEnterprise to produce the `adminsdholderprotected` property on user, computer, and group nodes as part of the AdminSDHolder design.

Adds 2 methods to ACLProcessor class:
- generate a SHA1 hash of an authoritative security descriptor (which consists of the SD flags and implicit ACEs in the DACL)
- compare a provided hash for the AdminSDHolder container for the domain with the user, group, or computer node being processed to determine if `adminsdholderprotected` should be set to true or false

Added tests to ACLProcessorTests.

Added `admincount` property to computer nodes as computers and computer-derived objects like (g/d)MSAs can be protected by AdminSDHolder.

## Motivation and Context

This code lays the foundation for SharpHound and SharpHoundEnterprise to set the `adminsdholderprotected` property, which will then enable graph expansion for AdminSDHolder in BloodHound and ultimately better findings in BHE.

Issue: https://specterops.atlassian.net/browse/BED-6178

This PR needs to be merged into a SharpHoundCommon version update prior to corresponding PRs for SharpHound and SharpHoundEnterprise being merged.  Those PRs should correspond to a BHCE and BHE version update with the graph expansion changes.

## How Has This Been Tested?

Code was first tested using debug functionality in Rider.

Code was tested as part of custom builds of both SharpHound and SharpHound Enterprise from the corresponding BED-6178 branches in my home lab environment using multiple AD forests configured for AdminSDHolder research.  Code was also tested as part of SharpHound FOSS by Jonas in the Dev GOAD Azure lab.

Tests in ACLProcessorTests are largely Windows-specific.  All tests were performed on a Windows 11 PC in Rider and via dotnet test:
<img width="1189" height="852" alt="image" src="https://github.com/user-attachments/assets/ec84a15c-2b03-47f3-b57b-04a73454154b" />

All tests were also performed in my WSL2 dev instance, but windows-specific tests were skipped:
<img width="2402" height="784" alt="image" src="https://github.com/user-attachments/assets/5fa811e9-3e0b-43f4-98ed-abde12273efa" />

I also tested this SharpHoundCommon version with the main branch of SharpHound FOSS of version 2.6.7 before rebasing to 2.7.0.  In that test in my lab environment there were no negative effects of running this SHC version with a SharpHound FOSS version that does not explicitly support it as none of the methods were called.
 
I also tested SharpHoundEnterprise with a bhe-dev environment running on my BED-6178 branch.  The SHDelegator is running in my home lab and provided accurate data to the bhe-dev build.

## Screenshots (if appropriate):

## Types of changes

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [X] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of AdminSDHolder protection via hash comparison in ACL processing.
  * Introduced calculation of implicit ACL hashes for security descriptors.
  * Added retrieval and processing of the AdminCount LDAP property for computer objects.

* **Bug Fixes**
  * Corrected minor formatting and whitespace issues in various components.

* **Tests**
  * Added new tests for AdminSDHolder protection detection and ACL hash calculation to ensure accuracy and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->