### PR TITLE
fix: Adaptive Timeout tests are too optimistic about runtime capabilities

### DIFF
--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -66,7 +66,7 @@ public class AdaptiveTimeoutTest {
 
         for (int i = 0; i < 3; i++) {
             await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200));
-            await Task.Delay(i + 5);
+            await Task.Delay(i * 5);
         }
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
@@ -77,24 +77,22 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_TimeSpikeSafetyValve_IgnoreHiccup() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromMilliseconds(100);
-        var numSamples = 10;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 5);
+        var numSamples = 5;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2);
 
         // Prepare our successful samples
         for (int i = 0; i < numSamples; i++)
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(i)));
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
 
         await Task.WhenAll(tasks);
 
         // Add some timeout tasks that will resolve last
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 3; i++)
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
-            await Task.Delay(i + 5);
-        }
 
         // These tasks are added later but will resolve first
         for (int i = 0; i < 4; i++)
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(i)));
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
 
         await Task.WhenAll(tasks);
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
@@ -107,11 +105,11 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_ThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromMilliseconds(100);
-        var numSamples = 10;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 5, throwIfExcessiveTimeouts: true);
+        var numSamples = 5;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: true);
 
         for (int i = 0; i < numSamples; i++)
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(10)));
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
 
         await Task.WhenAll(tasks);
 
@@ -126,7 +124,7 @@ public class AdaptiveTimeoutTest {
             // on a process that I want to run very very fast.
             // So instead of making TimeSpikeSafetyValve more thread safe than it is now,
             // I think I'd rather leave that hole and hack some thread stagger in this test.
-            await Task.Delay(i + 5);
+            await Task.Delay(i * 5);
         }
 
         await Assert.ThrowsAsync<ExcessiveTimeoutsException>(async () => await Task.WhenAll(tasks));
@@ -136,17 +134,17 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_DoNotThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromMilliseconds(100);
-        var numSamples = 10;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 5, throwIfExcessiveTimeouts: false);
+        var numSamples = 5;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: false);
 
         for (int i = 0; i < numSamples; i++)
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(10)));
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
 
         await Task.WhenAll(tasks);
 
         for (int i = 0; i < 15; i++) {
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
-            await Task.Delay(i + 5);
+            await Task.Delay(i * 5);
         }
 
         await Task.WhenAll(tasks);

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -64,10 +64,8 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 3; i++) {
-            await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200));
-            await Task.Delay(i * 5);
-        }
+        for (int i = 0; i < 3; i++)
+            await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(500));
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
         Assert.Equal(maxTimeout, adaptiveTimeoutResult);

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -76,7 +76,7 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_TimeSpikeSafetyValve_IgnoreHiccup() {
         var tasks = new List<Task>();
-        var maxTimeout = TimeSpan.FromMilliseconds(100);
+        var maxTimeout = TimeSpan.FromSeconds(1);
         var numSamples = 5;
         var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2);
 
@@ -87,8 +87,8 @@ public class AdaptiveTimeoutTest {
         await Task.WhenAll(tasks);
 
         // Add some timeout tasks that will resolve last
-        for (int i = 0; i < 3; i++)
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
+        for (int i = 0; i < 5; i++)
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(2000)));
 
         // These tasks are added later but will resolve first
         for (int i = 0; i < 4; i++)
@@ -104,7 +104,7 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_ThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
-        var maxTimeout = TimeSpan.FromMilliseconds(100);
+        var maxTimeout = TimeSpan.FromMilliseconds(500);
         var numSamples = 5;
         var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: true);
 
@@ -113,19 +113,8 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 15; i++) {
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
-            // Staggering these tasks because TimeSpikeSafetyValve is not entirely atomic.
-            // There's no guarantee that _timeSpikeDecay can't change between the moment it's read to the moment it's modified
-            // So too many concurrent reads may cause a race condition that bungles the process.
-            // In this case I suspect the cure is worse than the illness though,
-            // as I'm less worried about a little bit of wiggle in this process
-            // than I am about the additional overhead of guaranteeing atomicity through memory locks
-            // on a process that I want to run very very fast.
-            // So instead of making TimeSpikeSafetyValve more thread safe than it is now,
-            // I think I'd rather leave that hole and hack some thread stagger in this test.
-            await Task.Delay(i * 5);
-        }
+        for (int i = 0; i < 20; i++)
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(1000)));
 
         await Assert.ThrowsAsync<ExcessiveTimeoutsException>(async () => await Task.WhenAll(tasks));
     }
@@ -133,7 +122,7 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_DoNotThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
-        var maxTimeout = TimeSpan.FromMilliseconds(100);
+        var maxTimeout = TimeSpan.FromMilliseconds(500);
         var numSamples = 5;
         var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: false);
 
@@ -142,10 +131,8 @@ public class AdaptiveTimeoutTest {
 
         await Task.WhenAll(tasks);
 
-        for (int i = 0; i < 15; i++) {
-            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(200)));
-            await Task.Delay(i * 5);
-        }
+        for (int i = 0; i < 20; i++)
+            tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(1000)));
 
         await Task.WhenAll(tasks);
     }


### PR DESCRIPTION
## Description
Trying to minimize concurrency in adaptive timeout tests because atm I'd still rather hack the tests to be more robust against these race conditions than use a `lock` if I don't have to.

In fact when testing with `lock`, we learned that it's a non-starter - it slows this process far too significantly to be a viable solution.

Instead I've found my tests are too optimistic about runtime capabilities, so we're baking in some more generous time windows.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated adaptive timeout test scenarios with new timing parameters, simplified task delays, and adjusted sample sizes and thresholds to improve test clarity and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->