### PR TITLE
Don't apply adaptive timeouts to LDAP queries

### DIFF
--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -20,10 +20,10 @@ public sealed class AdaptiveTimeout : IDisposable {
     private int _timeSpikeDecay;
     private const int TimeSpikePenalty = 2;
     private const int TimeSpikeForgiveness = 1;
-    private const int TimeSpikeThreshold = 5;
+    private const int TimeSpikeThreshold = 3;
     private const int ExcessiveTimeoutsThreshold = 7;
-    private const int StdDevMultiplier = 5;
-    private const int CountOfLatestSuccessToKeep = 4;
+    private const int StdDevMultiplier = 7; // 7 standard deviations should be a very conservative upper bound
+    private const int CountOfLatestSuccessToKeep = 3;
 
     public AdaptiveTimeout(TimeSpan maxTimeout, ILogger log, int sampleCount = 100, int logFrequency = 1000, int minSamplesForAdaptiveTimeout = 30, bool useAdaptiveTimeout = true, bool throwIfExcessiveTimeouts = false) {
         if (maxTimeout <= TimeSpan.Zero)

--- a/src/CommonLib/LdapConnectionPool.cs
+++ b/src/CommonLib/LdapConnectionPool.cs
@@ -58,9 +58,9 @@ namespace SharpHoundCommonLib {
             _log = log ?? Logging.LogProvider.CreateLogger("LdapConnectionPool");
             _portScanner = scanner ?? new PortScanner();
             _nativeMethods = nativeMethods ?? new NativeMethods();
-            _queryAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapQuery"));
-            _pagedQueryAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapPagedQuery"));
-            _rangedRetrievalAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapRangedRetrieval"));
+            _queryAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapQuery"), useAdaptiveTimeout: false);
+            _pagedQueryAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapPagedQuery"), useAdaptiveTimeout: false);
+            _rangedRetrievalAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("LdapRangedRetrieval"), useAdaptiveTimeout: false);
             _testConnectionAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger("TestLdapConnection"));
         }
 


### PR DESCRIPTION
## Description
LDAP queries are too volatile I suspect in runtime for adaptive timeouts.  By the time backoff logic triggers, retries are already exhausted.
These queries should already be gated by connection checks, so we should be pretty confident that they respond successfully, and so we'll disable adaptive timeouts on them.

## Motivation and Context
https://github.com/SpecterOps/SharpHound/issues/177
Closes BED-6603

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Disabled adaptive timeout adjustments in LDAP connection handling to reduce sporadic delays and premature timeouts.

- Performance
  - Made timeout behavior more predictable and stable for directory lookups; reduced variance in query timing.

- Chores
  - Tuned adaptive-timeout parameters to be more conservative in spike detection and history retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->