### PR TITLE
[BED-6027] - Filter GPOs with Computer Configuration Setting Disabled

### DIFF
--- a/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
@@ -140,7 +140,9 @@ namespace SharpHoundCommonLib.Processors {
                         continue;
                     }
 
-                    if (!result.Value.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var filePath)) {
+                    if (!result.Value.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var filePath) 
+                        // Filter out GPOs that are disabled or the computer configuration is disabled
+                        || result.Value.TryGetProperty(LDAPProperties.Flags, out var flags) && flags is "2" or "3") {
                         GpoActionCache.TryAdd(linkDn, actions);
                         continue;
                     }

--- a/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/GPOLocalGroupProcessor.cs
@@ -131,7 +131,7 @@ namespace SharpHoundCommonLib.Processors {
                     var result = await _utils.Query(new LdapQueryParameters() {
                         LDAPFilter = new LdapFilter().AddAllObjects().GetFilter(),
                         SearchScope = SearchScope.Base,
-                        Attributes = CommonProperties.GPCFileSysPath,
+                        Attributes = [LDAPProperties.GPCFileSYSPath, LDAPProperties.Flags],
                         SearchBase = linkDn,
                         DomainName = gpoDomain
                     }).DefaultIfEmpty(LdapResult<IDirectoryObject>.Fail()).FirstOrDefaultAsync();
@@ -140,9 +140,9 @@ namespace SharpHoundCommonLib.Processors {
                         continue;
                     }
 
-                    if (!result.Value.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var filePath) 
+                    if (!result.Value.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var filePath) || 
                         // Filter out GPOs that are disabled or the computer configuration is disabled
-                        || result.Value.TryGetProperty(LDAPProperties.Flags, out var flags) && flags is "2" or "3") {
+                        (result.Value.TryGetProperty(LDAPProperties.Flags, out var flags) && flags is "2" or "3")) {
                         GpoActionCache.TryAdd(linkDn, actions);
                         continue;
                     }

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -165,9 +165,25 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
             entry.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var path);
             props.Add("gpcpath", path.ToUpper());
+            entry.TryGetProperty(LDAPProperties.Flags, out var flags);
+            props.Add("gpostatus", TranslateGPOFlag(flags));
             return props;
         }
 
+        private static string TranslateGPOFlag(string flag) {
+            switch (flag) {
+                case "0":
+                    return "Enabled";
+                case "1":
+                    return "User configuration disabled";
+                case "2":
+                    return "Computer configuration disabled";
+                case "3":
+                default:
+                    return "Disabled";
+            }
+        }
+        
         /// <summary>
         ///     Reads specific LDAP properties related to OUs
         /// </summary>

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -166,24 +166,10 @@ namespace SharpHoundCommonLib.Processors {
             entry.TryGetProperty(LDAPProperties.GPCFileSYSPath, out var path);
             props.Add("gpcpath", path.ToUpper());
             entry.TryGetProperty(LDAPProperties.Flags, out var flags);
-            props.Add("gpostatus", TranslateGPOFlag(flags));
+            props.Add("gpostatus", flags);
             return props;
         }
 
-        private static string TranslateGPOFlag(string flag) {
-            switch (flag) {
-                case "0":
-                    return "Enabled";
-                case "1":
-                    return "User configuration disabled";
-                case "2":
-                    return "Computer configuration disabled";
-                case "3":
-                default:
-                    return "Disabled";
-            }
-        }
-        
         /// <summary>
         ///     Reads specific LDAP properties related to OUs
         /// </summary>

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -154,17 +154,21 @@ namespace CommonLibTest {
             Assert.Equal(Label.Computer, actual.ObjectType);
             Assert.Equal("teapot", actual.ObjectIdentifier);
         }
-        
-        [WindowsOnlyFact]
-        public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups_Skip_Disabled_GPOs() {
+
+        [Fact]
+        public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups_Does_Not_Skip_Enabled_And_Skips_Disabled_GPOs() {
+            // Setup
             var mockLDAPUtils = new Mock<ILdapUtils>(MockBehavior.Loose);
             var gpcFileSysPath = Path.GetTempPath();
 
             var groupsXmlPath = Path.Join(gpcFileSysPath, "MACHINE", "Preferences", "Groups", "Groups.xml");
-
-            Path.GetDirectoryName(groupsXmlPath);
             Directory.CreateDirectory(Path.GetDirectoryName(groupsXmlPath));
-            File.WriteAllText(groupsXmlPath, GroupXmlContent);
+            await File.WriteAllTextAsync(groupsXmlPath, GroupXmlContent);
+            
+            var gptTmplPath = Path.Join(gpcFileSysPath, "MACHINE", "Microsoft", "Windows NT", "SecEdit", "GptTmpl.inf");
+            Directory.CreateDirectory(Path.GetDirectoryName(gptTmplPath));
+            await File.WriteAllTextAsync(gptTmplPath, GpttmplInfContent); 
+            
             var mockComputerEntry = new Mock<IDirectoryObject>();
             var mockSearchResultEntry = new Mock<IDirectoryObject>();
             var sid = "teapot";
@@ -178,64 +182,70 @@ namespace CommonLibTest {
                         y.Attributes.Equals(CommonProperties.ObjectSID)),
                     It.IsAny<CancellationToken>())).Returns(mockSearchResults.ToAsyncEnumerable);
             mockComputerEntry.Setup(x => x.TryGetSecurityIdentifier(out sid)).Returns(true);
-            var mockComputerResults = new List<LdapResult<IDirectoryObject>>();
-            mockComputerResults.Add(LdapResult<IDirectoryObject>.Ok(mockComputerEntry.Object));
-
-            var mockGCPFileSysPathEntry = new Mock<IDirectoryObject>();
-            mockGCPFileSysPathEntry.Setup(x => x.TryGetProperty(It.IsAny<string>(), out gpcFileSysPath)).Returns(true);
-            var mockGCPFileSysPathResults = new List<LdapResult<IDirectoryObject>>
-                { LdapResult<IDirectoryObject>.Ok(mockGCPFileSysPathEntry.Object) };
-
-            mockLDAPUtils.SetupSequence(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
-                .Returns(mockComputerResults.ToAsyncEnumerable)
-                .Returns(mockGCPFileSysPathResults.ToAsyncEnumerable)
-                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
-            var domain = MockableDomain.Construct("TESTLAB.LOCAL");
-            mockLDAPUtils.Setup(x => x.GetDomain(out domain)).Returns(true);
-
-            // mockLDAPUtils
-            //     .Setup(x => x.Query(
-            //         It.Is<LdapQueryParameters>(y =>
-            //             y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter())),
-            //         It.IsAny<CancellationToken>()))
-            //     .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
-
+            mockLDAPUtils.Setup(x => x.ResolveAccountName(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal("S-1-5-21-3130019616-2776909439-2417379446-513", Label.User)));
+            
+            // Enabled
+            var mockDirectory0 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
+                "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
+            mockDirectory0.Properties = new Dictionary<string, string>() {
+                { LDAPProperties.GPCFileSYSPath, gpcFileSysPath },
+                { LDAPProperties.Flags, "0"}
+            };
+            var result0 = new List<LdapResult<IDirectoryObject>> {
+                LdapResult<IDirectoryObject>.Ok(mockDirectory0),
+            };
+            // User Configuration Disabled
             var mockDirectory1 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
                 "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
             mockDirectory1.Properties = new Dictionary<string, string>() {
-                { LDAPProperties.GPCFileSYSPath, "filePath1" },
+                { LDAPProperties.GPCFileSYSPath, gpcFileSysPath },
                 { LDAPProperties.Flags, "1"}
             };
             var result1 = new List<LdapResult<IDirectoryObject>> {
                 LdapResult<IDirectoryObject>.Ok(mockDirectory1),
             };
-            
+            // Computer Configuration Disabled -- Skipped
             var mockDirectory2 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
                 "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
             mockDirectory2.Properties = new Dictionary<string, string>() {
-                { LDAPProperties.GPCFileSYSPath, "filePath2" },
+                { LDAPProperties.GPCFileSYSPath, gpcFileSysPath },
                 { LDAPProperties.Flags, "2"}
             };
             var result2 = new List<LdapResult<IDirectoryObject>> {
                 LdapResult<IDirectoryObject>.Ok(mockDirectory2),
             };
+            // Disabled -- Skipped
             var mockDirectory3 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
                 "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
             mockDirectory3.Properties = new Dictionary<string, string>() {
-                { LDAPProperties.GPCFileSYSPath, "filePath3" },
+                { LDAPProperties.GPCFileSYSPath, gpcFileSysPath },
                 { LDAPProperties.Flags, "3"}
             };
             var result3 = new List<LdapResult<IDirectoryObject>> {
                 LdapResult<IDirectoryObject>.Ok(mockDirectory3),
             };
+            
             mockLDAPUtils
                 .Setup(x => x.Query(
                     It.Is<LdapQueryParameters>(y =>
                         y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
                         y.SearchScope.Equals(SearchScope.Base) &&
-                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
+                        y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
+                        y.Attributes.Contains(LDAPProperties.Flags) &&
                         y.SearchBase.Equals("cn=foouser (blah)123/dc=somedomain", StringComparison.OrdinalIgnoreCase) &&
                         y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(result0.ToAsyncEnumerable);
+            mockLDAPUtils
+                .Setup(x => x.Query(
+                    It.Is<LdapQueryParameters>(y =>
+                        y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
+                        y.SearchScope.Equals(SearchScope.Base) &&
+                        y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
+                        y.Attributes.Contains(LDAPProperties.Flags) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("someotherdomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result1.ToAsyncEnumerable);
             mockLDAPUtils
@@ -243,9 +253,10 @@ namespace CommonLibTest {
                     It.Is<LdapQueryParameters>(y =>
                         y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
                         y.SearchScope.Equals(SearchScope.Base) &&
-                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
-                        y.DomainName.Equals("someotherdomain", StringComparison.OrdinalIgnoreCase)),
+                        y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
+                        y.Attributes.Contains(LDAPProperties.Flags) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("somethirddomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result2.ToAsyncEnumerable);
             mockLDAPUtils
@@ -253,28 +264,35 @@ namespace CommonLibTest {
                     It.Is<LdapQueryParameters>(y =>
                         y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
                         y.SearchScope.Equals(SearchScope.Base) &&
-                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
-                        y.DomainName.Equals("somethirddomain", StringComparison.OrdinalIgnoreCase)),
+                        y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
+                        y.Attributes.Contains(LDAPProperties.Flags) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somefourthdomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("somefourthdomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result3.ToAsyncEnumerable);
-
+            
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
-            var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;2;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somethirddomain;2;]";
-            try {
-
-                var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, "DC=Testlab,DC=Local");
-                Assert.Single(result.AffectedComputers);
-                var actual = result.AffectedComputers.First();
-                Assert.Equal(Label.Computer, actual.ObjectType);
-                Assert.Equal("teapot", actual.ObjectIdentifier);
-            }
-            catch (Exception ex) {
-                Console.WriteLine(ex.Message);
-                Assert.True(false);
-            }
-
+            var testGPLinkProperty0 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;]";
+            var testGPLinkProperty1 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;0;]";
+            var testGPLinkProperty2 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somethirddomain;0;]";
+            var testGPLinkProperty3 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somefourthdomain;0;]";
+            
+            // Act
+            var act0 = await processor.ReadGPOLocalGroups(testGPLinkProperty0, "DC=Testlab,DC=Local");
+            var act1 = await processor.ReadGPOLocalGroups(testGPLinkProperty1, "DC=Testlab,DC=Local");
+            var act2 = await processor.ReadGPOLocalGroups(testGPLinkProperty2, "DC=Testlab,DC=Local");
+            var act3 = await processor.ReadGPOLocalGroups(testGPLinkProperty3, "DC=Testlab,DC=Local");
+            
+            // Assert
+            Assert.Single(act0.AffectedComputers);
+            Assert.Single(act1.AffectedComputers);
+            Assert.Single(act2.AffectedComputers);
+            Assert.Single(act3.AffectedComputers);
+            
+            Assert.Single(act0.LocalAdmins);
+            Assert.Single(act1.LocalAdmins);
+            Assert.Empty(act2.LocalAdmins);
+            Assert.Empty(act3.LocalAdmins);
         }
 
         [WindowsOnlyFact]

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -155,9 +155,17 @@ namespace CommonLibTest {
             Assert.Equal("teapot", actual.ObjectIdentifier);
         }
         
-        [Fact]
+        [WindowsOnlyFact]
         public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups_Skip_Disabled_GPOs() {
-            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockLDAPUtils = new Mock<ILdapUtils>(MockBehavior.Loose);
+            var gpcFileSysPath = Path.GetTempPath();
+
+            var groupsXmlPath = Path.Join(gpcFileSysPath, "MACHINE", "Preferences", "Groups", "Groups.xml");
+
+            Path.GetDirectoryName(groupsXmlPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(groupsXmlPath));
+            File.WriteAllText(groupsXmlPath, GroupXmlContent);
+            var mockComputerEntry = new Mock<IDirectoryObject>();
             var mockSearchResultEntry = new Mock<IDirectoryObject>();
             var sid = "teapot";
             mockSearchResultEntry.Setup(x => x.TryGetSecurityIdentifier(out sid)).Returns(true);
@@ -169,6 +177,21 @@ namespace CommonLibTest {
                         y.LDAPFilter.Equals(new LdapFilter().AddComputersNoMSAs().GetFilter()) &&
                         y.Attributes.Equals(CommonProperties.ObjectSID)),
                     It.IsAny<CancellationToken>())).Returns(mockSearchResults.ToAsyncEnumerable);
+            mockComputerEntry.Setup(x => x.TryGetSecurityIdentifier(out sid)).Returns(true);
+            var mockComputerResults = new List<LdapResult<IDirectoryObject>>();
+            mockComputerResults.Add(LdapResult<IDirectoryObject>.Ok(mockComputerEntry.Object));
+
+            var mockGCPFileSysPathEntry = new Mock<IDirectoryObject>();
+            mockGCPFileSysPathEntry.Setup(x => x.TryGetProperty(It.IsAny<string>(), out gpcFileSysPath)).Returns(true);
+            var mockGCPFileSysPathResults = new List<LdapResult<IDirectoryObject>>
+                { LdapResult<IDirectoryObject>.Ok(mockGCPFileSysPathEntry.Object) };
+
+            mockLDAPUtils.SetupSequence(x => x.Query(It.IsAny<LdapQueryParameters>(), It.IsAny<CancellationToken>()))
+                .Returns(mockComputerResults.ToAsyncEnumerable)
+                .Returns(mockGCPFileSysPathResults.ToAsyncEnumerable)
+                .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+            var domain = MockableDomain.Construct("TESTLAB.LOCAL");
+            mockLDAPUtils.Setup(x => x.GetDomain(out domain)).Returns(true);
 
             // mockLDAPUtils
             //     .Setup(x => x.Query(
@@ -222,7 +245,7 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
                         y.SearchBase.Equals("cn=foouser (blah)123/dc=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
-                        y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                        y.DomainName.Equals("someotherdomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result2.ToAsyncEnumerable);
             mockLDAPUtils
@@ -232,19 +255,26 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
                         y.SearchBase.Equals("cn=foouser (blah)123/dc=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
-                        y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                        y.DomainName.Equals("somethirddomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result3.ToAsyncEnumerable);
 
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
             var testGPLinkProperty =
                 "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;2;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somethirddomain;2;]";
-            var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, "DC=Testlab,DC=Local");
+            try {
 
-            Assert.Single(result.AffectedComputers);
-            var actual = result.AffectedComputers.First();
-            Assert.Equal(Label.Computer, actual.ObjectType);
-            Assert.Equal("teapot", actual.ObjectIdentifier);
+                var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, "DC=Testlab,DC=Local");
+                Assert.Single(result.AffectedComputers);
+                var actual = result.AffectedComputers.First();
+                Assert.Equal(Label.Computer, actual.ObjectType);
+                Assert.Equal("teapot", actual.ObjectIdentifier);
+            }
+            catch (Exception ex) {
+                Console.WriteLine(ex.Message);
+                Assert.True(false);
+            }
+
         }
 
         [WindowsOnlyFact]

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -154,6 +154,98 @@ namespace CommonLibTest {
             Assert.Equal(Label.Computer, actual.ObjectType);
             Assert.Equal("teapot", actual.ObjectIdentifier);
         }
+        
+        [Fact]
+        public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups_Skip_Disabled_GPOs() {
+            var mockLDAPUtils = new Mock<ILdapUtils>();
+            var mockSearchResultEntry = new Mock<IDirectoryObject>();
+            var sid = "teapot";
+            mockSearchResultEntry.Setup(x => x.TryGetSecurityIdentifier(out sid)).Returns(true);
+            var mockResult = LdapResult<IDirectoryObject>.Ok(mockSearchResultEntry.Object);
+            var mockSearchResults = new List<LdapResult<IDirectoryObject>> { mockResult };
+            mockLDAPUtils
+                .Setup(x => x.Query(
+                    It.Is<LdapQueryParameters>(y =>
+                        y.LDAPFilter.Equals(new LdapFilter().AddComputersNoMSAs().GetFilter()) &&
+                        y.Attributes.Equals(CommonProperties.ObjectSID)),
+                    It.IsAny<CancellationToken>())).Returns(mockSearchResults.ToAsyncEnumerable);
+
+            // mockLDAPUtils
+            //     .Setup(x => x.Query(
+            //         It.Is<LdapQueryParameters>(y =>
+            //             y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter())),
+            //         It.IsAny<CancellationToken>()))
+            //     .Returns(Array.Empty<LdapResult<IDirectoryObject>>().ToAsyncEnumerable);
+
+            var mockDirectory1 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
+                "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
+            mockDirectory1.Properties = new Dictionary<string, string>() {
+                { LDAPProperties.GPCFileSYSPath, "filePath1" },
+                { LDAPProperties.Flags, "1"}
+            };
+            var result1 = new List<LdapResult<IDirectoryObject>> {
+                LdapResult<IDirectoryObject>.Ok(mockDirectory1),
+            };
+            
+            var mockDirectory2 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
+                "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
+            mockDirectory2.Properties = new Dictionary<string, string>() {
+                { LDAPProperties.GPCFileSYSPath, "filePath2" },
+                { LDAPProperties.Flags, "2"}
+            };
+            var result2 = new List<LdapResult<IDirectoryObject>> {
+                LdapResult<IDirectoryObject>.Ok(mockDirectory2),
+            };
+            var mockDirectory3 = new MockDirectoryObject("CN=Users,DC=testlab,DC=local", null, "",
+                "ECAD920E-8EB1-4E31-A80E-DD36367F81F4");
+            mockDirectory3.Properties = new Dictionary<string, string>() {
+                { LDAPProperties.GPCFileSYSPath, "filePath3" },
+                { LDAPProperties.Flags, "3"}
+            };
+            var result3 = new List<LdapResult<IDirectoryObject>> {
+                LdapResult<IDirectoryObject>.Ok(mockDirectory3),
+            };
+            mockLDAPUtils
+                .Setup(x => x.Query(
+                    It.Is<LdapQueryParameters>(y =>
+                        y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
+                        y.SearchScope.Equals(SearchScope.Base) &&
+                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somedomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(result1.ToAsyncEnumerable);
+            mockLDAPUtils
+                .Setup(x => x.Query(
+                    It.Is<LdapQueryParameters>(y =>
+                        y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
+                        y.SearchScope.Equals(SearchScope.Base) &&
+                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(result2.ToAsyncEnumerable);
+            mockLDAPUtils
+                .Setup(x => x.Query(
+                    It.Is<LdapQueryParameters>(y =>
+                        y.LDAPFilter.Equals(new LdapFilter().AddAllObjects().GetFilter()) &&
+                        y.SearchScope.Equals(SearchScope.Base) &&
+                        y.Attributes.Equals(CommonProperties.GPCFileSysPath) &&
+                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<CancellationToken>()))
+                .Returns(result3.ToAsyncEnumerable);
+
+            var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
+            var testGPLinkProperty =
+                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;2;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somethirddomain;2;]";
+            var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, "DC=Testlab,DC=Local");
+
+            Assert.Single(result.AffectedComputers);
+            var actual = result.AffectedComputers.First();
+            Assert.Equal(Label.Computer, actual.ObjectType);
+            Assert.Equal("teapot", actual.ObjectIdentifier);
+        }
 
         [WindowsOnlyFact]
         public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups() {


### PR DESCRIPTION
## Description

Filter GPOs that are disabled or, computer configuration disabled while doing local group processing. Adding the GPO status as one of the collected properties. 

## Motivation and Context

Resolves [BED-6027](https://specterops.atlassian.net/browse/BED-6027)

## How Has This Been Tested?

This has been tested by running collection in an environment with and without the GPO enabled and monitoring the results of the collection to ensure that the results are affected. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-6027]: https://specterops.atlassian.net/browse/BED-6027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * GPO properties now include a status field (gpostatus) derived from LDAP Flags.

* Bug Fixes
  * Local group processing now skips GPOs that are disabled or have computer configuration disabled, preventing unintended application of settings and improving result accuracy.

* Tests
  * Added a unit test validating that enabled GPOs are applied while disabled or computer-disabled GPOs are skipped, increasing coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->