### PR TITLE
add support for WriteLogonScript

### DIFF
--- a/src/CommonLib/Enums/EdgeNames.cs
+++ b/src/CommonLib/Enums/EdgeNames.cs
@@ -18,6 +18,7 @@
         public const string ReadGMSAPassword = "ReadGMSAPassword";
         public const string AddMember = "AddMember";
         public const string WriteSPN = "WriteSPN";
+        public const string WriteLogonScript = "WriteLogonScript";
         public const string AddKeyCredentialLink = "AddKeyCredentialLink";
         public const string SQLAdmin = "SQLAdmin";
         public const string WriteAccountRestrictions = "WriteAccountRestrictions";

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -10,6 +10,7 @@
         public const string WriteMember = "bf9679c0-0de6-11d0-a285-00aa003049e2";
         public const string WriteAllowedToAct = "3f78c3e5-f79a-46bd-a0b8-9d18116ddc79";
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
+        public const string WriteLogonScript = "bf9679a8-0de6-11d0-a285-00aa003049e2";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";
         public const string UserAccountRestrictions = "4c164200-20c0-11d0-a768-00aa006e0529";
         public const string WriteGPLink = "f30e3bbe-9ff0-11d1-b603-0000f80367c1";

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -756,6 +756,17 @@ namespace SharpHoundCommonLib.Processors {
                             IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                             IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                         };
+                    else if (objectType == Label.User && aceType == ACEGuids.WriteLogonScript)
+                        yield return new ACE
+                        {
+                            PrincipalType = resolvedPrincipal.ObjectType,
+                            PrincipalSID = resolvedPrincipal.ObjectIdentifier,
+                            IsInherited = inherited,
+                            RightName = EdgeNames.WriteLogonScript,
+                            InheritanceHash = aceInheritanceHash,
+                            IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
+                            IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
+                        };
                     else if (objectType == Label.Computer && aceType == ACEGuids.WriteAllowedToAct)
                         yield return new ACE {
                             PrincipalType = resolvedPrincipal.ObjectType,


### PR DESCRIPTION
## Description

This pull request adds the ability to SharpHound to collect write privilege over a user's scriptPath property.

## Motivation and Context

This PR follows https://github.com/SpecterOps/BloodHound/pull/2046.

## How Has This Been Tested?

The changes have been tested manually on a lab environment.

## Screenshots (if appropriate):

<img width="1048" height="245" alt="writelogonscript" src="https://github.com/user-attachments/assets/b93b5aa7-b2da-41ca-ada4-dccfb674af00" />

## Types of changes

-   [ ] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [ ] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WriteLogonScript permission type on User objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->