### PR TITLE
chore: tone down logging in adminsdholder functions

### DIFF
--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -182,12 +182,12 @@ namespace SharpHoundCommonLib.Processors {
 
             // If we got a valid hash, check if it matches this domain's AdminSDHolder hash
             if (!string.IsNullOrEmpty(currentObjectHash)) {
-                _log.LogDebug("Comparing ACL hash {Hash} with AdminSDHolder hashes for {Name}",
+                _log.LogTrace("Comparing ACL hash {Hash} with AdminSDHolder hashes for {Name}",
                     currentObjectHash, objectName);
                 isAdminSdHolderProtected = adminSdHolderHash.Equals(currentObjectHash, StringComparison.OrdinalIgnoreCase);
 
                 if (isAdminSdHolderProtected == true) {
-                    _log.LogDebug("Object {Name} is protected by AdminSDHolder", objectName);
+                    _log.LogTrace("Object {Name} is protected by AdminSDHolder", objectName);
                 }
             }
 
@@ -245,7 +245,7 @@ namespace SharpHoundCommonLib.Processors {
                 return string.Empty;
             }
 
-            _log.LogInformation("Calculating hash of implicit ACEs for {Name}", objectName);
+            _log.LogTrace("Calculating hash of implicit ACEs for {Name}", objectName);
             var descriptor = _utils.MakeSecurityDescriptor();
 
             try
@@ -262,7 +262,7 @@ namespace SharpHoundCommonLib.Processors {
 
             // Check if DACL is protected
             bool isDaclProtected = descriptor.AreAccessRulesProtected();
-            _log.LogInformation("DACL Protection status for {Name}: {IsProtected}", objectName, isDaclProtected);
+            _log.LogTrace("DACL Protection status for {Name}: {IsProtected}", objectName, isDaclProtected);
 
             // Get all ACEs, including Deny ACEs, but skip inherited ones
             var aceList = new List<ACEForHashing>();


### PR DESCRIPTION
Resolves: BED-6242

## Description

Logging level for AdminSDHolder  functions was too verbose.  Moved several log entries down to LogTrace.  Trace is the lower level of logging from debug.

0 Trace
1 Debug
2 Informational

## Motivation and Context

I had a lot of logging built in and had been testing SharpHound with -v 0 to get the full effect.  Once I tried running with -v 2 I noted that the logging was excessive for debug purposes.

## How Has This Been Tested?

Ran all build tests, passed.
Built and then built SH and SHE with the updated SHC.

Collected data from my lab environment with both SH and SHE.  With SH FOSS I set the log verbosity to -v 2 and the log level was as expected.

## Screenshots (if appropriate):

## Types of changes

-   [X ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

-   [X ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the verbosity of certain internal log messages, resulting in less detailed logs during normal usage. No changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->