### PR TITLE
BED-5558 - SharpHound warn on inability to collect necessary properties

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -265,11 +265,18 @@ namespace SharpHoundCommonLib.Processors {
                             continue;
 
                         var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                        if (resolvedHost.Success && resolvedHost.SecurityIdentifier.Contains("S-1"))
-                            comps.Add(new TypedPrincipal {
-                                ObjectIdentifier = resolvedHost.SecurityIdentifier,
-                                ObjectType = Label.Computer
-                            });
+                        if (!resolvedHost.Success || !resolvedHost.SecurityIdentifier.Contains("S-1")) continue;
+                        await SendComputerStatus(new CSVComputerStatus {
+                            Status = CSVComputerStatus.StatusSuccess,
+                            Task = nameof(ReadUserProperties),
+                            ComputerName = Helpers.StripServicePrincipalName(d).ToUpper().TrimEnd('$'),
+                            ObjectId = resolvedHost.SecurityIdentifier,
+                        });
+                            
+                        comps.Add(new TypedPrincipal {
+                            ObjectIdentifier = resolvedHost.SecurityIdentifier,
+                            ObjectType = Label.Computer
+                        });
                     }
                 }
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -251,6 +251,7 @@ namespace SharpHoundCommonLib.Processors {
                 props.Add("lockedout", uacFlags.HasFlag(UacFlags.Lockout));
                 props.Add("passwordcantchange", uacFlags.HasFlag(UacFlags.PasswordCantChange));
                 props.Add("passwordexpired", uacFlags.HasFlag(UacFlags.PasswordExpired));
+                props.Add("useraccountcontrol", uac);
 
                 userProps.UnconstrainedDelegation = uacFlags.HasFlag(UacFlags.TrustedForDelegation);
                 
@@ -275,7 +276,8 @@ namespace SharpHoundCommonLib.Processors {
                 userProps.AllowedToDelegate = comps.Distinct().ToArray();
             }
             else {
-                _log.LogWarning("Unable to collect UserAccountControl flags.");
+                entry.TryGetSecurityIdentifier(out var sid);
+                _log.LogWarning("Unable to collect UserAccountControl flags for {SecurityIdentifier}.", sid);
             }
 
             if (!entry.TryGetProperty(LDAPProperties.LastLogon, out var lastLogon)) {
@@ -308,7 +310,6 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("unicodepassword", entry.GetProperty(LDAPProperties.UnicodePassword));
             props.Add("sfupassword", entry.GetProperty(LDAPProperties.MsSFU30Password));
             props.Add("logonscript", entry.GetProperty(LDAPProperties.ScriptPath));
-            props.Add("useraccountcontrol", uac);
             props.Add("profilepath", entry.GetProperty(LDAPProperties.ProfilePath));
 
             entry.TryGetLongProperty(LDAPProperties.AdminCount, out var ac);

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -265,7 +265,7 @@ namespace SharpHoundCommonLib.Processors {
                             continue;
 
                         var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                        if (!resolvedHost.Success || !resolvedHost.SecurityIdentifier.Contains("S-1")) continue;
+                        if (!resolvedHost.Success || !resolvedHost.SecurityIdentifier.StartsWith("S-1-5-")) continue;
                         await SendComputerStatus(new CSVComputerStatus {
                             Status = CSVComputerStatus.StatusSuccess,
                             Task = nameof(ReadUserProperties),
@@ -384,19 +384,17 @@ namespace SharpHoundCommonLib.Processors {
                         continue;
 
                     var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                    if (resolvedHost.Success && resolvedHost.SecurityIdentifier.Contains("S-1"))
-                    {
-                        await SendComputerStatus(new CSVComputerStatus {
-                            Status = CSVComputerStatus.StatusSuccess,
-                            Task = nameof(ReadComputerProperties),
-                            ComputerName = d,
-                            ObjectId = resolvedHost.SecurityIdentifier,
-                        });
-                        comps.Add(new TypedPrincipal {
-                            ObjectIdentifier = resolvedHost.SecurityIdentifier,
-                            ObjectType = Label.Computer
-                        });
-                    }
+                    if (!resolvedHost.Success || !resolvedHost.SecurityIdentifier.StartsWith("S-1-5-")) continue;
+                    await SendComputerStatus(new CSVComputerStatus {
+                        Status = CSVComputerStatus.StatusSuccess,
+                        Task = nameof(ReadComputerProperties),
+                        ComputerName = d,
+                        ObjectId = resolvedHost.SecurityIdentifier,
+                    });
+                    comps.Add(new TypedPrincipal {
+                        ObjectIdentifier = resolvedHost.SecurityIdentifier,
+                        ObjectType = Label.Computer
+                    });
                 }
             }
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -36,9 +36,11 @@ namespace SharpHoundCommonLib.Processors {
         }
 
         private readonly ILdapUtils _utils;
+        private readonly ILogger _log;
 
-        public LdapPropertyProcessor(ILdapUtils utils) {
+        public LdapPropertyProcessor(ILdapUtils utils, ILogger log = null) {
             _utils = utils;
+            _log = log ?? Logging.LogProvider.CreateLogger(nameof(LdapPropertyProcessor));
         }
 
         private static Dictionary<string, object> GetCommonProps(IDirectoryObject entry) {
@@ -233,55 +235,48 @@ namespace SharpHoundCommonLib.Processors {
             var userProps = new UserProperties();
             var props = GetCommonProps(entry);
 
-            var uacFlags = (UacFlags)0;
             if (entry.TryGetLongProperty(LDAPProperties.UserAccountControl, out var uac)) {
-                uacFlags = (UacFlags)uac;
-            }
+              var uacFlags = (UacFlags)uac;
+                props.Add("sensitive", uacFlags.HasFlag(UacFlags.NotDelegated));
+                props.Add("dontreqpreauth", uacFlags.HasFlag(UacFlags.DontReqPreauth));
+                props.Add("passwordnotreqd", uacFlags.HasFlag(UacFlags.PasswordNotRequired));
+                props.Add("unconstraineddelegation", uacFlags.HasFlag(UacFlags.TrustedForDelegation));
+                props.Add("pwdneverexpires", uacFlags.HasFlag(UacFlags.DontExpirePassword));
+                props.Add("enabled", !uacFlags.HasFlag(UacFlags.AccountDisable));
+                props.Add("trustedtoauth", uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation));
+                props.Add("smartcardrequired", uacFlags.HasFlag(UacFlags.SmartcardRequired));
+                props.Add("encryptedtextpwdallowed", uacFlags.HasFlag(UacFlags.EncryptedTextPwdAllowed));
+                props.Add("usedeskeyonly", uacFlags.HasFlag(UacFlags.UseDesKeyOnly));
+                props.Add("logonscriptenabled", uacFlags.HasFlag(UacFlags.Script));
+                props.Add("lockedout", uacFlags.HasFlag(UacFlags.Lockout));
+                props.Add("passwordcantchange", uacFlags.HasFlag(UacFlags.PasswordCantChange));
+                props.Add("passwordexpired", uacFlags.HasFlag(UacFlags.PasswordExpired));
 
-            props.Add("sensitive", uacFlags.HasFlag(UacFlags.NotDelegated));
-            props.Add("dontreqpreauth", uacFlags.HasFlag(UacFlags.DontReqPreauth));
-            props.Add("passwordnotreqd", uacFlags.HasFlag(UacFlags.PasswordNotRequired));
-            props.Add("unconstraineddelegation", uacFlags.HasFlag(UacFlags.TrustedForDelegation));
-            props.Add("pwdneverexpires", uacFlags.HasFlag(UacFlags.DontExpirePassword));
-            props.Add("enabled", !uacFlags.HasFlag(UacFlags.AccountDisable));
-            props.Add("trustedtoauth", uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation));
-            props.Add("smartcardrequired", uacFlags.HasFlag(UacFlags.SmartcardRequired));
-            props.Add("encryptedtextpwdallowed", uacFlags.HasFlag(UacFlags.EncryptedTextPwdAllowed));
-            props.Add("usedeskeyonly", uacFlags.HasFlag(UacFlags.UseDesKeyOnly));
-            props.Add("logonscriptenabled", uacFlags.HasFlag(UacFlags.Script));
-            props.Add("lockedout", uacFlags.HasFlag(UacFlags.Lockout));
-            props.Add("passwordcantchange", uacFlags.HasFlag(UacFlags.PasswordCantChange));
-            props.Add("passwordexpired", uacFlags.HasFlag(UacFlags.PasswordExpired));
+                userProps.UnconstrainedDelegation = uacFlags.HasFlag(UacFlags.TrustedForDelegation);
+                
+                var comps = new List<TypedPrincipal>();
+                if (uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
+                    entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
+                    props.Add("allowedtodelegate", delegates);
 
-            userProps.UnconstrainedDelegation = uacFlags.HasFlag(UacFlags.TrustedForDelegation);
+                    foreach (var d in delegates) {
+                        if (d == null)
+                            continue;
 
-            var comps = new List<TypedPrincipal>();
-            if (uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
-                entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
-                props.Add("allowedtodelegate", delegates);
-
-                foreach (var d in delegates) {
-                    if (d == null)
-                        continue;
-
-                    var resolvedHost = await _utils.ResolveHostToSid(d, domain);
-                    if (resolvedHost.Success && resolvedHost.SecurityIdentifier.Contains("S-1"))
-                    {
-                        await SendComputerStatus(new CSVComputerStatus {
-                            Status = CSVComputerStatus.StatusSuccess,
-                            Task = nameof(ReadUserProperties),
-                            ComputerName = Helpers.StripServicePrincipalName(d).ToUpper().TrimEnd('$'),
-                            ObjectId = resolvedHost.SecurityIdentifier,
-                        });
-                        comps.Add(new TypedPrincipal {
-                            ObjectIdentifier = resolvedHost.SecurityIdentifier,
-                            ObjectType = Label.Computer
-                        });
+                        var resolvedHost = await _utils.ResolveHostToSid(d, domain);
+                        if (resolvedHost.Success && resolvedHost.SecurityIdentifier.Contains("S-1"))
+                            comps.Add(new TypedPrincipal {
+                                ObjectIdentifier = resolvedHost.SecurityIdentifier,
+                                ObjectType = Label.Computer
+                            });
                     }
                 }
-            }
 
-            userProps.AllowedToDelegate = comps.Distinct().ToArray();
+                userProps.AllowedToDelegate = comps.Distinct().ToArray();
+            }
+            else {
+                _log.LogWarning("Unable to collect UserAccountControl flags.");
+            }
 
             if (!entry.TryGetProperty(LDAPProperties.LastLogon, out var lastLogon)) {
                 lastLogon = null;

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -418,20 +418,13 @@ namespace CommonLibTest
             Assert.Empty(props["sidhistory"] as string[]);
             Assert.Contains("admincount", keys);
             Assert.False((bool)props["admincount"]);
-            Assert.Contains("sensitive", keys);
-            Assert.Contains("dontreqpreauth", keys);
-            Assert.Contains("passwordnotreqd", keys);
-            Assert.Contains("unconstraineddelegation", keys);
-            Assert.Contains("pwdneverexpires", keys);
-            Assert.Contains("enabled", keys);
-            Assert.Contains("trustedtoauth", keys);
-            Assert.False((bool)props["trustedtoauth"]);
-            Assert.False((bool)props["sensitive"]);
-            Assert.False((bool)props["dontreqpreauth"]);
-            Assert.False((bool)props["passwordnotreqd"]);
-            Assert.False((bool)props["unconstraineddelegation"]);
-            Assert.False((bool)props["pwdneverexpires"]);
-            Assert.True((bool)props["enabled"]);
+            Assert.DoesNotContain("sensitive", keys);
+            Assert.DoesNotContain("dontreqpreauth", keys);
+            Assert.DoesNotContain("passwordnotreqd", keys);
+            Assert.DoesNotContain("unconstraineddelegation", keys);
+            Assert.DoesNotContain("pwdneverexpires", keys);
+            Assert.DoesNotContain("enabled", keys);
+            Assert.DoesNotContain("trustedtoauth", keys);
         }
 
         [WindowsOnlyFact]


### PR DESCRIPTION
## Description

This stops SharpHound from setting property values on users when we were unable to collect User Account Control. A Log Warning has been added to explicitly state this. 

## Motivation and Context

BED-5558

## How Has This Been Tested?

This was tested by creating a build, running collection, and ingesting the collection. In addition the Unit test passed locally. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional runtime logging support to improve diagnostic output.

* **Bug Fixes**
  * Improved handling and validation of account delegation data, skipping invalid entries and emitting clearer warnings when required flags are missing.
  * Strengthened SID validation for delegated hosts to reduce false positives.

* **Tests**
  * Updated unit tests to match the tightened property validation and delegation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->