### PR TITLE
fix: add adaptive timeouts to missing portions of enumeration

### DIFF
--- a/src/CommonLib/IRegistryKey.cs
+++ b/src/CommonLib/IRegistryKey.cs
@@ -39,8 +39,7 @@ namespace SharpHoundCommonLib {
             var remoteKey = await _adaptiveTimeout.ExecuteWithTimeout((_) => RegistryKey.OpenRemoteBaseKey(hive, machineName));
             if (remoteKey.IsSuccess)
                 return new SHRegistryKey(remoteKey.Value);
-            else
-                throw new TimeoutException($"Failed to connect to registry on {machineName}: {remoteKey.Error}");
+            throw new TimeoutException($"Failed to connect to registry on {machineName}: {remoteKey.Error}");
         }
 
         public void Dispose() {

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -15,6 +15,7 @@ public class RegistryProcessor {
     private readonly IPortScanner _portScanner;
     private readonly ICollectionStrategy<RegistryQueryResult, RegistryQuery>[] _strategies;
     private readonly RegistryQuery[] _queries;
+    private readonly AdaptiveTimeout _registryAdaptiveTimeout = new(maxTimeout:TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ReadRegistrySettings)));
 
     public RegistryProcessor(ILogger log, string domain) {
         _log = log ?? Logging.LogProvider.CreateLogger("RegistryProcessor");
@@ -54,9 +55,15 @@ public class RegistryProcessor {
 
         try {
             var registryCollector = new StrategyExecutor();
-            var collectedData = await registryCollector
+            var result = await _registryAdaptiveTimeout.ExecuteWithTimeout(async (_) => await registryCollector
                 .CollectAsync(targetMachine, _queries, _strategies)
-                .ConfigureAwait(false);
+                .ConfigureAwait(false));
+
+            if (!result.IsSuccess) {
+                return APIResult<RegistryData>.Failure($"Timeout when grabbing registry data from {targetMachine}");
+            }
+
+            var collectedData = result.Value;
 
             foreach (var key in collectedData.Results ?? []) {
                 if (!key.ValueExists)

--- a/src/CommonLib/Processors/WebClientServiceProcessor.cs
+++ b/src/CommonLib/Processors/WebClientServiceProcessor.cs
@@ -88,6 +88,7 @@ namespace SharpHoundCommonLib.Processors {
                 }
             });
 
+            //TODO: Not a big fan of nested result objects. We should look at this later to see if we can simplify the interface
             if (result.IsSuccess) {
                 return result.Value;
             }

--- a/src/CommonLib/Processors/WebClientServiceProcessor.cs
+++ b/src/CommonLib/Processors/WebClientServiceProcessor.cs
@@ -16,6 +16,7 @@ namespace SharpHoundCommonLib.Processors {
     /// <param name="log"></param>
     public class WebClientServiceProcessor(ILogger log = null) {
         private readonly ILogger _log = log ?? Logging.LogProvider.CreateLogger("WebClientServiceProcessor");
+        private readonly AdaptiveTimeout _createFileAdaptiveTimeout = new(maxTimeout:TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(IsWebClientRunning)));
 
         // Define constants
         public const uint MAXIMUM_ALLOWED = 0x02000000;
@@ -78,15 +79,20 @@ namespace SharpHoundCommonLib.Processors {
             // When the service is running, this named pipe is present
             var pipePath = @$"\\{computerName}\pipe\DAV RPC SERVICE";
 
-            return await Task.Run(() => {
+            var result = await _createFileAdaptiveTimeout.ExecuteWithTimeout((_) => {
                 try {
                     var exists = TestPathExists(pipePath);
-
                     return APIResult<bool>.Success(exists);
                 } catch (Exception ex) {
                     return APIResult<bool>.Failure(ex.ToString());
                 }
             });
+
+            if (result.IsSuccess) {
+                return result.Value;
+            }
+            
+            throw new TimeoutException($"Failed to check pipe on {computerName}: {pipePath}");
         }
     }
 }

--- a/src/CommonLib/Processors/WebClientServiceProcessor.cs
+++ b/src/CommonLib/Processors/WebClientServiceProcessor.cs
@@ -93,7 +93,7 @@ namespace SharpHoundCommonLib.Processors {
                 return result.Value;
             }
             
-            throw new TimeoutException($"Failed to check pipe on {computerName}: {pipePath}");
+            return APIResult<bool>.Failure($"Failed to check pipe on {computerName} due to timeout: {pipePath}");
         }
     }
 }


### PR DESCRIPTION
## Description

The check for IsWebClientRunning was not wrapped in a timeout. Additionally, our registry strategy executor was not wrapped in timeouts either. Both of these are used during SHE local group collection and could potentially lead to major hangs.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-6829

## How Has This Been Tested?

Unable to reproduce, so adding these as a precaution.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal control flow to reduce branching and improve readability.

* **Bug Fixes**
  * Added adaptive timeout protection (2-minute max) to registry and web-client operations to prevent hangs and return clear timeout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->