### PR TITLE
Bed 6619 collection of objectguid

### DIFF
--- a/src/CommonLib/LdapQueries/CommonProperties.cs
+++ b/src/CommonLib/LdapQueries/CommonProperties.cs
@@ -31,7 +31,7 @@
         {
             LDAPProperties.SAMAccountName, LDAPProperties.DistinguishedName, LDAPProperties.DNSHostName,
             LDAPProperties.SAMAccountType, LDAPProperties.OperatingSystem, LDAPProperties.PasswordLastSet,
-            LDAPProperties.LastLogonTimestamp
+            LDAPProperties.LastLogonTimestamp, LDAPProperties.ObjectGUID
         };
 
         public static readonly string[] ACLProps =

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -440,7 +440,7 @@ namespace SharpHoundCommonLib.Processors {
             if (objectGuidBytes != null)
             {
                 Guid guid = new Guid(objectGuidBytes);
-                props.Add(LDAPProperties.ObjectGUID, guid.ToString());
+                props.Add(LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
             }
 
             compProps.DumpSMSAPassword = smsaPrincipals.ToArray();

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -437,10 +437,17 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             var objectGuidBytes = entry.GetByteProperty(LDAPProperties.ObjectGUID);
-            if (objectGuidBytes != null)
+            if (objectGuidBytes != null && objectGuidBytes.Length == 16)
             {
-                Guid guid = new Guid(objectGuidBytes);
-                props.Add(LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
+                try
+                {
+                    Guid guid = new Guid(objectGuidBytes);
+                    props.Add(LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
+                }
+                catch
+                {
+                    // Skip malformed GUID bytes
+                }
             }
 
             compProps.DumpSMSAPassword = smsaPrincipals.ToArray();

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -436,6 +436,11 @@ namespace SharpHoundCommonLib.Processors {
                 }
             }
 
+            var objectGuidBytes = entry.GetByteProperty(LDAPProperties.ObjectGUID);
+            if (objectGuidBytes.Length > 0){
+                Guid guid = new Guid(objectGuidBytes);
+                props.Add(LDAPProperties.ObjectGUID, guid.ToString());    
+            }
             compProps.DumpSMSAPassword = smsaPrincipals.ToArray();
 
             compProps.Props = props;

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -437,10 +437,12 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             var objectGuidBytes = entry.GetByteProperty(LDAPProperties.ObjectGUID);
-            if (objectGuidBytes.Length > 0){
+            if (objectGuidBytes != null)
+            {
                 Guid guid = new Guid(objectGuidBytes);
-                props.Add(LDAPProperties.ObjectGUID, guid.ToString());    
+                props.Add(LDAPProperties.ObjectGUID, guid.ToString());
             }
+
             compProps.DumpSMSAPassword = smsaPrincipals.ToArray();
 
             compProps.Props = props;

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -392,7 +392,6 @@ namespace CommonLibTest
                     {"useraccountcontrol", "abc"},
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
-                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"homedirectory", @"\\win10\testdir"},
                     {
                         "serviceprincipalname", new[]
@@ -618,7 +617,6 @@ namespace CommonLibTest
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
                     {"operatingsystemservicepack", "1607"},
-                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"admincount", "c"},
                     {
                         "sidhistory", new[]
@@ -675,7 +673,6 @@ namespace CommonLibTest
             var testDumpSMSAPassword = test.DumpSMSAPassword;
             Assert.Equal(2, testDumpSMSAPassword.Length);
             Assert.Equal(expected, testDumpSMSAPassword);
-
         }
 
         [Fact]

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -544,6 +544,9 @@ namespace CommonLibTest
             {
                 Assert.Equal("Success", status.Status);
             }
+            Assert.Contains("objectguid", keys);
+            Assert.Equal("A6F75BA4-F1AE-4B47-A606-E3A0A69AEC83", props["objectguid"]);
+
         }
 
         [Fact]
@@ -557,7 +560,6 @@ namespace CommonLibTest
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
-                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"admincount", "c"},
                     {
                         "sidhistory", new[]
@@ -600,6 +602,7 @@ namespace CommonLibTest
             Assert.False((bool)props["trustedtoauth"]);
             Assert.Contains("sidhistory", keys);
             Assert.Empty(props["sidhistory"] as string[]);
+            Assert.DoesNotContain("objectguid", keys);
         }
 
 
@@ -1430,6 +1433,9 @@ namespace CommonLibTest
                 ObjectIdentifier = "S-1-5-21-3130019616-2776909439-2417379446-1001",
                 ObjectType = Label.Computer
             }, test.AllowedToDelegate);
+
+            Assert.Contains("objectguid", keys);
+            Assert.Equal("A6F75BA4-F1AE-4B47-A606-E3A0A69AEC83", props["objectguid"]);
         }
         
         [WindowsOnlyFact]

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -392,6 +392,7 @@ namespace CommonLibTest
                     {"useraccountcontrol", "abc"},
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"homedirectory", @"\\win10\testdir"},
                     {
                         "serviceprincipalname", new[]
@@ -446,6 +447,7 @@ namespace CommonLibTest
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"operatingsystemservicepack", "1607"},
                     {"mail", "test@testdomain.com"},
                     {"admincount", "c"},
@@ -555,6 +557,7 @@ namespace CommonLibTest
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"admincount", "c"},
                     {
                         "sidhistory", new[]
@@ -612,6 +615,7 @@ namespace CommonLibTest
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
                     {"operatingsystemservicepack", "1607"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"admincount", "c"},
                     {
                         "sidhistory", new[]
@@ -1380,6 +1384,7 @@ namespace CommonLibTest
                     {"operatingsystem", "Windows 10 Enterprise"},
                     {"operatingsystemservicepack", "1607"},
                     {"mail", "test@testdomain.com"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"admincount", "c"},
                     {
                         "sidhistory", new[]
@@ -1445,13 +1450,14 @@ namespace CommonLibTest
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},
                     {"operatingsystemservicepack", "1607"},
+                    {"objectguid", Guid.Parse("a6f75ba4-f1ae-4b47-a606-e3a0a69aec83").ToByteArray()},
                     {"mail", "test@testdomain.com"},
                     {"admincount", "c"},
                     {
-                        "msds-allowedtoactonbehalfofotheridentity", 
-                        
+                        "msds-allowedtoactonbehalfofotheridentity",
+
                             Utils.B64ToBytes("AQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQUQQAAA==")
-                        
+
                     }
                 }, "S-1-5-21-3130019616-2776909439-2417379446-1101","");
             


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Locally in a hybrid lab with both Entra and AD devices. I ran SharpHound
in an AD environment and observed the ObjectGuid being populated in the
collect and eventually in the BH info panel. If a device does not have an ObjectGUID,
it will simply ignore and fail gracefully.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ X] I have added and/or updated tests to cover my changes.
-   [ X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Computer objects now include their Object GUID in collected properties and outputs when available.

* **Bug Fixes**
  * Malformed or unexpected GUID data is safely ignored to prevent processing errors.

* **Tests**
  * Unit tests updated to validate presence, absence, normalization, and error handling for Object GUID data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->