### PR TITLE
fix: Fix misnomer in PortScanner timeout log message

### DIFF
--- a/src/CommonLib/Processors/PortScanner.cs
+++ b/src/CommonLib/Processors/PortScanner.cs
@@ -44,7 +44,7 @@ namespace SharpHoundCommonLib.Processors {
                 using var client = new TcpClient();
                 var ca = await _adaptiveTimeout.ExecuteWithTimeout((_) => client.ConnectAsync(hostname, port));
                 if (!ca.IsSuccess) {
-                    _log.LogDebug("{HostName} did not respond to scan on port {Port} within {Timeout}ms", hostname, port, _adaptiveTimeout.GetAdaptiveTimeout());
+                    _log.LogDebug("{HostName} did not respond to scan on port {Port} within {TimeoutMs}ms", hostname, port, _adaptiveTimeout.GetAdaptiveTimeout().TotalMilliseconds);
                     if (throwError) {
                         throw new TimeoutException(ca.Error);
                     }


### PR DESCRIPTION
## Description
PortScanner timeout log messages read like "did not respond to scan on port 445 within 00:00:10ms"
Where 00:00:10 is actually 10 seconds.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated debug log messages to display timeout values in milliseconds for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->