### PR TITLE
[BED-6389] Add retry logic to GetDomains to make more resilient to network hiccups

### DIFF
--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -340,6 +340,23 @@ namespace SharpHoundCommonLib {
                 }
             } while (!success && attempt < retryCount);
         }
+
+        public static U RetryOnException<T, U>(Func<U> action, int retryCount, ILogger logger = null) where T : Exception {
+            int attempt = 0;
+            do {
+                try {
+                    return action();
+                }
+                catch (T e) {
+                    attempt++;
+                    logger?.LogDebug(e, "Exception caught, retrying attempt {Attempt}", attempt);
+                    if (attempt >= retryCount)
+                        throw;
+                }
+            } while (attempt < retryCount);
+
+            throw new InvalidOperationException($"You really shouldn't be here, {nameof(RetryOnException)} isn't working as intended.");
+        }
     }
 
     public class ParsedGPLink {

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -322,7 +322,7 @@ namespace SharpHoundCommonLib {
 
         public static TimeSpan BackoffWithDecorrelatedJitter(int attempt, TimeSpan baseDelay, TimeSpan maxDelay) {
             // Decorrelated Jitter Backoff - see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-            var temp = Math.Min(maxDelay.Ticks, baseDelay.Ticks * Math.Pow(2, attempt));
+            var temp = Math.Min(maxDelay.Ticks, baseDelay.Ticks * (attempt * attempt));
             temp = temp / 2 + RandomUtils.Between(0, temp / 2);
             var ticksToDelay = Math.Min(maxDelay.Ticks, RandomUtils.Between(baseDelay.Ticks, temp * 3));
             

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -19,6 +19,7 @@ namespace SharpHoundCommonLib {
         private static readonly HashSet<string> Groups = new() { "268435456", "268435457", "536870912", "536870913" };
         private static readonly HashSet<string> Computers = new() { "805306369" };
         private static readonly HashSet<string> Users = new() { "805306368", "805306370" };
+        private static readonly double MaxTimeSpanTicks = (double)TimeSpan.MaxValue.Ticks - 1_000;
 
         private static readonly Regex DCReplaceRegex = new("DC=", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SPNRegex = new(@".*\/.*", RegexOptions.Compiled);
@@ -344,8 +345,10 @@ namespace SharpHoundCommonLib {
             } while (!success && attempt < retryCount);
         }
 
-        public static async Task<U> RetryOnException<T, U>(Func<U> action, int retryCount, ILogger logger = null) where T : Exception {
+        public static async Task<U> RetryOnException<T, U>(Func<U> action, int retryCount, TimeSpan? baseDelay = null, TimeSpan? maxDelay = null, ILogger logger = null) where T : Exception {
             int attempt = 0;
+            baseDelay ??= TimeSpan.FromSeconds(1);
+            maxDelay ??= TimeSpan.FromSeconds(10);
             do {
                 try {
                     return action();
@@ -355,8 +358,15 @@ namespace SharpHoundCommonLib {
                     logger?.LogDebug(e, "Exception caught, retrying attempt {Attempt}", attempt);
                     if (attempt >= retryCount)
                         throw;
-
-                    await Task.Delay(200 * attempt * attempt);
+                    
+                    // Decorrelated Jitter Backoff - see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+                    var temp = RandomUtils.Between(0,
+                        Math.Min(maxDelay.Value.Ticks, baseDelay.Value.Ticks * Math.Pow(2, attempt)));
+                    var ticksToDelay = Math.Min(maxDelay.Value.Ticks, RandomUtils.Between(baseDelay.Value.Ticks, temp * 3));
+                    if (double.IsInfinity(ticksToDelay)) {
+                        await Task.Delay(TimeSpan.FromTicks((long)MaxTimeSpanTicks));
+                    }
+                    await Task.Delay(TimeSpan.FromTicks((long)Math.Min(MaxTimeSpanTicks, ticksToDelay)));
                 }
             } while (attempt < retryCount);
 

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -12,6 +12,7 @@ using System.Security;
 using SharpHoundCommonLib.Processors;
 using Microsoft.Win32;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace SharpHoundCommonLib {
     public static class Helpers {
@@ -337,11 +338,13 @@ namespace SharpHoundCommonLib {
                     logger?.LogDebug(e, "Exception caught, retrying attempt {Attempt}", attempt);
                     if (attempt >= retryCount)
                         throw;
+
+                    await Task.Delay(200 * attempt * attempt);
                 }
             } while (!success && attempt < retryCount);
         }
 
-        public static U RetryOnException<T, U>(Func<U> action, int retryCount, ILogger logger = null) where T : Exception {
+        public static async Task<U> RetryOnException<T, U>(Func<U> action, int retryCount, ILogger logger = null) where T : Exception {
             int attempt = 0;
             do {
                 try {
@@ -352,6 +355,8 @@ namespace SharpHoundCommonLib {
                     logger?.LogDebug(e, "Exception caught, retrying attempt {Attempt}", attempt);
                     if (attempt >= retryCount)
                         throw;
+
+                    await Task.Delay(200 * attempt * attempt);
                 }
             } while (attempt < retryCount);
 

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -320,15 +320,28 @@ namespace SharpHoundCommonLib {
             return builder.ToString();
         }
 
+        public static TimeSpan BackoffWithDecorrelatedJitter(int attempt, TimeSpan baseDelay, TimeSpan maxDelay) {
+            // Decorrelated Jitter Backoff - see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+            var temp = Math.Min(maxDelay.Ticks, baseDelay.Ticks * Math.Pow(2, attempt));
+            temp = temp / 2 + RandomUtils.Between(0, temp / 2);
+            var ticksToDelay = Math.Min(maxDelay.Ticks, RandomUtils.Between(baseDelay.Ticks, temp * 3));
+            
+            // This ensures that a TimeSpan can be created with the ticks amount as TimeSpan uses a long.
+            return double.IsInfinity(ticksToDelay) ? TimeSpan.FromTicks((long)MaxTimeSpanTicks) :
+                TimeSpan.FromTicks((long)Math.Min(MaxTimeSpanTicks, ticksToDelay));
+        }
+
         /// <summary>
         /// Attempt an action a number of times, quietly eating a specific exception until the last attempt if it throws.
         /// </summary>
         /// <param name="action"></param>
         /// <param name="retryCount"></param>
         /// <param name="logger"></param>
-        public static async Task RetryOnException<T>(Func<Task> action, int retryCount, ILogger logger = null) where T : Exception {
+        public static async Task RetryOnException<T>(Func<Task> action, int retryCount, TimeSpan? baseDelay = null, TimeSpan? maxDelay = null, ILogger logger = null) where T : Exception {
             int attempt = 0;
             bool success = false;
+            baseDelay ??= TimeSpan.FromSeconds(1);
+            maxDelay ??= TimeSpan.FromSeconds(30);
             do {
                 try {
                     await action();
@@ -340,7 +353,8 @@ namespace SharpHoundCommonLib {
                     if (attempt >= retryCount)
                         throw;
 
-                    await Task.Delay(200 * attempt * attempt);
+                    var delay = BackoffWithDecorrelatedJitter(attempt, baseDelay.Value, maxDelay.Value);
+                    await Task.Delay(delay);
                 }
             } while (!success && attempt < retryCount);
         }
@@ -348,7 +362,7 @@ namespace SharpHoundCommonLib {
         public static async Task<U> RetryOnException<T, U>(Func<U> action, int retryCount, TimeSpan? baseDelay = null, TimeSpan? maxDelay = null, ILogger logger = null) where T : Exception {
             int attempt = 0;
             baseDelay ??= TimeSpan.FromSeconds(1);
-            maxDelay ??= TimeSpan.FromSeconds(10);
+            maxDelay ??= TimeSpan.FromSeconds(30);
             do {
                 try {
                     return action();
@@ -358,15 +372,8 @@ namespace SharpHoundCommonLib {
                     logger?.LogDebug(e, "Exception caught, retrying attempt {Attempt}", attempt);
                     if (attempt >= retryCount)
                         throw;
-                    
-                    // Decorrelated Jitter Backoff - see https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
-                    var temp = RandomUtils.Between(0,
-                        Math.Min(maxDelay.Value.Ticks, baseDelay.Value.Ticks * Math.Pow(2, attempt)));
-                    var ticksToDelay = Math.Min(maxDelay.Value.Ticks, RandomUtils.Between(baseDelay.Value.Ticks, temp * 3));
-                    if (double.IsInfinity(ticksToDelay)) {
-                        await Task.Delay(TimeSpan.FromTicks((long)MaxTimeSpanTicks));
-                    }
-                    await Task.Delay(TimeSpan.FromTicks((long)Math.Min(MaxTimeSpanTicks, ticksToDelay)));
+                    var delay = BackoffWithDecorrelatedJitter(attempt, baseDelay.Value, maxDelay.Value);
+                    await Task.Delay(delay);
                 }
             } while (attempt < retryCount);
 

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -37,9 +37,6 @@ namespace SharpHoundCommonLib {
         private const int MaxRetries = 3;
         private static readonly ConcurrentDictionary<string, NetAPIStructs.DomainControllerInfo?> DCInfoCache = new();
 
-        // Tracks domains we know we've determined we shouldn't try to connect to
-        private static readonly ConcurrentHashSet _excludedDomains = new();
-
         public LdapConnectionPool(string identifier, string poolIdentifier, LdapConfig config,
             IPortScanner scanner = null, NativeMethods nativeMethods = null, ILogger log = null) {
             _connections = new ConcurrentBag<LdapConnectionWrapper>();
@@ -693,7 +690,7 @@ namespace SharpHoundCommonLib {
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)>
             GetConnectionAsync() {
-            if (_excludedDomains.Contains(_identifier)) {
+            if (LdapUtils.IsExcludedDomain(_identifier)) {
                 return (false, null, $"Identifier {_identifier} excluded for connection attempt");
             }
 
@@ -727,7 +724,7 @@ namespace SharpHoundCommonLib {
 
         public async Task<(bool Success, LdapConnectionWrapper ConnectionWrapper, string Message)>
             GetGlobalCatalogConnectionAsync() {
-            if (_excludedDomains.Contains(_identifier)) {
+            if (LdapUtils.IsExcludedDomain(_identifier)) {
                 return (false, null, $"Identifier {_identifier} excluded for connection attempt");
             }
 
@@ -813,7 +810,7 @@ namespace SharpHoundCommonLib {
                     _log.LogDebug(
                         "Could not get domain object from GetDomain, unable to create ldap connection for domain {Domain}",
                         _identifier);
-                    _excludedDomains.Add(_identifier);
+                    LdapUtils.AddExcludedDomain(_identifier);
                     return (false, null, "Unable to get domain object for further strategies");
                 }
 
@@ -852,7 +849,7 @@ namespace SharpHoundCommonLib {
             catch (Exception e) {
                 _log.LogInformation(e, "We will not be able to connect to domain {Domain} by any strategy, leaving it.",
                     _identifier);
-                _excludedDomains.Add(_identifier);
+                LdapUtils.AddExcludedDomain(_identifier);
             }
 
             return (false, null, "All attempted connections failed");

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -506,7 +506,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2).GetAwaiter().GetResult();
                 if (domain == null) return false;
                 _domainCache.TryAdd(cacheKey, domain);
                 return true;
@@ -535,7 +535,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2).GetAwaiter().GetResult();
                 if (domain == null) return false;
                 _domainCache.TryAdd(domainName, domain);
                 return true;
@@ -565,7 +565,7 @@ namespace SharpHoundCommonLib {
                     : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2).GetAwaiter().GetResult();
                 _domainCache.TryAdd(_nullCacheKey, domain);
                 return true;
             }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -506,7 +506,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
                 if (domain == null) return false;
                 _domainCache.TryAdd(cacheKey, domain);
                 return true;
@@ -535,7 +535,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
                 if (domain == null) return false;
                 _domainCache.TryAdd(domainName, domain);
                 return true;
@@ -565,7 +565,7 @@ namespace SharpHoundCommonLib {
                     : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
+                domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2);
                 _domainCache.TryAdd(_nullCacheKey, domain);
                 return true;
             }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -506,7 +506,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Domain.GetDomain(context);
+                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
                 if (domain == null) return false;
                 _domainCache.TryAdd(cacheKey, domain);
                 return true;
@@ -535,7 +535,7 @@ namespace SharpHoundCommonLib {
                         : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Domain.GetDomain(context);
+                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
                 if (domain == null) return false;
                 _domainCache.TryAdd(domainName, domain);
                 return true;
@@ -565,7 +565,7 @@ namespace SharpHoundCommonLib {
                     : new DirectoryContext(DirectoryContextType.Domain);
 
                 // Blocking External Call
-                domain = Domain.GetDomain(context);
+                domain = Helpers.RetryOnException<Exception, Domain>(() => Domain.GetDomain(context), 2);
                 _domainCache.TryAdd(_nullCacheKey, domain);
                 return true;
             }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -515,9 +515,9 @@ namespace SharpHoundCommonLib {
                 return true;
             }
             catch (Exception e) {
+                // The Static GetDomain Function ran into an issue requiring to exclude a domain as it would continuously 
+                // try to connect to a domain that it could not connect to. This method may also need the same logic. 
                 _log.LogDebug(e, "GetDomain call failed for domain name {Name}", domainName);
-                // TODO: should the domain be excluded here? 
-                // AddExcludedDomain(domainName);
                 domain = null;
                 return false;
             }
@@ -525,6 +525,10 @@ namespace SharpHoundCommonLib {
 
         public static bool GetDomain(string domainName, LdapConfig ldapConfig, out Domain domain) {
             if (_domainCache.TryGetValue(domainName, out domain)) return true;
+            if (IsExcludedDomain(domainName)) {
+                Logging.Logger.LogDebug("Domain: {DomainName} has been excluded for collection. Skipping", domainName);
+                return false;
+            }
 
             try {
                 DirectoryContext context;
@@ -546,9 +550,11 @@ namespace SharpHoundCommonLib {
                 return true;
             }
             catch (Exception e) {
-                Logging.Logger.LogDebug("Static GetDomain call failed for domain {DomainName}: {Error}", domainName,
+                Logging.Logger.LogDebug("Static GetDomain call failed, adding to exclusion, for domain {DomainName}: {Error}", domainName,
                     e.Message);
-                // TODO: should the domain be excluded here? 
+                // If a domain cannot be contacted, this will exclude the domain so that it does not continuously try to connect, and 
+                // cause more timeouts. 
+                AddExcludedDomain(domainName);
                 domain = null;
                 return false;
             }
@@ -576,8 +582,9 @@ namespace SharpHoundCommonLib {
                 return true;
             }
             catch (Exception e) {
+                // The Static GetDomain Function ran into an issue requiring to exclude a domain as it would continuously 
+                // try to connect to a domain that it could not connect to. This method may also need the same logic. 
                 _log.LogDebug(e, "GetDomain call failed for blank domain");
-                // TODO: should the domain be excluded here? 
                 domain = null;
                 return false;
             }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -30,6 +30,9 @@ namespace SharpHoundCommonLib {
         private static ConcurrentDictionary<string, Domain> _domainCache = new();
         private static ConcurrentHashSet _domainControllers = new(StringComparer.OrdinalIgnoreCase);
         private static ConcurrentHashSet _unresolvablePrincipals = new(StringComparer.OrdinalIgnoreCase);
+        
+        // Tracks Domains we know we've determined we shouldn't try to connect to
+        private static ConcurrentHashSet _excludedDomains = new(StringComparer.OrdinalIgnoreCase);
 
         private static readonly ConcurrentDictionary<string, string> DomainToForestCache =
             new(StringComparer.OrdinalIgnoreCase);
@@ -513,6 +516,8 @@ namespace SharpHoundCommonLib {
             }
             catch (Exception e) {
                 _log.LogDebug(e, "GetDomain call failed for domain name {Name}", domainName);
+                // TODO: should the domain be excluded here? 
+                // AddExcludedDomain(domainName);
                 domain = null;
                 return false;
             }
@@ -543,6 +548,7 @@ namespace SharpHoundCommonLib {
             catch (Exception e) {
                 Logging.Logger.LogDebug("Static GetDomain call failed for domain {DomainName}: {Error}", domainName,
                     e.Message);
+                // TODO: should the domain be excluded here? 
                 domain = null;
                 return false;
             }
@@ -571,6 +577,7 @@ namespace SharpHoundCommonLib {
             }
             catch (Exception e) {
                 _log.LogDebug(e, "GetDomain call failed for blank domain");
+                // TODO: should the domain be excluded here? 
                 domain = null;
                 return false;
             }
@@ -1129,6 +1136,7 @@ namespace SharpHoundCommonLib {
             _domainControllers = new ConcurrentHashSet(StringComparer.OrdinalIgnoreCase);
             _connectionPool?.Dispose();
             _connectionPool = new ConnectionPoolManager(_ldapConfig, scanner: _portScanner);
+            _excludedDomains = new ConcurrentHashSet(StringComparer.OrdinalIgnoreCase);
         }
 
         private IDirectoryObject CreateDirectoryEntry(string path) {
@@ -1142,6 +1150,9 @@ namespace SharpHoundCommonLib {
         public void Dispose() {
             _connectionPool?.Dispose();
         }
+
+        public static bool IsExcludedDomain(string domain) => _excludedDomains.Contains(domain);
+        public static void AddExcludedDomain(string domain) => _excludedDomains.Add(domain);
 
         internal static bool ResolveLabel(string objectIdentifier, string distinguishedName, string samAccountType,
             string[] objectClasses, int flags, out Label type) {

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -53,7 +53,7 @@ namespace SharpHoundCommonLib {
         private readonly ILogger _log;
         private readonly IPortScanner _portScanner;
         private readonly NativeMethods _nativeMethods;
-        private readonly string _nullCacheKey = Guid.NewGuid().ToString();
+        private static readonly string _nullCacheKey = Guid.NewGuid().ToString();
         private static readonly Regex SIDRegex = new(@"^(S-\d+-\d+-\d+-\d+-\d+-\d+)(-\d+)?$");
 
         private readonly string[] _translateNames = { "Administrator", "admin" };
@@ -524,9 +524,11 @@ namespace SharpHoundCommonLib {
         }
 
         public static bool GetDomain(string domainName, LdapConfig ldapConfig, out Domain domain) {
+            var cacheKey = domainName ?? _nullCacheKey;
             if (_domainCache.TryGetValue(domainName, out domain)) return true;
             if (IsExcludedDomain(domainName)) {
                 Logging.Logger.LogDebug("Domain: {DomainName} has been excluded for collection. Skipping", domainName);
+                domain = null;
                 return false;
             }
 
@@ -546,7 +548,7 @@ namespace SharpHoundCommonLib {
                 // Blocking External Call
                 domain = Helpers.RetryOnException<ActiveDirectoryObjectNotFoundException, Domain>(() => Domain.GetDomain(context), 2).GetAwaiter().GetResult();
                 if (domain == null) return false;
-                _domainCache.TryAdd(domainName, domain);
+                _domainCache.TryAdd(cacheKey, domain);
                 return true;
             }
             catch (Exception e) {
@@ -554,7 +556,7 @@ namespace SharpHoundCommonLib {
                     e.Message);
                 // If a domain cannot be contacted, this will exclude the domain so that it does not continuously try to connect, and 
                 // cause more timeouts. 
-                AddExcludedDomain(domainName);
+                AddExcludedDomain(cacheKey);
                 domain = null;
                 return false;
             }

--- a/src/CommonLib/RandomUtils.cs
+++ b/src/CommonLib/RandomUtils.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading;
+
+namespace SharpHoundCommonLib;
+
+public static class RandomUtils {
+    private static readonly ThreadLocal<Random> Random = new(() => new Random());
+    
+    public static double NextDouble() => Random.Value.NextDouble();
+    public static double Between(double minValue, double maxValue) => Random.Value.NextDouble() * (maxValue - minValue) + minValue;
+}

--- a/src/CommonLib/RandomUtils.cs
+++ b/src/CommonLib/RandomUtils.cs
@@ -7,5 +7,13 @@ public static class RandomUtils {
     private static readonly ThreadLocal<Random> Random = new(() => new Random());
     
     public static double NextDouble() => Random.Value.NextDouble();
+    public static long NextLong() => LongRandom(long.MinValue, long.MaxValue);
+    private static long LongRandom(long min, long max) {
+        var buf = new byte[8];
+        Random.Value.NextBytes(buf);
+        var longRand = BitConverter.ToInt64(buf, 0);
+        return (Math.Abs(longRand % (max - min)) + min);
+    }
     public static double Between(double minValue, double maxValue) => Random.Value.NextDouble() * (maxValue - minValue) + minValue;
+    public static long Between(long minValue, long maxValue) => LongRandom(minValue, maxValue);
 }

--- a/src/CommonLib/RandomUtils.cs
+++ b/src/CommonLib/RandomUtils.cs
@@ -5,15 +5,16 @@ namespace SharpHoundCommonLib;
 
 public static class RandomUtils {
     private static readonly ThreadLocal<Random> Random = new(() => new Random());
-    
-    public static double NextDouble() => Random.Value.NextDouble();
-    public static long NextLong() => LongRandom(long.MinValue, long.MaxValue);
+
+    public static long NextLong() => LongRandom(0, long.MaxValue);
+
     private static long LongRandom(long min, long max) {
         var buf = new byte[8];
         Random.Value.NextBytes(buf);
         var longRand = BitConverter.ToInt64(buf, 0);
-        return (Math.Abs(longRand % (max - min)) + min);
+        return Math.Abs(longRand % (max - min)) + min;
     }
+    
     public static double Between(double minValue, double maxValue) => Random.Value.NextDouble() * (maxValue - minValue) + minValue;
     public static long Between(long minValue, long maxValue) => LongRandom(minValue, maxValue);
 }

--- a/test/unit/LdapConnectionPoolTest.cs
+++ b/test/unit/LdapConnectionPoolTest.cs
@@ -7,39 +7,16 @@ using Xunit;
 
 public class LdapConnectionPoolTest
 {
-    private static void AddExclusionDomain(string identifier) {
-        var excludedDomainsField = typeof(LdapConnectionPool)
-            .GetField("_excludedDomains", BindingFlags.Static | BindingFlags.NonPublic);
-
-        var excludedDomains = (ConcurrentHashSet)excludedDomainsField.GetValue(null);
-
-        excludedDomains.Add(identifier);
-    }
-
     [Fact]
-    public async Task LdapConnectionPool_ExcludedDomains_ShouldExitEarly()
+    public async Task LdapConnectionPool_Static_GetDomain_Add_To_ExcludedDomains_ShouldExitEarly()
     {
         var mockLogger = new Mock<ILogger>();
         var ldapConfig = new LdapConfig();
         var connectionPool = new ConnectionPoolManager(ldapConfig, mockLogger.Object);
 
-        AddExclusionDomain("excludedDomain.com");
         var connectAttempt = await connectionPool.TestDomainConnection("excludedDomain.com", false);
 
         Assert.False(connectAttempt.Success);
         Assert.Contains("excluded for connection attempt", connectAttempt.Message);
-    }
-
-    [Fact]
-    public async Task LdapConnectionPool_ExcludedDomains_NonExcludedShouldntExit()
-    {
-        var mockLogger = new Mock<ILogger>();
-        var ldapConfig = new LdapConfig();
-        var connectionPool = new ConnectionPoolManager(ldapConfig, mockLogger.Object);
-
-        AddExclusionDomain("excludedDomain.com");
-        var connectAttempt = await connectionPool.TestDomainConnection("perfectlyValidDomain.com", false);
-
-        Assert.DoesNotContain("excluded for connection attempt", connectAttempt.Message);
     }
 }

--- a/test/unit/TimeoutTests.cs
+++ b/test/unit/TimeoutTests.cs
@@ -251,4 +251,21 @@ public class TimeoutTests {
         Assert.False(result.IsSuccess);
         Assert.Equal("Cancellation requested", result.Error);
     }
+    
+    [Theory]
+    [InlineData(0, 2, 30, 2, 6)]
+    [InlineData(5, 2, 200, 1, 192)]
+    [InlineData(5, 5, 500, 5, 480)]
+    [InlineData(0, 2, 1, 1, 1)]
+    [InlineData(5, 2, 1, 1, 1)]
+    [InlineData(5, 2, 2, 2, 2)]
+    [InlineData(5, 30, 30, 30, 30)]
+    public void DecorrelatedTimeSpan_BetweenExpected(int attempt, int baseDelayValue, int maxDelayValue, double expectedLowerBound, double expectedUpperBound) {
+        var baseDelay = TimeSpan.FromTicks(baseDelayValue);
+        var maxDelay = TimeSpan.FromTicks(maxDelayValue);
+        for (var trials = 0; trials < 500; trials++) {
+            var delay = SharpHoundCommonLib.Helpers.BackoffWithDecorrelatedJitter(attempt, baseDelay, maxDelay);
+            Assert.InRange(delay.Ticks, expectedLowerBound, expectedUpperBound);
+        }
+    }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context
When the static GetDomain call fails in CreateNewConnection, that domain is immediately added to the excluded domains list for the remainder of the job.  Maybe this should be a little more forgiving.
https://specterops.atlassian.net/browse/BED-6389

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configurable retry delays with decorrelated jitter, including support for retrying functions that return values.
  - Thread-safe random utilities for generating doubles and longs.

- Improvements
  - Centralized LDAP domain exclusion with early-exit checks and automatic exclusion after failures.
  - Safer delay handling with bounds to prevent overflow.

- Tests
  - Added comprehensive backoff timing tests.
  - Updated LDAP connection pool tests to reflect new exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->