### PR TITLE
fix: Stagger threads in Adaptive Timeout tests where necessary ...

### DIFF
--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Exceptions;
@@ -65,8 +64,10 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3; i++) {
             await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200));
+            await Task.Delay(i);
+        }
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
         Assert.Equal(maxTimeout, adaptiveTimeoutResult);
@@ -112,8 +113,19 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 20; i++)
+        for (int i = 0; i < 15; i++) {
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
+            // Staggering these tasks because TimeSpikeSafetyValve is not entirely atomic.
+            // There's no guarantee that _timeSpikeDecay can't change between the moment it's read to the moment it's modified
+            // So too many concurrent reads may cause a race condition that bungles the process.
+            // In this case I suspect the cure is worse than the illness though,
+            // as I'm less worried about a little bit of wiggle in this process
+            // than I am about the additional overhead of guaranteeing atomicity through memory locks
+            // on a process that I want to run very very fast.
+            // So instead of making TimeSpikeSafetyValve more thread safe than it is now,
+            // I think I'd rather leave that hole and hack some thread stagger in this test.
+            await Task.Delay(i);
+        }
 
         await Assert.ThrowsAsync<ExcessiveTimeoutsException>(async () => await Task.WhenAll(tasks));
     }

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -87,8 +87,10 @@ public class AdaptiveTimeoutTest {
         await Task.WhenAll(tasks);
 
         // Add some timeout tasks that will resolve last
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3; i++) {
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
+            await Task.Delay(i + 5);
+        }
 
         // These tasks are added later but will resolve first
         for (int i = 0; i < 4; i++)
@@ -142,8 +144,10 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 20; i++)
+        for (int i = 0; i < 15; i++) {
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
+            await Task.Delay(i + 5);
+        }
 
         await Task.WhenAll(tasks);
     }

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -66,7 +66,7 @@ public class AdaptiveTimeoutTest {
 
         for (int i = 0; i < 3; i++) {
             await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200));
-            await Task.Delay(i);
+            await Task.Delay(i + 5);
         }
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
@@ -124,7 +124,7 @@ public class AdaptiveTimeoutTest {
             // on a process that I want to run very very fast.
             // So instead of making TimeSpikeSafetyValve more thread safe than it is now,
             // I think I'd rather leave that hole and hack some thread stagger in this test.
-            await Task.Delay(i);
+            await Task.Delay(i + 5);
         }
 
         await Assert.ThrowsAsync<ExcessiveTimeoutsException>(async () => await Task.WhenAll(tasks));


### PR DESCRIPTION
…to dodge around potential race conditions that we're not interested in fixing.

## Description
We've seen one instance where test `AdaptiveTimeout_GetAdaptiveTimeout_ThrowWhenExcessiveTimeouts` was flaky, presumably due to a race condition where concurrent reads were fooled by queued writes because we don't guarantee atomicity between.

We don't mind a little bit of "wiggle" on this process however, and I suspect the cure is worse than the illness in cost of overhead on a method that we'd like to run very very quickly, so without evidence that this is happening regularly, I'd rather "hack" around the race condition by staggering tasks in test.

Appropriate comments have been added to communicate this choice.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of timeout-related unit tests by introducing staggered delays between task executions.
  * Reduced the number of iterations in one test to enhance stability and mitigate potential race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->