### PR TITLE
Adding Additional Logging around NTLM Authentication

### DIFF
--- a/src/CommonLib/Ntlm/HttpNtlmAuthenticationService.cs
+++ b/src/CommonLib/Ntlm/HttpNtlmAuthenticationService.cs
@@ -37,7 +37,8 @@ public class HttpNtlmAuthenticationService {
 
         var supportedAuthSchemes = await GetSupportedNtlmAuthSchemesAsync(url);
 
-        _logger.LogDebug($"Supported NTLM auth schemes for {url}: " + string.Join(",", supportedAuthSchemes));
+        _logger.LogDebug("Supported NTLM auth schemes for {Url}: {AuthSchemes}. UseBadChannelBinding: {UseBadChannelBinding}. UseBadChannelBindings is null: {UseBadChannelBindingsHasValue}", 
+            url, string.Join(",", supportedAuthSchemes), useBadChannelBindings ?? false, !useBadChannelBindings.HasValue);
 
         foreach (var authScheme in supportedAuthSchemes) {
             if (useBadChannelBindings == null) {

--- a/src/CommonLib/Ntlm/HttpNtlmAuthenticationService.cs
+++ b/src/CommonLib/Ntlm/HttpNtlmAuthenticationService.cs
@@ -37,7 +37,7 @@ public class HttpNtlmAuthenticationService {
 
         var supportedAuthSchemes = await GetSupportedNtlmAuthSchemesAsync(url);
 
-        _logger.LogDebug("Supported NTLM auth schemes for {Url}: {AuthSchemes}. UseBadChannelBinding: {UseBadChannelBinding}. UseBadChannelBindings is null: {UseBadChannelBindingsHasValue}", 
+        _logger.LogDebug("Supported NTLM auth schemes for {Url}: {AuthSchemes}. UseBadChannelBindings: {UseBadChannelBinding}. UseBadChannelBindings is null: {UseBadChannelBindingsIsNull}", 
             url, string.Join(",", supportedAuthSchemes), useBadChannelBindings ?? false, !useBadChannelBindings.HasValue);
 
         foreach (var authScheme in supportedAuthSchemes) {

--- a/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
+++ b/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
@@ -40,19 +40,19 @@ public class NtlmAuthenticationHandler : INtlmAuthenticationHandler {
         );
         _logger.LogTrace("Starting {MethodName}", nameof(PerformNtlmAuthenticationAsync));
 
-        _logger.LogDebug("Check if cancellation token is requested.");
+        _logger.LogTrace("Check if cancellation token is requested.");
         cancellationToken.ThrowIfCancellationRequested();
         _logger.LogTrace("After if cancellation token is requested.");
 
         // NEGOTIATE
         _logger.LogDebug("Initial NTLM Negotiate Step.");
         var negotiateMsgBytes = context.Step();
-        _logger.LogTrace("After negotiate step.");
+        _logger.LogTrace("Negotiate Step Complete.");
 
         // CHALLENGE
         _logger.LogDebug("Challenge Negotiate bytes.");
         var challengeMessageBytes = await transport.NegotiateAsync(negotiateMsgBytes);
-        _logger.LogTrace("After Challenge message bytes.");
+        _logger.LogTrace("Challenge Negotiate bytes complete.");
 
         _logger.LogTrace("Check if cancellation token is requested.");
         cancellationToken.ThrowIfCancellationRequested();
@@ -61,7 +61,7 @@ public class NtlmAuthenticationHandler : INtlmAuthenticationHandler {
         // AUTHENTICATE
         _logger.LogDebug("Perform NTLM Authentication Step.");
         var authenticateMsgBytes = context.Step(challengeMessageBytes);
-        _logger.LogTrace("After NTLM Authentication Step.");
+        _logger.LogTrace("NTLM Authentication Step Complete.");
 
         // Perform final authentication
         _logger.LogDebug("Perform final NTLM Authentication.");

--- a/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
+++ b/src/CommonLib/Ntlm/NtlmAuthenticationHandler.cs
@@ -38,22 +38,35 @@ public class NtlmAuthenticationHandler : INtlmAuthenticationHandler {
             Options.Signing,
             Options.Signing
         );
+        _logger.LogTrace("Starting {MethodName}", nameof(PerformNtlmAuthenticationAsync));
 
+        _logger.LogDebug("Check if cancellation token is requested.");
         cancellationToken.ThrowIfCancellationRequested();
+        _logger.LogTrace("After if cancellation token is requested.");
 
         // NEGOTIATE
+        _logger.LogDebug("Initial NTLM Negotiate Step.");
         var negotiateMsgBytes = context.Step();
+        _logger.LogTrace("After negotiate step.");
 
         // CHALLENGE
+        _logger.LogDebug("Challenge Negotiate bytes.");
         var challengeMessageBytes = await transport.NegotiateAsync(negotiateMsgBytes);
+        _logger.LogTrace("After Challenge message bytes.");
 
+        _logger.LogTrace("Check if cancellation token is requested.");
         cancellationToken.ThrowIfCancellationRequested();
+        _logger.LogTrace("After if cancellation token is requested.");
 
         // AUTHENTICATE
+        _logger.LogDebug("Perform NTLM Authentication Step.");
         var authenticateMsgBytes = context.Step(challengeMessageBytes);
+        _logger.LogTrace("After NTLM Authentication Step.");
 
         // Perform final authentication
+        _logger.LogDebug("Perform final NTLM Authentication.");
         var response = await transport.AuthenticateAsync(authenticateMsgBytes);
+        _logger.LogTrace("After authentication complete.");
 
         return response;
     }

--- a/src/CommonLib/Processors/CAEnrollmentProcessor.cs
+++ b/src/CommonLib/Processors/CAEnrollmentProcessor.cs
@@ -133,15 +133,18 @@ namespace SharpHoundCommonLib.Processors {
 
             try {
                 await authService.EnsureRequiresAuth(url, useBadChannelBinding);
+                _logger.LogDebug("{Url} was accessible. BadChannelBindings: {UseBadChannelBindings}", url.AbsoluteUri, useBadChannelBinding);
                 return APIResult<CAEnrollmentEndpoint>.Success(output);
             } catch (HttpRequestException ex) {
                 if (ex.InnerException is WebException webEx) {
                     if (webEx.InnerException is SocketException) {
                         output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PortInaccessible;
+                        _logger.LogDebug("{Url} labeled not vulnerable due to port being inaccessible.", url.AbsoluteUri);
                         return APIResult<CAEnrollmentEndpoint>.Success(output);
                     }
 
                     if (webEx.Status == WebExceptionStatus.NameResolutionFailure) {
+                        _logger.LogDebug("{Url} could not be resolved.", url.AbsoluteUri);
                         return APIResult<CAEnrollmentEndpoint>.Failure("Could not resolve hostname");
                     }
 
@@ -151,12 +154,16 @@ namespace SharpHoundCommonLib.Processors {
                         switch (statusCode) {
                             case HttpStatusCode.NotFound:
                                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathNotFound;
+                                _logger.LogDebug("{Url} labeled not vulnerable as the path was not found.", url.AbsoluteUri);
                                 break;
                             case HttpStatusCode.Forbidden:
                                 // Returned if the IIS is configured to require SSL (so no HTTP possible)
                                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathForbidden;
+                                _logger.LogDebug("{Url} labeled not vulnerable as the path was forbidden.", url.AbsoluteUri);
                                 break;
                             default:
+                                _logger.LogError("{Url} recieved an unexpected status code of {StatusCode}. UseBadChannelBindings: {UseBadChannelBindings}",
+                                    url.AbsoluteUri, statusCode, useBadChannelBinding);
                                 return APIResult<CAEnrollmentEndpoint>
                                     .Failure(
                                         $"Unexpected status code '{statusCode}' for the URL {url}. UseBadChannelBindings: {useBadChannelBinding}");
@@ -165,42 +172,51 @@ namespace SharpHoundCommonLib.Processors {
                         return APIResult<CAEnrollmentEndpoint>.Success(output);
                     }
 
-                    _logger.LogError($"WebException occurred: {ex}");
-
+                    _logger.LogError("Unhandled WebException. Url: {Url}. Exception: {ExceptionMessage}. Inner: {InnerExceptionMessage}  Data: {ExceptionData}",
+                        url.AbsoluteUri, webEx.Message, webEx.InnerException?.Message, webEx.Data);
                     return APIResult<CAEnrollmentEndpoint>
                         .Failure(
                             $"Unhandled WebException. Url: {url}. Exception: {webEx.Message}. Inner: {webEx.InnerException?.Message}  Data: {webEx.Data}");
                 }
-
+                
+                _logger.LogError("HttpRequestException occurred checking NTLM accessibility for URL: {URL}. Exception: {Message}", url.AbsoluteUri, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
                         $"HttpRequestException occured checking NTLM accessibility for URL: {url}. Exception: {ex.Message}");
             } catch (HttpUnauthorizedException ex) {
                 if (useBadChannelBinding == true) {
                     output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_NtlmChannelBindingRequired;
+                    _logger.LogDebug("{Url} labeled as not vulnerable, NTLM channel binding is required", url.AbsoluteUri);
                     return APIResult<CAEnrollmentEndpoint>.Success(output);
                 }
 
+                _logger.LogError("Unauthorized exception checking NTLM accessibility for URL: {Url}. Exception: {Message}", url.AbsoluteUri, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
                         $"401 Unauthorized exception checking NTLM accessibility for URL: {url}. Exception: {ex.Message}");
             } catch (HttpForbiddenException) {
                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathForbidden;
+                _logger.LogDebug("{Url} labeled not vulnerable as the path was forbidden.", url.AbsoluteUri);
                 return APIResult<CAEnrollmentEndpoint>
                     .Success(output);
             } catch (HttpServerErrorException) {
                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathNotFound;
+                _logger.LogDebug("{Url} labeled not vulnerable as the path was not found.", url.AbsoluteUri);
                 return APIResult<CAEnrollmentEndpoint>
                     .Success(output);
             } catch (MissingChallengeException) {
                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_NoNtlmChallenge;
+                _logger.LogDebug("{Url} labeled not vulnerable as no NTLM challenge.", url.AbsoluteUri);
                 return APIResult<CAEnrollmentEndpoint>
                     .Success(output);
             } catch (ExtendedProtectionMisconfiguredException) {
                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_EpaMisconfigured;
+                _logger.LogDebug("{Url} labeled not vulnerable as EPA is misconfigured.", url.AbsoluteUri);
                 return APIResult<CAEnrollmentEndpoint>
                     .Success(output);
             } catch (Exception ex) {
+                _logger.LogError("An unhandled exception occurred checking NTLM accessibility for URL: {Url}. BadChannelBindings: {UseBadChannelBindings} Exception: {Message}",
+                    url.AbsoluteUri, useBadChannelBinding, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
                         $"Unhandled exception checking NTLM accessibility for URL: {url}. BadChannelBindings: {useBadChannelBinding}.  Exception: {ex.Message}");

--- a/src/CommonLib/Processors/CAEnrollmentProcessor.cs
+++ b/src/CommonLib/Processors/CAEnrollmentProcessor.cs
@@ -167,7 +167,7 @@ namespace SharpHoundCommonLib.Processors {
                                     url.AbsoluteUri, useBadChannelBinding, type);
                                 break;
                             default:
-                                _logger.LogError("Unexpected status code while checking {Url}. StatusCode {StatusCode}. UseBadChannelBindings: {UseBadChannelBindings}, EnpointType: {EndpointType}",
+                                _logger.LogError("Unexpected status code while checking {Url}. StatusCode {StatusCode}. UseBadChannelBindings: {UseBadChannelBindings}, EndpointType: {EndpointType}",
                                     url.AbsoluteUri, statusCode, useBadChannelBinding, type);
                                 return APIResult<CAEnrollmentEndpoint>
                                     .Failure(
@@ -187,7 +187,7 @@ namespace SharpHoundCommonLib.Processors {
                 _logger.LogError("HttpRequestException occurred checking NTLM accessibility for URL: {Url}. Exception: {Message}", url.AbsoluteUri, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
-                        $"HttpRequestException occured checking NTLM accessibility for URL: {url}. Exception: {ex.Message}");
+                        $"HttpRequestException occurred checking NTLM accessibility for URL: {url}. Exception: {ex.Message}");
             } catch (HttpUnauthorizedException ex) {
                 if (useBadChannelBinding == true) {
                     output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_NtlmChannelBindingRequired;

--- a/src/CommonLib/Processors/CAEnrollmentProcessor.cs
+++ b/src/CommonLib/Processors/CAEnrollmentProcessor.cs
@@ -133,18 +133,21 @@ namespace SharpHoundCommonLib.Processors {
 
             try {
                 await authService.EnsureRequiresAuth(url, useBadChannelBinding);
-                _logger.LogDebug("{Url} was accessible. BadChannelBindings: {UseBadChannelBindings}", url.AbsoluteUri, useBadChannelBinding);
+                _logger.LogDebug("{Url} was accessible. BadChannelBindings: {UseBadChannelBindings}. EndpointType {EndpointType}",
+                    url.AbsoluteUri, useBadChannelBinding, type);
                 return APIResult<CAEnrollmentEndpoint>.Success(output);
             } catch (HttpRequestException ex) {
                 if (ex.InnerException is WebException webEx) {
                     if (webEx.InnerException is SocketException) {
                         output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PortInaccessible;
-                        _logger.LogDebug("{Url} labeled not vulnerable due to port being inaccessible.", url.AbsoluteUri);
+                        _logger.LogDebug("{Url} labeled not vulnerable due to port being inaccessible. EndpointType: {EndpointType}",
+                            url.AbsoluteUri, type);
                         return APIResult<CAEnrollmentEndpoint>.Success(output);
                     }
 
                     if (webEx.Status == WebExceptionStatus.NameResolutionFailure) {
-                        _logger.LogDebug("{Url} could not be resolved.", url.AbsoluteUri);
+                        _logger.LogDebug("{Url} could not be resolved. BadChannelBindings: {UseBadChannelBindings}. EndpointType: {EndpointType}",
+                            url.AbsoluteUri, useBadChannelBinding, type);
                         return APIResult<CAEnrollmentEndpoint>.Failure("Could not resolve hostname");
                     }
 
@@ -154,16 +157,18 @@ namespace SharpHoundCommonLib.Processors {
                         switch (statusCode) {
                             case HttpStatusCode.NotFound:
                                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathNotFound;
-                                _logger.LogDebug("{Url} labeled not vulnerable as the path was not found.", url.AbsoluteUri);
+                                _logger.LogDebug("Path not found for {Url}; marking not vulnerable. BadChannelBindings: {UseBadChannelBindings}. EndpointType: {EndpointType}",
+                                    url.AbsoluteUri, useBadChannelBinding, type);
                                 break;
                             case HttpStatusCode.Forbidden:
                                 // Returned if the IIS is configured to require SSL (so no HTTP possible)
                                 output.Status = CAEnrollmentEndpointScanResult.NotVulnerable_PathForbidden;
-                                _logger.LogDebug("{Url} labeled not vulnerable as the path was forbidden.", url.AbsoluteUri);
+                                _logger.LogDebug("Path forbidden for {Url}; marking not vulnerable. BadChannelBindings: {UseBadChannelBindings}. EndpointType: {EndpointType}",
+                                    url.AbsoluteUri, useBadChannelBinding, type);
                                 break;
                             default:
-                                _logger.LogError("{Url} recieved an unexpected status code of {StatusCode}. UseBadChannelBindings: {UseBadChannelBindings}",
-                                    url.AbsoluteUri, statusCode, useBadChannelBinding);
+                                _logger.LogError("Unexpected status code while checking {Url}. StatusCode {StatusCode}. UseBadChannelBindings: {UseBadChannelBindings}, EnpointType: {EndpointType}",
+                                    url.AbsoluteUri, statusCode, useBadChannelBinding, type);
                                 return APIResult<CAEnrollmentEndpoint>
                                     .Failure(
                                         $"Unexpected status code '{statusCode}' for the URL {url}. UseBadChannelBindings: {useBadChannelBinding}");
@@ -172,14 +177,14 @@ namespace SharpHoundCommonLib.Processors {
                         return APIResult<CAEnrollmentEndpoint>.Success(output);
                     }
 
-                    _logger.LogError("Unhandled WebException. Url: {Url}. Exception: {ExceptionMessage}. Inner: {InnerExceptionMessage}  Data: {ExceptionData}",
+                    _logger.LogError(webEx, "Unhandled WebException while checking {Url}. Exception: {ExceptionMessage}. Inner: {InnerExceptionMessage}  Data: {ExceptionData}",
                         url.AbsoluteUri, webEx.Message, webEx.InnerException?.Message, webEx.Data);
                     return APIResult<CAEnrollmentEndpoint>
                         .Failure(
                             $"Unhandled WebException. Url: {url}. Exception: {webEx.Message}. Inner: {webEx.InnerException?.Message}  Data: {webEx.Data}");
                 }
                 
-                _logger.LogError("HttpRequestException occurred checking NTLM accessibility for URL: {URL}. Exception: {Message}", url.AbsoluteUri, ex.Message);
+                _logger.LogError("HttpRequestException occurred checking NTLM accessibility for URL: {Url}. Exception: {Message}", url.AbsoluteUri, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
                         $"HttpRequestException occured checking NTLM accessibility for URL: {url}. Exception: {ex.Message}");
@@ -215,8 +220,8 @@ namespace SharpHoundCommonLib.Processors {
                 return APIResult<CAEnrollmentEndpoint>
                     .Success(output);
             } catch (Exception ex) {
-                _logger.LogError("An unhandled exception occurred checking NTLM accessibility for URL: {Url}. BadChannelBindings: {UseBadChannelBindings} Exception: {Message}",
-                    url.AbsoluteUri, useBadChannelBinding, ex.Message);
+                _logger.LogError("An unhandled exception occurred checking NTLM accessibility for URL: {Url}. BadChannelBindings: {UseBadChannelBindings}. EndpointType: {EndpointType}. Exception: {Message}",
+                    url.AbsoluteUri, useBadChannelBinding, type, ex.Message);
                 return APIResult<CAEnrollmentEndpoint>
                     .Failure(
                         $"Unhandled exception checking NTLM accessibility for URL: {url}. BadChannelBindings: {useBadChannelBinding}.  Exception: {ex.Message}");


### PR DESCRIPTION
## Description

This adds more logging around NTLM Authentication for endpoints to check potential ESC8 Vulnerability.

## Motivation and Context

BED-6657

## How Has This Been Tested?

This has been tested by creating a build with this change, and ensuring the log statement are available. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced diagnostic logging across NTLM authentication and enrollment flows: structured, step‑by‑step traces of authentication stages, reported supported schemes, channel binding status, endpoint accessibility, and richer context for network and authorization errors to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->