### PR TITLE
Add netlogon reg key

### DIFF
--- a/src/CommonLib/OutputTypes/APIResults/StrRegistryAPIResult.cs
+++ b/src/CommonLib/OutputTypes/APIResults/StrRegistryAPIResult.cs
@@ -1,0 +1,7 @@
+namespace SharpHoundCommonLib.OutputTypes
+{
+    public class StrRegistryAPIResult : APIResult
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/CommonLib/OutputTypes/Computer.cs
+++ b/src/CommonLib/OutputTypes/Computer.cs
@@ -65,6 +65,7 @@ namespace SharpHoundCommonLib.OutputTypes {
     public class DCRegistryData {
         public IntRegistryAPIResult CertificateMappingMethods { get; set; }
         public IntRegistryAPIResult StrongCertificateBindingEnforcement { get; set; }
+        public StrRegistryAPIResult VulnerableNetlogonSecurityDescriptor { get; set; }
     }
 
     public class ComputerStatus {

--- a/src/CommonLib/Processors/DCRegistryProcessor.cs
+++ b/src/CommonLib/Processors/DCRegistryProcessor.cs
@@ -81,5 +81,36 @@ namespace SharpHoundCommonLib.Processors
 
             return ret;
         }
+
+        /// <summary>
+        /// This function gets the VulnerableChannelAllowList registry value stored on DCs.
+        /// </summary>
+        /// <remarks>https://support.microsoft.com/en-us/topic/how-to-manage-the-changes-in-netlogon-secure-channel-connections-associated-with-cve-2020-1472-f7e8cc17-0309-1d6a-304e-5ba73cd1a11e</remarks>
+        /// <param name="target"></param>
+        /// <returns>StrRegistryAPIResult</returns>
+        [ExcludeFromCodeCoverage]
+        public StrRegistryAPIResult GetVulnerableNetlogonSecurityDescriptor(string target)
+        {
+            var ret = new StrRegistryAPIResult();
+            const string subKey = @"SYSTEM\CurrentControlSet\Services\Netlogon\Parameters";
+            const string subValue = "VulnerableChannelAllowList";
+            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+
+            ret.Collected = data.Collected;
+            if (!data.Collected)
+            {
+                ret.FailureReason = data.FailureReason;
+                return ret;
+            }
+
+            if (data.Value == null)
+            {
+                return ret;
+            }
+
+            ret.Value = (string)data.Value;
+
+            return ret;
+        }
     }
 }


### PR DESCRIPTION
## Description

Collect the registry key that holds the security descriptor that determines who can perform the vulnerable version of netlogon

## Motivation and Context

Ticket: BED-6429

## How Has This Been Tested?

Locally in GOAD lab.

## Screenshots (if appropriate):

From corresponding BloodHound PR:
<img width="461" height="106" alt="image" src="https://github.com/user-attachments/assets/d059cd18-7a4b-4ea0-bb9b-25c38a87c0cc" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added retrieval and reporting of the Netlogon security descriptor vulnerability setting from domain controllers.
  - Introduced a new string-based registry result type for API responses to represent registry values as plain text.
  - Extended computer/domain controller registry output to include this string-based configuration value for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->