### PR TITLE
Add CompStatus Events to CertAbuseProcessor BED-6967

### DIFF
--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -1,17 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
-using System.Security;
 using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
 using SharpHoundCommonLib.Enums;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
-using Microsoft.Win32;
-using SharpHoundCommonLib.Processors;
 
 namespace SharpHoundCommonLib {
     public static class Helpers {

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Security;
 using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
 using SharpHoundCommonLib.Enums;
 using Microsoft.Extensions.Logging;
-using System.IO;
-using System.Security;
-using SharpHoundCommonLib.Processors;
-using Microsoft.Win32;
 using System.Threading.Tasks;
+using Microsoft.Win32;
+using SharpHoundCommonLib.Processors;
 
 namespace SharpHoundCommonLib {
     public static class Helpers {
@@ -151,7 +151,7 @@ namespace SharpHoundCommonLib {
         }
 
         /// <summary>
-        /// Converts a domain name to a distinguished name using simple string substitution
+        ///     Converts a domain name to a distinguished name using simple string substitution
         /// </summary>
         /// <param name="domainName"></param>
         /// <returns></returns>
@@ -258,6 +258,7 @@ namespace SharpHoundCommonLib {
             return false;
         }
 
+        //TODO: replace with IRegistryAccessor
         public static RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log) {
             var data = new RegistryResult();
 
@@ -292,6 +293,7 @@ namespace SharpHoundCommonLib {
             return data;
         }
 
+        //TODO: replace with IRegistryAccessor
         public static IRegistryKey OpenRemoteRegistry(string target) {
             return SHRegistryKey.Connect(RegistryHive.LocalMachine, target).GetAwaiter().GetResult();
         }

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -258,46 +258,6 @@ namespace SharpHoundCommonLib {
             return false;
         }
 
-        //TODO: replace with IRegistryAccessor
-        public static RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log) {
-            var data = new RegistryResult();
-
-            try {
-                var baseKey = OpenRemoteRegistry(target);
-                var value = baseKey.GetValue(subkey, subvalue);
-                data.Value = value;
-
-                data.Collected = true;
-            }
-            catch (IOException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
-                    target, subkey, subvalue);
-                data.FailureReason = "Target machine was not found or not connectable";
-            }
-            catch (SecurityException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
-                    target, subkey, subvalue);
-                data.FailureReason = "User does not have the proper permissions to perform this operation";
-            }
-            catch (UnauthorizedAccessException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
-                    target, subkey, subvalue);
-                data.FailureReason = "User does not have the necessary registry rights";
-            }
-            catch (Exception e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
-                    target, subkey, subvalue);
-                data.FailureReason = e.Message;
-            }
-
-            return data;
-        }
-
-        //TODO: replace with IRegistryAccessor
-        public static IRegistryKey OpenRemoteRegistry(string target) {
-            return SHRegistryKey.Connect(RegistryHive.LocalMachine, target).GetAwaiter().GetResult();
-        }
-
         public static string[] AuthenticationOIDs = new string[] {
             CommonOids.ClientAuthentication,
             CommonOids.PKINITClientAuthentication,

--- a/src/CommonLib/IRegistryAccessor.cs
+++ b/src/CommonLib/IRegistryAccessor.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.IO;
+using System.Security;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+using SharpHoundCommonLib.Processors;
+
+namespace SharpHoundCommonLib {
+    public interface IRegistryAccessor {
+        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log);
+        public IRegistryKey OpenRemoteRegistry(string target);
+        public Task<IRegistryKey> Connect(RegistryHive hive, string machineName);
+    }
+
+    public class RegistryAccessor : IRegistryAccessor {
+        private static readonly AdaptiveTimeout _adaptiveTimeout =
+            new AdaptiveTimeout(maxTimeout: TimeSpan.FromSeconds(10), Logging.LogProvider.CreateLogger(nameof(SHRegistryKey)));
+        
+        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log) {
+            var data = new RegistryResult();
+
+            try {
+                var baseKey = OpenRemoteRegistry(target);
+                var value = baseKey.GetValue(subkey, subvalue);
+                data.Value = value;
+                data.Collected = true;
+            } 
+            catch (IOException e) {
+                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                    target, subkey, subvalue);
+                data.FailureReason = "Target machine was not found or not connectable";
+            } 
+            catch (SecurityException e) {
+                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                  target, subkey, subvalue);
+                data.FailureReason = "User does not have the proper permissions to perform this operation";
+            }
+            catch (UnauthorizedAccessException e) {
+                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                  target, subkey, subvalue);
+                data.FailureReason = "User does not have the necessary registry rights";
+            }
+            catch (Exception e) {
+                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                  target, subkey, subvalue);
+                data.FailureReason = e.Message;
+            }
+
+            return data;
+        }
+
+        public IRegistryKey OpenRemoteRegistry(string target) {
+            return Connect(RegistryHive.LocalMachine, target).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///     Gets a handle to a remote registry.
+        /// </summary>
+        /// <param name="hive"></param>
+        /// <param name="machineName"></param>
+        /// <returns></returns>
+        /// <exception cref="TimeoutException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        /// <exception cref="System.IO.IOException"></exception>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="System.Security.SecurityException"></exception>
+        /// <exception cref="UnauthorizedAccessException"></exception>
+        public async Task<IRegistryKey> Connect(RegistryHive hive, string machineName) {
+            var remoteKey = await _adaptiveTimeout.ExecuteWithTimeout((_) => RegistryKey.OpenRemoteBaseKey(hive, machineName));
+            if (remoteKey.IsSuccess)
+                return new SHRegistryKey(remoteKey.Value);
+            throw new TimeoutException($"Failed to connect to registry on {machineName}: {remoteKey.Error}");
+        }
+    }
+}

--- a/src/CommonLib/IRegistryAccessor.cs
+++ b/src/CommonLib/IRegistryAccessor.cs
@@ -8,41 +8,47 @@ using SharpHoundCommonLib.Processors;
 
 namespace SharpHoundCommonLib {
     public interface IRegistryAccessor {
-        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log);
+        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue);
         public IRegistryKey OpenRemoteRegistry(string target);
         public Task<IRegistryKey> Connect(RegistryHive hive, string machineName);
     }
 
     public class RegistryAccessor : IRegistryAccessor {
-        private static readonly AdaptiveTimeout _adaptiveTimeout =
-            new AdaptiveTimeout(maxTimeout: TimeSpan.FromSeconds(10), Logging.LogProvider.CreateLogger(nameof(SHRegistryKey)));
+        private readonly ILogger _log;
+        private readonly AdaptiveTimeout _adaptiveTimeout;
+
+        public RegistryAccessor(ILogger log = null) {
+            _log = log ?? Logging.LogProvider.CreateLogger(nameof(RegistryAccessor));
+            _adaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromSeconds(10), _log);
+        }
         
-        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue, ILogger log) {
+        public RegistryResult GetRegistryKeyData(string target, string subkey, string subvalue) {
             var data = new RegistryResult();
 
             try {
-                var baseKey = OpenRemoteRegistry(target);
-                var value = baseKey.GetValue(subkey, subvalue);
-                data.Value = value;
-                data.Collected = true;
+                using (var baseKey = OpenRemoteRegistry(target)) {
+                    var value = baseKey.GetValue(subkey, subvalue);
+                    data.Value = value;
+                    data.Collected = true;
+                }
             } 
             catch (IOException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                _log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
                     target, subkey, subvalue);
                 data.FailureReason = "Target machine was not found or not connectable";
             } 
             catch (SecurityException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                _log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
                   target, subkey, subvalue);
                 data.FailureReason = "User does not have the proper permissions to perform this operation";
             }
             catch (UnauthorizedAccessException e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                _log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
                   target, subkey, subvalue);
                 data.FailureReason = "User does not have the necessary registry rights";
             }
             catch (Exception e) {
-                log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
+                _log.LogDebug(e, "Error getting data from registry for {Target}: {RegSubKey}:{RegValue}",
                   target, subkey, subvalue);
                 data.FailureReason = e.Message;
             }

--- a/src/CommonLib/IRegistryKey.cs
+++ b/src/CommonLib/IRegistryKey.cs
@@ -12,7 +12,7 @@ namespace SharpHoundCommonLib {
         private readonly RegistryKey _currentKey;
         private static readonly AdaptiveTimeout _adaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromSeconds(10), Logging.LogProvider.CreateLogger(nameof(SHRegistryKey)));
 
-        private SHRegistryKey(RegistryKey registryKey) {
+        public SHRegistryKey(RegistryKey registryKey) {
             _currentKey = registryKey;
         }
 
@@ -35,6 +35,8 @@ namespace SharpHoundCommonLib {
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="System.Security.SecurityException"></exception>
         /// <exception cref="UnauthorizedAccessException"></exception>
+        /// 
+        //TODO: replace with IRegistryAccessor
         public static async Task<SHRegistryKey> Connect(RegistryHive hive, string machineName) {
             var remoteKey = await _adaptiveTimeout.ExecuteWithTimeout((_) => RegistryKey.OpenRemoteBaseKey(hive, machineName));
             if (remoteKey.IsSuccess)

--- a/src/CommonLib/IRegistryKey.cs
+++ b/src/CommonLib/IRegistryKey.cs
@@ -25,15 +25,4 @@ namespace SharpHoundCommonLib {
             _currentKey.Dispose();
         }
     }
-
-    // public class MockRegistryKey : IRegistryKey {
-    //     public virtual object GetValue(string subkey, string name) {
-    //         //Unimplemented
-    //         return default;
-    //     }
-    //
-    //     public virtual string[] GetSubKeyNames() {
-    //         throw new NotImplementedException();
-    //     }
-    // }
 }

--- a/src/CommonLib/IRegistryKey.cs
+++ b/src/CommonLib/IRegistryKey.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Microsoft.Win32;
 
 namespace SharpHoundCommonLib {
-    public interface IRegistryKey {
+    public interface IRegistryKey: IDisposable {
         public object GetValue(string subkey, string name);
         public string[] GetSubKeyNames();
     }
 
-    public class SHRegistryKey : IRegistryKey, IDisposable {
+    public class SHRegistryKey : IRegistryKey {
         private readonly RegistryKey _currentKey;
-        private static readonly AdaptiveTimeout _adaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromSeconds(10), Logging.LogProvider.CreateLogger(nameof(SHRegistryKey)));
-
+        
         public SHRegistryKey(RegistryKey registryKey) {
             _currentKey = registryKey;
         }
@@ -23,40 +21,19 @@ namespace SharpHoundCommonLib {
 
         public string[] GetSubKeyNames() => _currentKey.GetSubKeyNames();
 
-        /// <summary>
-        /// Gets a handle to a remote registry.
-        /// </summary>
-        /// <param name="hive"></param>
-        /// <param name="machineName"></param>
-        /// <returns></returns>
-        /// <exception cref="TimeoutException"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        /// <exception cref="System.IO.IOException"></exception>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="System.Security.SecurityException"></exception>
-        /// <exception cref="UnauthorizedAccessException"></exception>
-        /// 
-        //TODO: replace with IRegistryAccessor
-        public static async Task<SHRegistryKey> Connect(RegistryHive hive, string machineName) {
-            var remoteKey = await _adaptiveTimeout.ExecuteWithTimeout((_) => RegistryKey.OpenRemoteBaseKey(hive, machineName));
-            if (remoteKey.IsSuccess)
-                return new SHRegistryKey(remoteKey.Value);
-            throw new TimeoutException($"Failed to connect to registry on {machineName}: {remoteKey.Error}");
-        }
-
         public void Dispose() {
             _currentKey.Dispose();
         }
     }
 
-    public class MockRegistryKey : IRegistryKey {
-        public virtual object GetValue(string subkey, string name) {
-            //Unimplemented
-            return default;
-        }
-
-        public virtual string[] GetSubKeyNames() {
-            throw new NotImplementedException();
-        }
-    }
+    // public class MockRegistryKey : IRegistryKey {
+    //     public virtual object GetValue(string subkey, string name) {
+    //         //Unimplemented
+    //         return default;
+    //     }
+    //
+    //     public virtual string[] GetSubKeyNames() {
+    //         throw new NotImplementedException();
+    //     }
+    // }
 }

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -208,6 +208,12 @@ namespace SharpHoundCommonLib.Processors
             var isDomainController = await _utils.IsDomainController(computerObjectId, objectDomain);
             var machineSid = await GetMachineSid(computerName, computerObjectId);
             var descriptor = new RawSecurityDescriptor(regData.Value as byte[], 0);
+            
+            if (descriptor.DiscretionaryAcl is null)
+            {
+                return ret;
+            }
+            
             var enrollmentAgentRestrictions = new List<EnrollmentAgentRestriction>();
             foreach (var genericAce in descriptor.DiscretionaryAcl)
             {

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -248,7 +248,6 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="target"></param>
         /// <param name="caName"></param>
         /// <returns></returns>
-        [ExcludeFromCodeCoverage]
         private RegistryResult GetCASecurity(string target, string caName)
         {
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
@@ -264,7 +263,6 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="target"></param>
         /// <param name="caName"></param>
         /// <returns></returns>
-        [ExcludeFromCodeCoverage]
         private RegistryResult GetEnrollmentAgentRights(string target, string caName)
         {
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
@@ -282,7 +280,6 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="target"></param>
         /// <param name="caName"></param>
         /// <returns></returns>
-        [ExcludeFromCodeCoverage]
         public async Task<BoolRegistryAPIResult> IsUserSpecifiesSanEnabled(string target, string caName, string hostSid)
         {
             var ret = new BoolRegistryAPIResult();
@@ -333,7 +330,6 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="caName"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        [ExcludeFromCodeCoverage]
         public async Task<BoolRegistryAPIResult> RoleSeparationEnabled(string target, string caName, string hostSid)
         {
             var ret = new BoolRegistryAPIResult();

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -258,7 +258,7 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             const string regValue = "Security";
         
-            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             var regValue = "EnrollmentAgentRights";
 
-            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue);
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey =
                 $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string regValue = "EditFlags";
-            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -339,7 +339,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new BoolRegistryAPIResult();
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             const string regValue = "RoleSeparationEnabled";
-            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue);
 
             ret.Collected = data.Collected;
             if (!data.Collected)

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -460,6 +460,10 @@ namespace SharpHoundCommonLib.Processors
                 computerObjectId, machineSid);
 
             var opaque = ace.GetOpaque();
+            
+            if(opaque is null)
+                return (false, default);
+            
             var sidCount = BitConverter.ToUInt32(opaque, 0);
             index += 4;
 

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -20,11 +20,14 @@ namespace SharpHoundCommonLib.Processors
         private readonly ILdapUtils _utils;
         private readonly AdaptiveTimeout _getMachineSidAdaptiveTimeout;
         private readonly AdaptiveTimeout _openSamServerAdaptiveTimeout;
+        private readonly IRegistryAccessor _registryAccessor;
+        
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         public event ComputerStatusDelegate ComputerStatusEvent;
 
-        public CertAbuseProcessor(ILdapUtils utils, ILogger log = null) {
+        public CertAbuseProcessor(ILdapUtils utils, IRegistryAccessor registryAccessor, ILogger log = null) {
             _utils = utils;
+            _registryAccessor = registryAccessor;
             _log = log ?? Logging.LogProvider.CreateLogger("CAProc");
             _getMachineSidAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.GetMachineSid)));
             _openSamServerAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(SAMServer.OpenServer)));
@@ -251,7 +254,8 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             const string regValue = "Security";
         
-            return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            // return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
         }
 
         /// <summary>
@@ -266,7 +270,8 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             var regValue = "EnrollmentAgentRights";
 
-            return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            // return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
         }
 
         /// <summary>
@@ -281,10 +286,11 @@ namespace SharpHoundCommonLib.Processors
         public async Task<BoolRegistryAPIResult> IsUserSpecifiesSanEnabled(string target, string caName, string hostSid)
         {
             var ret = new BoolRegistryAPIResult();
-            var subKey =
+            var regSubKey =
                 $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
-            const string subValue = "EditFlags";
-            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+            const string regValue = "EditFlags";
+            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            // var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -333,7 +339,8 @@ namespace SharpHoundCommonLib.Processors
             var ret = new BoolRegistryAPIResult();
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             const string regValue = "RoleSeparationEnabled";
-            var data = Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
+            // var data = Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -518,7 +525,6 @@ namespace SharpHoundCommonLib.Processors
         {
             if (ComputerStatusEvent is not null) await ComputerStatusEvent(status);
         }
-
     }
 
     public class EnrollmentAgentRestriction

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -23,7 +23,6 @@ namespace SharpHoundCommonLib.Processors
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         public event ComputerStatusDelegate ComputerStatusEvent;
 
-
         public CertAbuseProcessor(ILdapUtils utils, ILogger log = null) {
             _utils = utils;
             _log = log ?? Logging.LogProvider.CreateLogger("CAProc");
@@ -47,9 +46,23 @@ namespace SharpHoundCommonLib.Processors
             data.Collected = aceData.Collected;
             if (!aceData.Collected)
             {
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = aceData.FailureReason,
+                    Task = nameof(ProcessRegistryEnrollmentPermissions),
+                    ComputerName = caName,
+                    ObjectId = computerObjectId,
+                });
+
                 data.FailureReason = aceData.FailureReason;
                 return data;
             }
+            
+            await SendComputerStatus(new CSVComputerStatus {
+                Status = CSVComputerStatus.StatusSuccess,
+                Task = nameof(ProcessRegistryEnrollmentPermissions),
+                ComputerName = caName,
+                ObjectId = computerObjectId,
+            });
 
             if (aceData.Value == null)
             {
@@ -167,9 +180,23 @@ namespace SharpHoundCommonLib.Processors
             ret.Collected = regData.Collected;
             if (!ret.Collected)
             {
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = regData.FailureReason,
+                    Task = nameof(ProcessEAPermissions),
+                    ComputerName = caName,
+                    ObjectId = computerObjectId,
+                });
+
                 ret.FailureReason = regData.FailureReason;
                 return ret;
             }
+            
+            await SendComputerStatus(new CSVComputerStatus {
+                Status = CSVComputerStatus.StatusSuccess,
+                Task = nameof(ProcessEAPermissions),
+                ComputerName = caName,
+                ObjectId = computerObjectId,
+            });
 
             if (regData.Value == null)
             {
@@ -251,7 +278,7 @@ namespace SharpHoundCommonLib.Processors
         /// <param name="caName"></param>
         /// <returns></returns>
         [ExcludeFromCodeCoverage]
-        public BoolRegistryAPIResult IsUserSpecifiesSanEnabled(string target, string caName)
+        public async Task<BoolRegistryAPIResult> IsUserSpecifiesSanEnabled(string target, string caName, string hostSid)
         {
             var ret = new BoolRegistryAPIResult();
             var subKey =
@@ -262,9 +289,23 @@ namespace SharpHoundCommonLib.Processors
             ret.Collected = data.Collected;
             if (!data.Collected)
             {
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = data.FailureReason,
+                    Task = nameof(IsUserSpecifiesSanEnabled),
+                    ComputerName = caName,
+                    ObjectId = hostSid
+                });
+            
                 ret.FailureReason = data.FailureReason;
                 return ret;
             }
+            
+            await SendComputerStatus(new CSVComputerStatus {
+                Status = CSVComputerStatus.StatusSuccess,
+                Task = nameof(IsUserSpecifiesSanEnabled),
+                ComputerName = caName,
+                ObjectId = hostSid
+            });
 
             if (data.Value == null)
             {
@@ -287,7 +328,7 @@ namespace SharpHoundCommonLib.Processors
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
         [ExcludeFromCodeCoverage]
-        public BoolRegistryAPIResult RoleSeparationEnabled(string target, string caName)
+        public async Task<BoolRegistryAPIResult> RoleSeparationEnabled(string target, string caName, string hostSid)
         {
             var ret = new BoolRegistryAPIResult();
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
@@ -297,9 +338,23 @@ namespace SharpHoundCommonLib.Processors
             ret.Collected = data.Collected;
             if (!data.Collected)
             {
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = data.FailureReason,
+                    Task = nameof(RoleSeparationEnabled),
+                    ComputerName = caName,
+                    ObjectId = hostSid
+                });
+
                 ret.FailureReason = data.FailureReason;
                 return ret;
             }
+            
+            await SendComputerStatus(new CSVComputerStatus {
+                Status = CSVComputerStatus.StatusSuccess,
+                Task = nameof(RoleSeparationEnabled),
+                ComputerName = caName,
+                ObjectId = hostSid
+            });
 
             if (data.Value == null)
             {

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Text;
@@ -8,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
-using SharpHoundRPC;
 using SharpHoundRPC.Wrappers;
 using Encoder = Microsoft.Security.Application.Encoder;
 
@@ -37,9 +35,10 @@ namespace SharpHoundCommonLib.Processors
         /// This function should be called with the security data fetched from <see cref="GetCASecurity"/>.
         /// The resulting ACEs will contain the owner of the CA as well as Management rights.
         /// </summary>
-        /// <param name="security"></param>
+        /// <param name="caName"></param>
         /// <param name="objectDomain"></param>
         /// <param name="computerName"></param>
+        /// <param name="computerObjectId"></param>
         /// <returns></returns>
         public async Task<AceRegistryAPIResult> ProcessRegistryEnrollmentPermissions(string caName, string objectDomain, string computerName, string computerObjectId)
         {
@@ -52,7 +51,7 @@ namespace SharpHoundCommonLib.Processors
                 await SendComputerStatus(new CSVComputerStatus {
                     Status = aceData.FailureReason,
                     Task = nameof(ProcessRegistryEnrollmentPermissions),
-                    ComputerName = caName,
+                    ComputerName = computerName,
                     ObjectId = computerObjectId,
                 });
 
@@ -63,7 +62,7 @@ namespace SharpHoundCommonLib.Processors
             await SendComputerStatus(new CSVComputerStatus {
                 Status = CSVComputerStatus.StatusSuccess,
                 Task = nameof(ProcessRegistryEnrollmentPermissions),
-                ComputerName = caName,
+                ComputerName = computerName,
                 ObjectId = computerObjectId,
             });
 
@@ -186,7 +185,7 @@ namespace SharpHoundCommonLib.Processors
                 await SendComputerStatus(new CSVComputerStatus {
                     Status = regData.FailureReason,
                     Task = nameof(ProcessEAPermissions),
-                    ComputerName = caName,
+                    ComputerName = computerName,
                     ObjectId = computerObjectId,
                 });
 
@@ -197,7 +196,7 @@ namespace SharpHoundCommonLib.Processors
             await SendComputerStatus(new CSVComputerStatus {
                 Status = CSVComputerStatus.StatusSuccess,
                 Task = nameof(ProcessEAPermissions),
-                ComputerName = caName,
+                ComputerName = computerName,
                 ObjectId = computerObjectId,
             });
 
@@ -277,8 +276,9 @@ namespace SharpHoundCommonLib.Processors
         /// <remarks>https://blog.keyfactor.com/hidden-dangers-certificate-subject-alternative-names-sans</remarks>
         /// <param name="target"></param>
         /// <param name="caName"></param>
+        /// <param name="computerObjectId"></param>
         /// <returns></returns>
-        public async Task<BoolRegistryAPIResult> IsUserSpecifiesSanEnabled(string target, string caName, string hostSid)
+        public async Task<BoolRegistryAPIResult> IsUserSpecifiesSanEnabled(string target, string caName, string computerObjectId)
         {
             var ret = new BoolRegistryAPIResult();
             var regSubKey =
@@ -292,8 +292,8 @@ namespace SharpHoundCommonLib.Processors
                 await SendComputerStatus(new CSVComputerStatus {
                     Status = data.FailureReason,
                     Task = nameof(IsUserSpecifiesSanEnabled),
-                    ComputerName = caName,
-                    ObjectId = hostSid
+                    ComputerName = target,
+                    ObjectId = computerObjectId
                 });
             
                 ret.FailureReason = data.FailureReason;
@@ -303,8 +303,8 @@ namespace SharpHoundCommonLib.Processors
             await SendComputerStatus(new CSVComputerStatus {
                 Status = CSVComputerStatus.StatusSuccess,
                 Task = nameof(IsUserSpecifiesSanEnabled),
-                ComputerName = caName,
-                ObjectId = hostSid
+                ComputerName = target,
+                ObjectId = computerObjectId
             });
 
             if (data.Value == null)
@@ -319,15 +319,16 @@ namespace SharpHoundCommonLib.Processors
         }
 
         /// <summary>
-        /// This function checks a registry setting on the target host for the specified CA to see if role seperation is enabled.
+        /// This function checks a registry setting on the target host for the specified CA to see if role separation is enabled.
         /// If enabled, you cannot perform any CA actions if you have both ManageCA and ManageCertificates permissions. Only CA admins can modify the setting.
         /// </summary>
         /// <remarks>https://www.itprotoday.com/security/q-how-can-i-make-sure-given-windows-account-assigned-only-single-certification-authority-ca</remarks>
         /// <param name="target"></param>
         /// <param name="caName"></param>
+        /// <param name="computerObjectId"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public async Task<BoolRegistryAPIResult> RoleSeparationEnabled(string target, string caName, string hostSid)
+        public async Task<BoolRegistryAPIResult> IsRoleSeparationEnabled(string target, string caName, string computerObjectId)
         {
             var ret = new BoolRegistryAPIResult();
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
@@ -339,9 +340,9 @@ namespace SharpHoundCommonLib.Processors
             {
                 await SendComputerStatus(new CSVComputerStatus {
                     Status = data.FailureReason,
-                    Task = nameof(RoleSeparationEnabled),
-                    ComputerName = caName,
-                    ObjectId = hostSid
+                    Task = nameof(IsRoleSeparationEnabled),
+                    ComputerName = target,
+                    ObjectId = computerObjectId
                 });
 
                 ret.FailureReason = data.FailureReason;
@@ -350,9 +351,9 @@ namespace SharpHoundCommonLib.Processors
             
             await SendComputerStatus(new CSVComputerStatus {
                 Status = CSVComputerStatus.StatusSuccess,
-                Task = nameof(RoleSeparationEnabled),
-                ComputerName = caName,
-                ObjectId = hostSid
+                Task = nameof(IsRoleSeparationEnabled),
+                ComputerName = target,
+                ObjectId = computerObjectId
             });
 
             if (data.Value == null)

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -254,7 +254,6 @@ namespace SharpHoundCommonLib.Processors
             const string regValue = "Security";
         
             return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
-            // return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
         }
 
         /// <summary>
@@ -269,7 +268,6 @@ namespace SharpHoundCommonLib.Processors
             var regValue = "EnrollmentAgentRights";
 
             return _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
-            // return Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
         }
 
         /// <summary>
@@ -287,7 +285,6 @@ namespace SharpHoundCommonLib.Processors
                 $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string regValue = "EditFlags";
             var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
-            // var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -336,7 +333,6 @@ namespace SharpHoundCommonLib.Processors
             var regSubKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}";
             const string regValue = "RoleSeparationEnabled";
             var data = _registryAccessor.GetRegistryKeyData(target, regSubKey, regValue, _log);
-            // var data = Helpers.GetRegistryKeyData(target, regSubKey, regValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)

--- a/src/CommonLib/Processors/CertAbuseProcessor.cs
+++ b/src/CommonLib/Processors/CertAbuseProcessor.cs
@@ -19,16 +19,18 @@ namespace SharpHoundCommonLib.Processors
         private readonly AdaptiveTimeout _getMachineSidAdaptiveTimeout;
         private readonly AdaptiveTimeout _openSamServerAdaptiveTimeout;
         private readonly IRegistryAccessor _registryAccessor;
+        private readonly ISAMServerAccessor _samServerAccessor;
         
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         public event ComputerStatusDelegate ComputerStatusEvent;
 
-        public CertAbuseProcessor(ILdapUtils utils, IRegistryAccessor registryAccessor, ILogger log = null) {
+        public CertAbuseProcessor(ILdapUtils utils, IRegistryAccessor registryAccessor, ISAMServerAccessor samServerAccessor, ILogger log = null) {
             _utils = utils;
             _registryAccessor = registryAccessor;
+            _samServerAccessor = samServerAccessor;
             _log = log ?? Logging.LogProvider.CreateLogger("CAProc");
             _getMachineSidAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.GetMachineSid)));
-            _openSamServerAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(SAMServer.OpenServer)));
+            _openSamServerAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServerAccessor.OpenServer)));
         }
 
         /// <summary>
@@ -407,11 +409,11 @@ namespace SharpHoundCommonLib.Processors
             return await _utils.ResolveIDAndType(sid.Value, computerDomain);
         }
 
-        private async Task<SecurityIdentifier> GetMachineSid(string computerName, string computerObjectId)
+        internal async Task<SecurityIdentifier> GetMachineSid(string computerName, string computerObjectId)
         {
             SecurityIdentifier machineSid = null;
 
-            //Try to get the machine sid for the computer if its not already cached
+            //Try to get the machine sid for the computer if it's not already cached
             if (!Cache.GetMachineSid(computerObjectId, out var tempMachineSid))
             {
                 // Open a handle to the server
@@ -421,7 +423,7 @@ namespace SharpHoundCommonLib.Processors
                     _log.LogTrace("OpenServer failed on {ComputerName}: {Error}", computerName, openServerResult.SError);
                     await SendComputerStatus(new CSVComputerStatus
                     {
-                        Task = "SamConnect",
+                        Task = nameof(OpenSamServer),
                         ComputerName = computerName,
                         Status = openServerResult.SError,
                         ObjectId = computerObjectId,
@@ -438,14 +440,21 @@ namespace SharpHoundCommonLib.Processors
                     {
                         Status = getMachineSidResult.SError,
                         ComputerName = computerName,
-                        Task = "GetMachineSid",
+                        Task = nameof(GetMachineSid),
                         ObjectId = computerObjectId,
                     });
-                    //If we can't get a machine sid, we wont be able to make local principals with unique object ids, or differentiate local/domain objects
+                    //If we can't get a machine sid, we won't be able to make local principals with unique object ids, or differentiate local/domain objects
                     _log.LogWarning("Unable to get machineSid for {Computer}: {Status}", computerName, getMachineSidResult.SError);
                     return null;
                 }
 
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = CSVComputerStatus.StatusSuccess,
+                    Task = nameof(GetMachineSid),
+                    ComputerName = computerName,
+                    ObjectId = computerObjectId
+                });
+                
                 machineSid = getMachineSidResult.Value;
                 Cache.AddMachineSid(computerObjectId, machineSid.Value);
             }
@@ -457,26 +466,28 @@ namespace SharpHoundCommonLib.Processors
             return machineSid;
         }
 
-        private async Task<(bool success, EnrollmentAgentRestriction restriction)> CreateEnrollmentAgentRestriction(QualifiedAce ace, string computerDomain, string computerName, bool isDomainController, string computerObjectId, SecurityIdentifier machineSid) {
+        internal async Task<(bool success, EnrollmentAgentRestriction restriction)> CreateEnrollmentAgentRestriction(QualifiedAce ace, string computerDomain, string computerName, bool isDomainController, string computerObjectId, SecurityIdentifier machineSid) 
+        {
+            var opaque = ace.GetOpaque();
+            
+            if(opaque is null)
+                return (false, default);
+            
             var targets = new List<TypedPrincipal>();
             var index = 0;
 
             var accessType = ace.AceType.ToString();
             var agent = await GetRegistryPrincipal(ace.SecurityIdentifier, computerDomain, computerName, isDomainController,
                 computerObjectId, machineSid);
-
-            var opaque = ace.GetOpaque();
-            
-            if(opaque is null)
-                return (false, default);
             
             var sidCount = BitConverter.ToUInt32(opaque, 0);
             index += 4;
 
             for (var i = 0; i < sidCount; i++) {
                 var sid = new SecurityIdentifier(opaque, index);
-                if (await GetRegistryPrincipal(sid, computerDomain, computerName, isDomainController, computerObjectId,
-                        machineSid) is (true, var regPrincipal)) {
+                if (await GetRegistryPrincipal(sid, computerDomain, computerName, isDomainController, computerObjectId, machineSid)
+                    is (true, var regPrincipal))
+                {
                     targets.Add(regPrincipal);
                 }
 
@@ -485,43 +496,47 @@ namespace SharpHoundCommonLib.Processors
 
             var finalTargets = targets.ToArray();
             var allTemplates = index >= opaque.Length;
-            if (index < opaque.Length) {
-                var template = Encoding.Unicode.GetString(opaque, index, opaque.Length - index - 2).Replace("\u0000", string.Empty);
-                if (await _utils.ResolveCertTemplateByProperty(Encoder.LdapFilterEncode(template), LDAPProperties.CanonicalName, computerDomain) is (true, var resolvedTemplate)) {
-                    return (true, new EnrollmentAgentRestriction {
-                        Template = resolvedTemplate,
-                        Agent = agent.Principal,
-                        AllTemplates = allTemplates,
-                        AccessType = accessType,
-                        Targets = finalTargets
-                    });
-                }
-
-                if (await _utils.ResolveCertTemplateByProperty(
-                        Encoder.LdapFilterEncode(template), LDAPProperties.CertTemplateOID, computerDomain) is
-                            (true, var resolvedOidTemplate)) {
-                    return (true, new EnrollmentAgentRestriction {
-                        Template = resolvedOidTemplate,
-                        Agent = agent.Principal,
-                        AllTemplates = allTemplates,
-                        AccessType = accessType,
-                        Targets = finalTargets
-                    });
-                }
+            
+            if (allTemplates) {
+                return (true, new EnrollmentAgentRestriction {
+                    Agent = agent.Principal,
+                    AllTemplates = allTemplates,
+                    AccessType = accessType,
+                    Targets = finalTargets
+                });
+            }
+            
+            var template = Encoding.Unicode.GetString(opaque, index, opaque.Length - index - 2).Replace("\u0000", string.Empty);
+            if (await _utils.ResolveCertTemplateByProperty(Encoder.LdapFilterEncode(template), LDAPProperties.CanonicalName, computerDomain)
+                is (true, var resolvedTemplate)) 
+            {
+                return (true, new EnrollmentAgentRestriction {
+                    Template = resolvedTemplate,
+                    Agent = agent.Principal,
+                    AllTemplates = allTemplates,
+                    AccessType = accessType,
+                    Targets = finalTargets
+                });
             }
 
+            if (await _utils.ResolveCertTemplateByProperty(Encoder.LdapFilterEncode(template), LDAPProperties.CertTemplateOID, computerDomain)
+                is (true, var resolvedOidTemplate))
+            {
+                return (true, new EnrollmentAgentRestriction {
+                    Template = resolvedOidTemplate,
+                    Agent = agent.Principal,
+                    AllTemplates = allTemplates,
+                    AccessType = accessType,
+                    Targets = finalTargets
+                });
+            }
+            
             return (false, default);
         }
 
         public virtual SharpHoundRPC.Result<ISAMServer> OpenSamServer(string computerName)
         {
-            var result = _openSamServerAdaptiveTimeout.ExecuteRPCWithTimeout((_) => SAMServer.OpenServer(computerName)).GetAwaiter().GetResult();
-            if (result.IsFailed)
-            {
-                return SharpHoundRPC.Result<ISAMServer>.Fail(result.SError);
-            }
-
-            return SharpHoundRPC.Result<ISAMServer>.Ok(result.Value);
+            return _openSamServerAdaptiveTimeout.ExecuteRPCWithTimeout((_) => _samServerAccessor.OpenServer(computerName)).GetAwaiter().GetResult();
         }
 
         private async Task SendComputerStatus(CSVComputerStatus status)

--- a/src/CommonLib/Processors/ComputerSessionProcessor.cs
+++ b/src/CommonLib/Processors/ComputerSessionProcessor.cs
@@ -24,6 +24,7 @@ namespace SharpHoundCommonLib.Processors {
         private readonly string _localAdminPassword;
         private readonly AdaptiveTimeout _readUserSessionsAdaptiveTimeout;
         private readonly AdaptiveTimeout _readUserSessionsPriviledgedAdaptiveTimeout;
+        private readonly IRegistryAccessor _registryAccessor;
 
         public ComputerSessionProcessor(ILdapUtils utils,
             NativeMethods nativeMethods = null, ILogger log = null, string currentUserName = null,
@@ -38,6 +39,7 @@ namespace SharpHoundCommonLib.Processors {
             _localAdminPassword = localAdminPassword;
             _readUserSessionsAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ReadUserSessions)));
             _readUserSessionsPriviledgedAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ReadUserSessionsPrivileged)));
+            _registryAccessor = new RegistryAccessor();
         }
 
         public event ComputerStatusDelegate ComputerStatusEvent;
@@ -293,7 +295,7 @@ namespace SharpHoundCommonLib.Processors {
             _log.LogDebug("Running RegSessionEnum for {ObjectName}", computerName);
 
             try {
-                using (var key = await SHRegistryKey.Connect(RegistryHive.Users, computerName)) {
+                using (var key = await _registryAccessor.Connect(RegistryHive.Users, computerName)) {
                     ret.Collected = true;
                     await SendComputerStatus(new CSVComputerStatus {
                         Status = CSVComputerStatus.StatusSuccess,

--- a/src/CommonLib/Processors/DCRegistryProcessor.cs
+++ b/src/CommonLib/Processors/DCRegistryProcessor.cs
@@ -1,5 +1,4 @@
 ﻿using SharpHoundCommonLib.OutputTypes;
-using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -17,8 +16,7 @@ namespace SharpHoundCommonLib.Processors
         public DCRegistryProcessor(ILdapUtils utils, ILogger log = null)
         {
             _utils = utils;
-            //TODO: inject dependency and mock for Unit Tests
-            _registryAccessor = new RegistryAccessor();
+            _registryAccessor = new RegistryAccessor(log);
             _log = log ?? Logging.LogProvider.CreateLogger("DCRegProc");
         }
 
@@ -34,7 +32,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new IntRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Control\SecurityProviders\Schannel";
             const string subValue = "CertificateMappingMethods";
-            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -66,7 +64,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new IntRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Services\Kdc";
             const string subValue = "StrongCertificateBindingEnforcement";
-            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -98,7 +96,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new StrRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Services\Netlogon\Parameters";
             const string subValue = "VulnerableChannelAllowList";
-            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue);
 
             ret.Collected = data.Collected;
             if (!data.Collected)

--- a/src/CommonLib/Processors/DCRegistryProcessor.cs
+++ b/src/CommonLib/Processors/DCRegistryProcessor.cs
@@ -9,12 +9,16 @@ namespace SharpHoundCommonLib.Processors
     public class DCRegistryProcessor
     {
         private readonly ILogger _log;
+        private readonly IRegistryAccessor _registryAccessor;
+        
         public readonly ILdapUtils _utils;
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
 
         public DCRegistryProcessor(ILdapUtils utils, ILogger log = null)
         {
             _utils = utils;
+            //TODO: inject dependency and mock for Unit Tests
+            _registryAccessor = new RegistryAccessor();
             _log = log ?? Logging.LogProvider.CreateLogger("DCRegProc");
         }
 
@@ -30,7 +34,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new IntRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Control\SecurityProviders\Schannel";
             const string subValue = "CertificateMappingMethods";
-            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -62,7 +66,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new IntRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Services\Kdc";
             const string subValue = "StrongCertificateBindingEnforcement";
-            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)
@@ -94,7 +98,7 @@ namespace SharpHoundCommonLib.Processors
             var ret = new StrRegistryAPIResult();
             const string subKey = @"SYSTEM\CurrentControlSet\Services\Netlogon\Parameters";
             const string subValue = "VulnerableChannelAllowList";
-            var data = Helpers.GetRegistryKeyData(target, subKey, subValue, _log);
+            var data = _registryAccessor.GetRegistryKeyData(target, subKey, subValue, _log);
 
             ret.Collected = data.Collected;
             if (!data.Collected)

--- a/src/CommonLib/Processors/LocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/LocalGroupProcessor.cs
@@ -16,6 +16,7 @@ namespace SharpHoundCommonLib.Processors
         public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
         private readonly ILogger _log;
         private readonly ILdapUtils _utils;
+        private readonly ISAMServerAccessor _samServerAccessor;
         private readonly AdaptiveTimeout _getMachineSidAdaptiveTimeout;
         private readonly AdaptiveTimeout _openSamServerAdaptiveTimeout;
         private readonly AdaptiveTimeout _getDomainsAdaptiveTimeout;
@@ -27,9 +28,10 @@ namespace SharpHoundCommonLib.Processors
 
         public LocalGroupProcessor(ILdapUtils utils, ILogger log = null) {
             _utils = utils;
+            _samServerAccessor = new SAMServerAccessor();
             _log = log ?? Logging.LogProvider.CreateLogger("LocalGroupProcessor");
             _getMachineSidAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.GetMachineSid)));
-            _openSamServerAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(SAMServer.OpenServer)));
+            _openSamServerAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServerAccessor.OpenServer)));
             _getDomainsAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.GetDomains)));
             _openDomainAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.OpenDomain)));
             _getAliasesAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMDomain.GetAliases)));
@@ -42,7 +44,7 @@ namespace SharpHoundCommonLib.Processors
 
         public virtual SharpHoundRPC.Result<ISAMServer> OpenSamServer(string computerName)
         {
-            var result = _openSamServerAdaptiveTimeout.ExecuteRPCWithTimeout((_) => SAMServer.OpenServer(computerName)).GetAwaiter().GetResult();
+            var result = _openSamServerAdaptiveTimeout.ExecuteRPCWithTimeout((_) => _samServerAccessor.OpenServer(computerName)).GetAwaiter().GetResult();
             if (result.IsFailed)
             {
                 return SharpHoundRPC.Result<ISAMServer>.Fail(result.SError);

--- a/src/SharpHoundRPC/SAMRPCNative/SAMMethods.cs
+++ b/src/SharpHoundRPC/SAMRPCNative/SAMMethods.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Security.Principal;
 using SharpHoundRPC.Handles;
 using SharpHoundRPC.Shared;
 

--- a/src/SharpHoundRPC/Wrappers/ISAMServerAccessor.cs
+++ b/src/SharpHoundRPC/Wrappers/ISAMServerAccessor.cs
@@ -1,0 +1,27 @@
+﻿using SharpHoundRPC.SAMRPCNative;
+
+namespace SharpHoundRPC.Wrappers
+{
+    public interface ISAMServerAccessor
+    {
+        Result<ISAMServer> OpenServer(string computerName, SAMEnums.SamAccessMasks requestedConnectAccess =
+            SAMEnums.SamAccessMasks.SamServerConnect |
+            SAMEnums.SamAccessMasks.SamServerEnumerateDomains |
+            SAMEnums.SamAccessMasks.SamServerLookupDomain);
+    }
+
+    public class SAMServerAccessor : ISAMServerAccessor
+    {
+        public Result<ISAMServer> OpenServer(string computerName, SAMEnums.SamAccessMasks requestedConnectAccess =
+            SAMEnums.SamAccessMasks.SamServerConnect |
+            SAMEnums.SamAccessMasks.SamServerEnumerateDomains |
+            SAMEnums.SamAccessMasks.SamServerLookupDomain)
+        {
+            var (status, handle) = SAMMethods.SamConnect(computerName, requestedConnectAccess);
+
+            return status.IsError()
+                ? status
+                : new SAMServer(handle, computerName);
+        }
+    }
+}

--- a/src/SharpHoundRPC/Wrappers/SAMServer.cs
+++ b/src/SharpHoundRPC/Wrappers/SAMServer.cs
@@ -22,19 +22,6 @@ namespace SharpHoundRPC.Wrappers
 
         public string ComputerName { get; }
 
-        public static Result<SAMServer> OpenServer(string computerName, SAMEnums.SamAccessMasks requestedConnectAccess =
-            SAMEnums.SamAccessMasks.SamServerConnect |
-            SAMEnums.SamAccessMasks
-                .SamServerEnumerateDomains |
-            SAMEnums.SamAccessMasks.SamServerLookupDomain)
-        {
-            var (status, handle) = SAMMethods.SamConnect(computerName, requestedConnectAccess);
-
-            return status.IsError()
-                ? status
-                : new SAMServer(handle, computerName);
-        }
-
         public Result<IEnumerable<(string Name, int Rid)>> GetDomains()
         {
             var (status, rids, count) = SAMMethods.SamEnumerateDomainsInSamServer(Handle);

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.AccessControl;
+﻿using System;
+using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Threading.Tasks;
 using Moq;
@@ -147,7 +148,46 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        //TODO: mock SAM server for sid lookups instead of fetching from localhost
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenDaclIsNull() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+            
+            //setup binary security descriptor as registry value
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.None,
+                null,
+                null,
+                null,
+                null);
+            
+            var regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    "localhost",
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+        
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+        
+            //Validate CompStatus Log
+            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenDaclIsEmpty() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
@@ -173,9 +213,6 @@ namespace CommonLibTest
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  true, Value = regValue });
-            
-            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
-                .ReturnsAsync(true);
         
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
         
@@ -191,7 +228,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsNull() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
@@ -227,9 +264,6 @@ namespace CommonLibTest
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  true, Value = regValue });
-            
-            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
-                .ReturnsAsync(true);
         
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
         
@@ -245,7 +279,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsEmpty() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
@@ -281,9 +315,6 @@ namespace CommonLibTest
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  true, Value = regValue });
-            
-            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
-                .ReturnsAsync(true);
         
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
         
@@ -325,33 +356,50 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: test happy path
-        // [Fact]
-        // public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsResult() {
-        //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-        //     const string subValue = "Security";
-        //     
-        //     _mockRegistryAccessor
-        //         .Setup(ra => ra.GetRegistryKeyData(
-        //             Target,
-        //             subKey,
-        //             subValue,
-        //             It.IsAny<ILogger>()))
-        //         .Returns(new RegistryResult { Collected =  true, Value = "regValue" });
-        //
-        //     var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, Target, HostSid);
-        //
-        //     //Validate result
-        //     Assert.True(results.Collected);
-        //     Assert.Equal(new ACE[0], results.Data);
-        //     Assert.Null(results.FailureReason);
-        //
-        //     //Validate CompStatus Log
-        //     Assert.Equal(CAName, _receivedCompStatus.ComputerName);
-        //     Assert.Equal(nameof(CertAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
-        //     Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-        //     Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
-        // }
+        //TODO: mock SAM server for sid lookups instead of fetching from localhost
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerSidNoRules() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "Security";
+            
+            //setup binary security descriptor as registry value
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,  //owner is null
+                null,
+                null,
+                null);
+            
+            byte[] regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+            
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    "localhost",
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue});
+        
+            //get access rules returns empty
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns([]);
+            _mockLdapUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            
+            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+
+            //Validate result 
+            Assert.True(results.Collected);
+            Assert.Empty(results.Data);
+            Assert.Null(results.FailureReason);
+        
+            //Validate CompStatus Log
+            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
         
         [Fact]
         public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_HandlesFailedLookup() {

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -625,7 +625,7 @@ namespace CommonLibTest
             //Validate CompStatus Log
             Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
             Assert.Equal(nameof(_certAbuseProcessor.GetMachineSid), _receivedCompStatus.Task);
-            Assert.Equal(ComputerStatus.Success, _receivedCompStatus.Status);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Threading.Tasks;
@@ -147,165 +148,57 @@ namespace CommonLibTest
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
-        
-        //TODO: mock SAM server for sid lookups instead of fetching from localhost
-        [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenDaclIsNull() {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "EnrollmentAgentRights";
-            
-            //setup binary security descriptor as registry value
-            var descriptor = new RawSecurityDescriptor(
-                ControlFlags.None,
-                null,
-                null,
-                null,
-                null);
-            
-            var regValue = new byte[descriptor.BinaryLength];
-            descriptor.GetBinaryForm(regValue, 0);
 
-            _mockRegistryAccessor
-                .Setup(ra => ra.GetRegistryKeyData(
-                    "localhost",
-                    subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue });
-        
-            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
-        
-            //Validate result
-            Assert.True(results.Collected);
-            Assert.Empty(results.Restrictions);
-            Assert.Null(results.FailureReason);
-        
-            //Validate CompStatus Log
-            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
-        }
-        
-        //TODO: mock SAM server for sid lookups instead of fetching from localhost
-        [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenDaclIsEmpty() {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "EnrollmentAgentRights";
-            
-            //setup binary security descriptor as registry value
-            var dacl = new RawAcl(2, 0); //dacl is empty
-            
-            var descriptor = new RawSecurityDescriptor(
-                ControlFlags.DiscretionaryAclPresent,
-                null,
-                null,
-                null,
-                dacl);
-            
-            byte[] regValue = new byte[descriptor.BinaryLength];
-            descriptor.GetBinaryForm(regValue, 0);
-
-            _mockRegistryAccessor
-                .Setup(ra => ra.GetRegistryKeyData(
-                    "localhost",
-                    subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue });
-        
-            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
-        
-            //Validate result
-            Assert.True(results.Collected);
-            Assert.Empty(results.Restrictions);
-            Assert.Null(results.FailureReason);
-        
-            //Validate CompStatus Log
-            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
-        }
-        
-        //TODO: mock SAM server for sid lookups instead of fetching from localhost
-        [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsNull() {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "EnrollmentAgentRights";
-            
-            //setup binary security descriptor as registry value
-            var ace = new CommonAce(
+        public static IEnumerable<object[]> ProcessEAPermissionsTestData() {
+            var nullOpaqueAce = new CommonAce(
                 AceFlags.None,
                 AceQualifier.AccessAllowed,
-                0x00020089,
+                0x0000,
                 new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
                 false,
-                null //is callback false, null opaque
+                null
             );
             
-            var dacl = new RawAcl(2, 1);
-            dacl.InsertAce(0, ace);
+            var daclWithNullOpaque = new RawAcl(2, 1);
+            daclWithNullOpaque.InsertAce(0, nullOpaqueAce);
             
-            var descriptor = new RawSecurityDescriptor(
-                ControlFlags.DiscretionaryAclPresent,
-                null,
-                null,
-                null,
-                dacl);
-            
-            byte[] regValue = new byte[descriptor.BinaryLength];
-            descriptor.GetBinaryForm(regValue, 0);
+            var emptyOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[] { 0, 0, 0, 0 }
+            );
 
-            _mockRegistryAccessor
-                .Setup(ra => ra.GetRegistryKeyData(
-                    "localhost",
-                    subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue });
-        
-            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
-        
-            //Validate result
-            Assert.True(results.Collected);
-            Assert.Empty(results.Restrictions);
-            Assert.Null(results.FailureReason);
-        
-            //Validate CompStatus Log
-            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+            var daclWithEmptyOpaque = new RawAcl(2, 1);
+            daclWithEmptyOpaque.InsertAce(0, emptyOpaqueAce);
+            
+            return new List<object[]>
+            {
+                new object[] { null }, //null dacl
+                new object[] { new RawAcl(2, 0) }, //empty dacl
+                new object[] { daclWithNullOpaque }, //dacl is callback false, null opaque
+                new object[] { daclWithEmptyOpaque }, //dacl is callback true, empty opaque
+            };
         }
         
         //TODO: mock SAM server for sid lookups instead of fetching from localhost
-        [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsEmpty() {
+        [WindowsOnlyTheory]
+        [MemberData(nameof(ProcessEAPermissionsTestData))]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty(RawAcl dacl) {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "EnrollmentAgentRights";
             
             //setup binary security descriptor as registry value
-            var ace = new CommonAce(
-                AceFlags.None,
-                AceQualifier.AccessAllowed,
-                0x00020089,
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
-                true,
-                new byte[] { 0, 0, 0, 0 } //is callback true, empty opaque
-            );
-            
-            var dacl = new RawAcl(2, 1);
-            dacl.InsertAce(0, ace);
-            
             var descriptor = new RawSecurityDescriptor(
                 ControlFlags.DiscretionaryAclPresent,
                 null,
                 null,
                 null,
                 dacl);
-
-            byte[] regValue = new byte[descriptor.BinaryLength];
+            
+            var regValue = new byte[descriptor.BinaryLength];
             descriptor.GetBinaryForm(regValue, 0);
 
             _mockRegistryAccessor
@@ -358,7 +251,7 @@ namespace CommonLibTest
         
         //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerSidNoRules() {
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerAndNoRules() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "Security";
             

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,6 +1,6 @@
-﻿using System.Security.Principal;
+﻿using System.Security.AccessControl;
+using System.Security.Principal;
 using System.Threading.Tasks;
-using CommonLibTest.Facades;
 using Moq;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Processors;
@@ -28,7 +28,7 @@ namespace CommonLibTest
         public CertAbuseProcessorTest() {
             _mockLdapUtils = new Mock<ILdapUtils>();
             _mockRegistryAccessor = new Mock<IRegistryAccessor>();
-            _certAbuseProcessor = new CertAbuseProcessor(new MockLdapUtils(), _mockRegistryAccessor.Object);
+            _certAbuseProcessor = new CertAbuseProcessor(_mockLdapUtils.Object, _mockRegistryAccessor.Object);
             
             _certAbuseProcessor.ComputerStatusEvent += status =>
             {
@@ -147,33 +147,157 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: test happy path
-        // [Fact]
-        // public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsResult() {
-        //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-        //     const string subValue = "EnrollmentAgentRights";
-        //     
-        //     _mockRegistryAccessor
-        //         .Setup(ra => ra.GetRegistryKeyData(
-        //             Target,
-        //             subKey,
-        //             subValue,
-        //             It.IsAny<ILogger>()))
-        //         .Returns(new RegistryResult { Collected =  true, Value = "regValue" });
-        //
-        //     var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, Target, HostSid);
-        //
-        //     //Validate result
-        //     Assert.True(results.Collected);
-        //     Assert.Equal(new EnrollmentAgentRestriction[0], results.Restrictions);
-        //     Assert.Null(results.FailureReason);
-        //
-        //     //Validate CompStatus Log
-        //     Assert.Equal(CAName, _receivedCompStatus.ComputerName);
-        //     Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
-        //     Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-        //     Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
-        // }
+        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenDaclIsEmpty() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+            
+            //setup binary security descriptor as registry value
+            var dacl = new RawAcl(2, 0); //dacl is empty
+            
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,
+                null,
+                null,
+                dacl);
+            
+            byte[] regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    "localhost",
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+            
+            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
+                .ReturnsAsync(true);
+        
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+        
+            //Validate CompStatus Log
+            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsNull() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+            
+            //setup binary security descriptor as registry value
+            var ace = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x00020089,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                false,
+                null //is callback false, null opaque
+            );
+            
+            var dacl = new RawAcl(2, 1);
+            dacl.InsertAce(0, ace);
+            
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,
+                null,
+                null,
+                dacl);
+            
+            byte[] regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    "localhost",
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+            
+            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
+                .ReturnsAsync(true);
+        
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+        
+            //Validate CompStatus Log
+            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        //TODO: mock SAM server, for sid lookups instead of fetching from localhost
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty_WhenOpaqueIsEmpty() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+            
+            //setup binary security descriptor as registry value
+            var ace = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x00020089,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[] { 0, 0, 0, 0 } //is callback true, empty opaque
+            );
+            
+            var dacl = new RawAcl(2, 1);
+            dacl.InsertAce(0, ace);
+            
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,
+                null,
+                null,
+                dacl);
+
+            byte[] regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    "localhost",
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+            
+            _mockLdapUtils.Setup(x => x.IsDomainController(TargetDomainSid, DomainName))
+                .ReturnsAsync(true);
+        
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+        
+            //Validate CompStatus Log
+            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
         
         [Fact]
         public async Task CertAbuseProcessor_ProcessEAPermissions_HandlesFailedLookup() {
@@ -260,9 +384,16 @@ namespace CommonLibTest
             const string validCN = "ValidCN";
             const string invalidCN = "InvalidCN";
             
+            _mockLdapUtils
+                .Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string cn, string _, string _) =>
+                    cn == validCN
+                        ? (true, new TypedPrincipal("test guid", Label.CertTemplate))
+                        : (false, null));
+            
             var results = await _certAbuseProcessor.ProcessCertTemplates([validCN, invalidCN], DomainName);
 
-            var expectedTemplate = new TypedPrincipal("guid", Label.CertTemplate);
+            var expectedTemplate = new TypedPrincipal("test guid", Label.CertTemplate);
             Assert.Single(results.resolvedTemplates);
             Assert.Contains(expectedTemplate, results.resolvedTemplates);
             Assert.Single(results.unresolvedTemplates);
@@ -284,28 +415,28 @@ namespace CommonLibTest
                 TargetName,
                 true,
                 TargetDomainSid,
-                new SecurityIdentifier(TargetDomainSid)
+                new SecurityIdentifier("S-1-5-18")
             );
 
             Assert.Equal((false, null), results);
         }
         
         [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsTrueForDomainController() {
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvedDomainController_ReturnsTrue() {
             var expectedPrincipalType = Label.Group;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var domainSid = new SecurityIdentifier(expectedPrincipalSID);
+            var sid = new SecurityIdentifier(expectedPrincipalSID);
             
             _mockLdapUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
             
             var results = await _certAbuseProcessor.GetRegistryPrincipal(
-                domainSid,
+                sid,
                 DomainName,
                 TargetName,
                 true,
                 TargetDomainSid,
-                new SecurityIdentifier("S-1-5-21-3130019616-2776909439-2417379446-1104")
+                new SecurityIdentifier("S-1-5-18")
             );
 
             Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.DirectoryServices;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using Moq;
@@ -8,20 +9,98 @@ using SharpHoundCommonLib;
 using SharpHoundCommonLib.Processors;
 using Xunit;
 using Xunit.Abstractions;
+using FluentAssertions.Events;
+using Microsoft.Extensions.Logging;
 
-namespace CommonLibTest {
-    //TODO: Make these tests work
-    public class CertAbuseProcessorTest : IDisposable {
-        private const string CASecurityFixture =
-            "AQAUhCABAAAwAQAAFAAAAEQAAAACADAAAgAAAALAFAD//wAAAQEAAAAAAAEAAAAAAsAUAP//AAABAQAAAAAABQcAAAACANwABwAAAAADGAABAAAAAQIAAAAAAAUgAAAAIAIAAAADGAACAAAAAQIAAAAAAAUgAAAAIAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADFAAAAgAAAQEAAAAAAAULAAAAAQIAAAAAAAUgAAAAIAIAAAECAAAAAAAFIAAAACACAAA=";
+namespace CommonLibTest 
+{
+    public class CertAbuseProcessorTest 
+    {
+        // private const string CASecurityFixture =
+        //     "AQAUhCABAAAwAQAAFAAAAEQAAAACADAAAgAAAALAFAD//wAAAQEAAAAAAAEAAAAAAsAUAP//AAABAQAAAAAABQcAAAACANwABwAAAAADGAABAAAAAQIAAAAAAAUgAAAAIAIAAAADGAACAAAAAQIAAAAAAAUgAAAAIAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADFAAAAgAAAQEAAAAAAAULAAAAAQIAAAAAAAUgAAAAIAIAAAECAAAAAAAFIAAAACACAAA=";
+        
+        [Theory]
+        [InlineData(0x00040000, true)]
+        [InlineData(0x00020000, false)]
+        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_ChecksKey(int editFlags, bool expectedResult) {
+            const string target = "target machine name";
+            const string caName = "TEST-CA";
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
+            const string subValue = "EditFlags";
+            const string hostSid = "S-1-5-21-ENTERPRISE-CA";
+            
+            var mockRegistryAccessor = new Mock<IRegistryAccessor>();
+            mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = editFlags });
+            
+            var processor = new CertAbuseProcessor(new MockLdapUtils(), mockRegistryAccessor.Object);
+            
+            CSVComputerStatus capturedStatus = null;
+            processor.ComputerStatusEvent += status =>
+            {
+                capturedStatus = status;
+                return Task.CompletedTask;
+            };
 
-        private readonly ITestOutputHelper _testOutputHelper;
+            var results = await processor.IsUserSpecifiesSanEnabled(target, caName, hostSid);
 
-        public CertAbuseProcessorTest(ITestOutputHelper testOutputHelper) {
-            _testOutputHelper = testOutputHelper;
+            //Validate result
+            Assert.Null(results.FailureReason);
+            Assert.True(results.Collected);
+            Assert.Equal(expectedResult, results.Value);
+
+            //Validate CompStatus Log
+            Assert.Equal(caName, capturedStatus.ComputerName);
+            Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, capturedStatus.Status);
+            Assert.Equal(hostSid, capturedStatus.ObjectId);
         }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_FailsLookup() {
+            const string target = "target machine name";
+            const string caName = "TEST-CA";
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
+            const string subValue = "EditFlags";
+            const string hostSid = "S-1-5-21-ENTERPRISE-CA";
+            
+            
+            const string failureReason = "Registry Lookup Failure";
+            
+            var mockRegistryAccessor = new Mock<IRegistryAccessor>();
+            mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  false, FailureReason = failureReason });
+            
+            var processor = new CertAbuseProcessor(new MockLdapUtils(), mockRegistryAccessor.Object);
+            
+            CSVComputerStatus capturedStatus = null;
+            processor.ComputerStatusEvent += status =>
+            {
+                capturedStatus = status;
+                return Task.CompletedTask;
+            };
 
-        public void Dispose() {
+            var results = await processor.IsUserSpecifiesSanEnabled(target, caName, hostSid);
+
+            //Validate result
+            Assert.Equal(failureReason, results.FailureReason);
+            Assert.False(results.Collected);
+
+            //Validate CompStatus Log
+            Assert.Equal(caName, capturedStatus.ComputerName);
+            Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
+            Assert.Equal(failureReason, capturedStatus.Status);
+            Assert.Equal(hostSid, capturedStatus.ObjectId);
         }
 
         // [Fact]
@@ -89,12 +168,25 @@ namespace CommonLibTest {
         // public async Task CertAbuseProcessor_ProcessCAPermissions_NullSecurity_ReturnsNull()
         // {
         //     var processor = new CertAbuseProcessor(new MockLdapUtils());
+        //     
+        //     CSVComputerStatus capturedStatus = null;
+        //
+        //     processor.ComputerStatusEvent += status =>
+        //     {
+        //       capturedStatus = status;
+        //       return Task.CompletedTask;
+        //     };
         //
         //     var results = await processor.ProcessRegistryEnrollmentPermissions(null, "DUMPSTER.FIRE", null, "test");
         //
         //     Assert.Equal("Value cannot be null. (Parameter 'machineName')", results.FailureReason);
         //     Assert.False(results.Collected);
-        //     Assert.Null(results.Data);
+        //     Assert.Empty(results.Data);
+        //     
+        //     Assert.Equal(null, capturedStatus.ComputerName);
+        //     Assert.Equal("test", capturedStatus.ObjectId);
+        //     Assert.Equal("Value cannot be null. (Parameter 'machineName')", capturedStatus.Status);
+        //     Assert.Equal(nameof(processor.ProcessRegistryEnrollmentPermissions), capturedStatus.Task);
         // }
 
         // [WindowsOnlyFact]
@@ -136,6 +228,31 @@ namespace CommonLibTest {
         //         x => x.RightName == EdgeNames.ManageCertificates &&
         //              x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-519" &&
         //              !x.IsInherited);
+        // }
+
+        // [Fact]
+        // public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_HandlesFailure()
+        // {
+        //   var processor = new CertAbuseProcessor(new MockLdapUtils());
+        //     
+        //   CSVComputerStatus capturedStatus = null;
+        //
+        //   processor.ComputerStatusEvent += status =>
+        //   {
+        //     capturedStatus = status;
+        //     return Task.CompletedTask;
+        //   };
+        //
+        //   var results = await processor.IsUserSpecifiesSanEnabled("target", "DUMPSTER.FIRE", "sid");
+        //
+        //   Assert.Equal("Target machine was not found or not connectable", results.FailureReason);
+        //   Assert.False(results.Collected);
+        //   Assert.False(results.Value);
+        //     
+        //   Assert.Equal("DUMPSTER.FIRE", capturedStatus.ComputerName);
+        //   Assert.Equal("sid", capturedStatus.ObjectId);
+        //   Assert.Equal("Target machine was not found or not connectable", capturedStatus.Status);
+        //   Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
         // }
     }
 }

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -13,18 +13,20 @@ namespace CommonLibTest
 {
     public class CertAbuseProcessorTest 
     {
+        private readonly Mock<ILdapUtils> _mockLdapUtils;
         private readonly Mock<IRegistryAccessor> _mockRegistryAccessor;
         private readonly CertAbuseProcessor _certAbuseProcessor;
         
-        private const string Target = "target.test.local";
-        private const string CAName = "TEST-CA";
         private const string DomainName = "TEST.LOCAL";
-        private const string HostSid = "S-1-5-21-TEST-ENTERPRISE-CA";
+        private const string CAName = "TEST-CA";
+        private const string TargetName = "target.test.local";
+        private const string TargetDomainSid = "S-1-5-21-123456789-123456789-123456789";
         private const string FailureReason = "Registry Lookup Failure";
         
         private CSVComputerStatus _receivedCompStatus;
         
         public CertAbuseProcessorTest() {
+            _mockLdapUtils = new Mock<ILdapUtils>();
             _mockRegistryAccessor = new Mock<IRegistryAccessor>();
             _certAbuseProcessor = new CertAbuseProcessor(new MockLdapUtils(), _mockRegistryAccessor.Object);
             
@@ -37,20 +39,20 @@ namespace CommonLibTest
         
         [Theory]
         [InlineData(0x00040000, true)]
-        [InlineData(0x00020000, false)]
-        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_ChecksKey(int editFlags, bool expectedResult) {
+        [InlineData(0x00000000, false)]
+        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_ReturnsResult(int editFlags, bool expectedResult) {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  true, Value = editFlags });
 
-            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(Target, CAName, HostSid);
+            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
 
             //Validate result
             Assert.True(results.Collected);
@@ -58,54 +60,54 @@ namespace CommonLibTest
             Assert.Null(results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
             Assert.Equal(nameof(CertAbuseProcessor.IsUserSpecifiesSanEnabled), _receivedCompStatus.Task);
             Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         [Fact]
-        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_FailsLookup() {
+        public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
-            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(Target, CAName, HostSid);
+            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
 
             //Validate result
             Assert.False(results.Collected);
             Assert.Equal(FailureReason, results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
             Assert.Equal(nameof(_certAbuseProcessor.IsUserSpecifiesSanEnabled), _receivedCompStatus.Task);
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         [Theory]
         [InlineData(1, true)]
         [InlineData(0, false)]
-        public async Task CertAbuseProcessor_RoleSeparationEnabled_ChecksKey(int regValue, bool expectedResult) {
+        public async Task CertAbuseProcessor_IsRoleSeparationEnabled_ReturnsResult(int roleSeparationEnabled, bool expectedResult) {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "RoleSeparationEnabled";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+                .Returns(new RegistryResult { Collected =  true, Value = roleSeparationEnabled });
 
-            var results = await _certAbuseProcessor.RoleSeparationEnabled(Target, CAName, HostSid);
+            var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
 
             //Validate result
             Assert.True(results.Collected);
@@ -113,41 +115,41 @@ namespace CommonLibTest
             Assert.Null(results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.RoleSeparationEnabled), _receivedCompStatus.Task);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.IsRoleSeparationEnabled), _receivedCompStatus.Task);
             Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         [Fact]
-        public async Task CertAbuseProcessor_RoleSeparationEnabled_FailsLookup() {
+        public async Task CertAbuseProcessor_IsRoleSeparationEnabled_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "RoleSeparationEnabled";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
-            var results = await _certAbuseProcessor.RoleSeparationEnabled(Target, CAName, HostSid);
+            var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
 
             //Validate result
             Assert.False(results.Collected);
             Assert.Equal(FailureReason, results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(_certAbuseProcessor.RoleSeparationEnabled), _receivedCompStatus.Task);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.IsRoleSeparationEnabled), _receivedCompStatus.Task);
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         //TODO: test happy path
         // [Fact]
-        // public async Task CertAbuseProcessor_ProcessEAPermissions_ChecksKey() {
+        // public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsResult() {
         //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
         //     const string subValue = "EnrollmentAgentRights";
         //     
@@ -174,34 +176,34 @@ namespace CommonLibTest
         // }
         
         [Fact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_FailsLookup() {
+        public async Task CertAbuseProcessor_ProcessEAPermissions_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "EnrollmentAgentRights";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
-            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, Target, HostSid);
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, TargetName, TargetDomainSid);
 
             //Validate result
             Assert.False(results.Collected);
             Assert.Equal(FailureReason, results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
             Assert.Equal(nameof(_certAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         //TODO: test happy path
         // [Fact]
-        // public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ChecksKey() {
+        // public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsResult() {
         //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
         //     const string subValue = "Security";
         //     
@@ -228,33 +230,33 @@ namespace CommonLibTest
         // }
         
         [Fact]
-        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_FailsLookup() {
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "Security";
             
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    Target,
+                    TargetName,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
-            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, Target, HostSid);
+            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, TargetName, TargetDomainSid);
 
             //Validate result
             Assert.False(results.Collected);
             Assert.Equal(FailureReason, results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
             Assert.Equal(nameof(_certAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
-            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
         [Fact]
-        public async Task CertAbuseProcessor_ProcessCertTemplates_ReturnResolvedAndUnresolvedTemplates() {
+        public async Task CertAbuseProcessor_ProcessCertTemplates_ReturnsResolvedAndUnresolvedTemplates() {
             const string validCN = "ValidCN";
             const string invalidCN = "InvalidCN";
             
@@ -275,9 +277,38 @@ namespace CommonLibTest
         public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID(string sidValue) {
             var sid = new SecurityIdentifier(sidValue);
             
-            var results = await _certAbuseProcessor.GetRegistryPrincipal(sid, DomainName, Target, true,  "compId", sid);
+            //TODO: check inputs
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(
+                sid,
+                DomainName,
+                TargetName,
+                true,
+                TargetDomainSid,
+                new SecurityIdentifier(TargetDomainSid)
+            );
 
             Assert.Equal((false, null), results);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsTrueForDomainController() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+            var domainSid = new SecurityIdentifier(expectedPrincipalSID);
+            
+            _mockLdapUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+            
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(
+                domainSid,
+                DomainName,
+                TargetName,
+                true,
+                TargetDomainSid,
+                new SecurityIdentifier("S-1-5-21-3130019616-2776909439-2417379446-1104")
+            );
+
+            Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
         }
         
         //TODO finish testing GetRegistryPrincipal

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -2,56 +2,67 @@
 using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using System.Threading;
 using System.Threading.Tasks;
+using CommonLibTest.CollectionDefinitions;
 using Moq;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Processors;
 using Xunit;
-using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.OutputTypes;
+using SharpHoundRPC.SAMRPCNative;
+using SharpHoundRPC.Wrappers;
 
 namespace CommonLibTest 
 {
-    public class CertAbuseProcessorTest 
+    [Collection(nameof(CacheTestCollectionDefinition))]
+    public class CertAbuseProcessorTest
     {
         private readonly Mock<ILdapUtils> _mockLdapUtils;
         private readonly Mock<IRegistryAccessor> _mockRegistryAccessor;
+        private readonly Mock<ISAMServerAccessor> _mockSAMServerAccessor;
         private readonly CertAbuseProcessor _certAbuseProcessor;
-        
+
         private const string DomainName = "TEST.LOCAL";
         private const string CAName = "TEST-CA";
         private const string TargetName = "target.test.local";
         private const string TargetDomainSid = "S-1-5-21-123456789-123456789-123456789";
         private const string FailureReason = "Registry Lookup Failure";
-        
+
         private CSVComputerStatus _receivedCompStatus;
-        
+
         public CertAbuseProcessorTest() {
             _mockLdapUtils = new Mock<ILdapUtils>();
             _mockRegistryAccessor = new Mock<IRegistryAccessor>();
-            _certAbuseProcessor = new CertAbuseProcessor(_mockLdapUtils.Object, _mockRegistryAccessor.Object);
-            
-            _certAbuseProcessor.ComputerStatusEvent += status =>
-            {
+            _mockSAMServerAccessor = new Mock<ISAMServerAccessor>();
+            _certAbuseProcessor = new CertAbuseProcessor(_mockLdapUtils.Object, _mockRegistryAccessor.Object, _mockSAMServerAccessor.Object);
+
+            _certAbuseProcessor.ComputerStatusEvent += status => {
                 _receivedCompStatus = status;
                 return Task.CompletedTask;
             };
+            
+            Cache.SetCacheInstance(Cache.CreateNewCache());
         }
-        
+
         [Theory]
         [InlineData(0x00040000, true)]
         [InlineData(0x00000000, false)]
         public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_ReturnsResult(int editFlags, bool expectedResult) {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
-            
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  true, Value = editFlags });
+                .Returns(new RegistryResult
+                {
+                    Collected = true,
+                    Value = editFlags
+                });
 
             var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
 
@@ -66,18 +77,22 @@ namespace CommonLibTest
             Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
-        
+
         [Fact]
         public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
-            
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+                .Returns(new RegistryResult
+                {
+                    Collected = false,
+                    FailureReason = FailureReason
+                });
 
             var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
 
@@ -91,20 +106,24 @@ namespace CommonLibTest
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
-        
+
         [Theory]
         [InlineData(1, true)]
         [InlineData(0, false)]
         public async Task CertAbuseProcessor_IsRoleSeparationEnabled_ReturnsResult(int roleSeparationEnabled, bool expectedResult) {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "RoleSeparationEnabled";
-            
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  true, Value = roleSeparationEnabled });
+                .Returns(new RegistryResult
+                {
+                    Collected = true,
+                    Value = roleSeparationEnabled
+                });
 
             var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
 
@@ -119,18 +138,22 @@ namespace CommonLibTest
             Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
-        
+
         [Fact]
         public async Task CertAbuseProcessor_IsRoleSeparationEnabled_HandlesFailedLookup() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "RoleSeparationEnabled";
-            
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+                .Returns(new RegistryResult
+                {
+                    Collected = false,
+                    FailureReason = FailureReason
+                });
 
             var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
 
@@ -145,89 +168,50 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
 
-        public static IEnumerable<object[]> ProcessEAPermissionsTestData() {
-            var nullOpaqueAce = new CommonAce(
-                AceFlags.None,
-                AceQualifier.AccessAllowed,
-                0x0000,
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
-                false,
-                null
-            );
-            
-            var daclWithNullOpaque = new RawAcl(2, 1);
-            daclWithNullOpaque.InsertAce(0, nullOpaqueAce);
-            
-            var emptyOpaqueAce = new CommonAce(
-                AceFlags.None,
-                AceQualifier.AccessAllowed,
-                0x0000,
-                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
-                true,
-                new byte[] { 0, 0, 0, 0 }
-            );
-
-            var daclWithEmptyOpaque = new RawAcl(2, 1);
-            daclWithEmptyOpaque.InsertAce(0, emptyOpaqueAce);
-            
-            return new List<object[]>
-            {
-                new object[] { null }, //null dacl
-                new object[] { new RawAcl(2, 0) }, //empty dacl
-                new object[] { daclWithNullOpaque }, //dacl is callback false, null opaque
-                new object[] { daclWithEmptyOpaque }, //dacl is callback true, empty opaque
-            };
-        }
-        
-        [WindowsOnlyTheory]
-        [MemberData(nameof(ProcessEAPermissionsTestData))]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty(RawAcl dacl) {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "EnrollmentAgentRights";
-            
-            //setup binary security descriptor as registry value
-            var descriptor = new RawSecurityDescriptor(
-                ControlFlags.DiscretionaryAclPresent,
-                null,
-                null,
-                null,
-                dacl);
-            
-            var regValue = new byte[descriptor.BinaryLength];
-            descriptor.GetBinaryForm(regValue, 0);
-
-            _mockRegistryAccessor
-                .Setup(ra => ra.GetRegistryKeyData(
-                    "localhost",
-                    subKey,
-                    subValue))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue });
-        
-            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
-        
-            //Validate result
-            Assert.True(results.Collected);
-            Assert.Empty(results.Restrictions);
-            Assert.Null(results.FailureReason);
-        
-            //Validate CompStatus Log
-            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
-        }
-        
         [Fact]
-        public async Task CertAbuseProcessor_ProcessEAPermissions_HandlesFailedLookup() {
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmptyResult() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
             const string subValue = "EnrollmentAgentRights";
-            
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+                .Returns(new RegistryResult
+                {
+                    Collected = true
+                });
+
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, TargetName, TargetDomainSid);
+
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_HandlesFailedLookup() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    TargetName,
+                    subKey,
+                    subValue))
+                .Returns(new RegistryResult
+                {
+                    Collected = false,
+                    FailureReason = FailureReason
+                });
 
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, TargetName, TargetDomainSid);
 
@@ -242,60 +226,101 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerAndNoRules() {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "Security";
+        public static IEnumerable<object[]> ProcessEAPermissionsTestData() {
+            return new List<object[]>
+            {
+                new object[] { null }, //null dacl
+                new object[] { new RawAcl(2, 0) }, //empty dacl
+            };
+        }
+
+        [WindowsOnlyTheory]
+        [MemberData(nameof(ProcessEAPermissionsTestData))]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty(RawAcl dacl) {
+            var mockSamServer = new Mock<ISAMServer>();
             
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+
             //setup binary security descriptor as registry value
             var descriptor = new RawSecurityDescriptor(
                 ControlFlags.DiscretionaryAclPresent,
-                null,  //owner is null
                 null,
                 null,
-                null);
-            
-            byte[] regValue = new byte[descriptor.BinaryLength];
-            descriptor.GetBinaryForm(regValue, 0);
-            
-            _mockRegistryAccessor
-                .Setup(ra => ra.GetRegistryKeyData(
-                    "localhost",
-                    subKey,
-                    subValue))
-                .Returns(new RegistryResult { Collected =  true, Value = regValue});
-        
-            //get access rules returns empty
-            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(MockBehavior.Loose, null);
-            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
-                .Returns([]);
-            _mockLdapUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
-            
-            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, "localhost", TargetDomainSid);
+                null,
+                dacl);
 
-            //Validate result 
-            Assert.True(results.Collected);
-            Assert.Empty(results.Data);
-            Assert.Null(results.FailureReason);
-        
-            //Validate CompStatus Log
-            Assert.Equal("localhost", _receivedCompStatus.ComputerName);
-            Assert.Equal(nameof(CertAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
-            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
-        }
-        
-        [Fact]
-        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_HandlesFailedLookup() {
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
-            const string subValue = "Security";
-            
+            var regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
             _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
                     subValue))
-                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+                .Returns(new RegistryResult
+                {
+                    Collected = true,
+                    Value = regValue
+                });
+            
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Ok(mockSamServer.Object));
+            mockSamServer.Setup(x => x.GetMachineSid(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(new SecurityIdentifier(TargetDomainSid));
+
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, TargetName, TargetDomainSid);
+
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Restrictions);
+            Assert.Null(results.FailureReason);
+        }
+
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmptyResult() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "Security";
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    TargetName,
+                    subKey,
+                    subValue))
+                .Returns(new RegistryResult
+                {
+                    Collected = true
+                });
+
+            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, TargetName, TargetDomainSid);
+
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Empty(results.Data);
+            Assert.Null(results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_HandlesFailedLookup() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "Security";
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    TargetName,
+                    subKey,
+                    subValue))
+                .Returns(new RegistryResult
+                {
+                    Collected = false,
+                    FailureReason = FailureReason
+                });
 
             var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, TargetName, TargetDomainSid);
 
@@ -309,19 +334,68 @@ namespace CommonLibTest
             Assert.Equal(FailureReason, _receivedCompStatus.Status);
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
-        
+
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerAndNoRules() {
+            var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(null);
+            var mockSamServer = new Mock<ISAMServer>();
+            
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "Security";
+
+            //setup binary security descriptor as registry value
+            var descriptor = new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,
+                null,
+                null,
+                null);
+
+            byte[] regValue = new byte[descriptor.BinaryLength];
+            descriptor.GetBinaryForm(regValue, 0);
+
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    TargetName,
+                    subKey,
+                    subValue))
+                .Returns(new RegistryResult
+                {
+                    Collected = true,
+                    Value = regValue
+                });
+
+            _mockLdapUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(mockSecurityDescriptor.Object);
+            
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Ok(mockSamServer.Object));
+            mockSamServer.Setup(x => x.GetMachineSid(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(new SecurityIdentifier(TargetDomainSid));
+            
+            //get access rules returns empty
+            mockSecurityDescriptor.Setup(m => m.GetAccessRules(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<Type>()))
+                .Returns([]);
+
+            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, TargetName, TargetDomainSid);
+
+            //Validate result 
+            Assert.True(results.Collected);
+            Assert.Empty(results.Data);
+            Assert.Null(results.FailureReason);
+        }
+
         [Fact]
         public async Task CertAbuseProcessor_ProcessCertTemplates_ReturnsResolvedAndUnresolvedTemplates() {
             const string validCN = "ValidCN";
             const string invalidCN = "InvalidCN";
-            
+
             _mockLdapUtils
                 .Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((string cn, string _, string _) =>
                     cn == validCN
                         ? (true, new TypedPrincipal("test guid", Label.CertTemplate))
                         : (false, null));
-            
+
             var results = await _certAbuseProcessor.ProcessCertTemplates([validCN, invalidCN], DomainName);
 
             var expectedTemplate = new TypedPrincipal("test guid", Label.CertTemplate);
@@ -330,46 +404,378 @@ namespace CommonLibTest
             Assert.Single(results.unresolvedTemplates);
             Assert.Contains(invalidCN, results.unresolvedTemplates);
         }
-        
-        [WindowsOnlyTheory]
-        [InlineData("S-1-5-80")]
-        [InlineData("S-1-5-82")]
-        [InlineData("S-1-5-90")] 
-        [InlineData("S-1-5-96")]
-        public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID(string sidValue) {
-            var sid = new SecurityIdentifier(sidValue);
-            
+
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID() {
+            var sid = new SecurityIdentifier("S-1-5-3");
+
             var results = await _certAbuseProcessor.GetRegistryPrincipal(
                 sid,
                 DomainName,
                 TargetName,
                 true,
                 TargetDomainSid,
-                new SecurityIdentifier("S-1-5-18")
+                null
             );
 
             Assert.Equal((false, null), results);
+            _mockLdapUtils.VerifyNoOtherCalls();
         }
-        
+
         [WindowsOnlyFact]
-        public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvedDomainController_ReturnsTrue() {
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_CallsResolveIDAndType_ForDomainController() {
             var expectedPrincipalType = Label.Group;
             var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
-            var sid = new SecurityIdentifier(expectedPrincipalSID);
-            
+
             _mockLdapUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
-            
+
+            var sid = new SecurityIdentifier(expectedPrincipalSID);
+
             var results = await _certAbuseProcessor.GetRegistryPrincipal(
                 sid,
                 DomainName,
                 TargetName,
                 true,
                 TargetDomainSid,
-                new SecurityIdentifier("S-1-5-18")
+                null
             );
 
             Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
+
+            _mockLdapUtils.Verify(
+                x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+
+            _mockLdapUtils.VerifyNoOtherCalls();
+        }
+
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_CallsConvertLocalWellKnownPrincipal_ForNonDomainController() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            _mockLdapUtils.Setup(x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+
+            var sid = new SecurityIdentifier(expectedPrincipalSID);
+
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(
+                sid,
+                DomainName,
+                TargetName,
+                false,
+                TargetDomainSid,
+                null
+            );
+
+            Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
+
+            _mockLdapUtils.Verify(
+                x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+            _mockLdapUtils.VerifyNoOtherCalls();
+        }
+
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvesToLocalPrincipal_ForLocalSID() {
+            var expectedPrincipalType = Label.LocalGroup;
+            var expectedPrincipalSID = $"{TargetDomainSid}-123";
+
+            _mockLdapUtils.Setup(x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((false, null));
+
+            var sid = new SecurityIdentifier(expectedPrincipalSID);
+
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(
+                sid,
+                DomainName,
+                TargetName,
+                false,
+                TargetDomainSid,
+                new SecurityIdentifier(TargetDomainSid)
+            );
+
+            Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
+
+            _mockLdapUtils.Verify(
+                x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+            _mockLdapUtils.VerifyNoOtherCalls();
+        }
+
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvesToDomainPrincipal() {
+            var expectedPrincipalType = Label.Group;
+            var expectedPrincipalSID = "S-1-5-21-3130019616-2776909439-2417379446-512";
+
+            _mockLdapUtils.Setup(x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((false, null));
+            _mockLdapUtils.Setup(x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)));
+
+            var sid = new SecurityIdentifier(expectedPrincipalSID);
+
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(
+                sid,
+                DomainName,
+                TargetName,
+                false,
+                TargetDomainSid,
+                null
+            );
+
+            Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
+
+            _mockLdapUtils.Verify(
+                x => x.ConvertLocalWellKnownPrincipal(It.IsAny<SecurityIdentifier>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+            _mockLdapUtils.Verify(
+                x => x.ResolveIDAndType(It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+            _mockLdapUtils.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void CertAbuseProcessor_OpenSamServer_CallsOpenServer_Failure() {
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Fail("Connection Failed"));
+            
+            var result = _certAbuseProcessor.OpenSamServer(TargetName);
+            
+            Assert.True(result.IsFailed);
+            Assert.Null(result.Value);
+        }
+        
+        [Fact]
+        public void CertAbuseProcessor_OpenSamServer_CallsOpenServer_Success() {
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Ok(new SAMServer(null, "TestServer")));
+            
+            var result = _certAbuseProcessor.OpenSamServer(TargetName);
+            
+            Assert.True(result.IsSuccess);
+            Assert.IsType<SAMServer>(result.Value);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetMachineSid_ReturnsCachedValue() {
+            Cache.AddMachineSid(TargetDomainSid, TargetDomainSid);
+            
+            var result = await _certAbuseProcessor.GetMachineSid(TargetName, TargetDomainSid);
+            
+            Assert.Equal(TargetDomainSid, result.Value);
+            Assert.Null(_receivedCompStatus);
+        }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_GetMachineSid_OpenSAMFailure_ReturnsNull() {
+            var error = "Connection Failed";
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Fail(error));
+            
+            var result = await _certAbuseProcessor.GetMachineSid(TargetName, TargetDomainSid);
+            
+            //Validate result
+            Assert.Null(result);
+            
+            //Validate CompStatus Log
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.OpenSamServer), _receivedCompStatus.Task);
+            Assert.Equal(error, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetMachineSid_GetMachineSidFailure_ReturnsNull() {
+            var mockSamServer = new Mock<ISAMServer>();
+            var error = "Sid Lookup Failed";
+            
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Ok(mockSamServer.Object));
+            mockSamServer.Setup(x => x.GetMachineSid(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(SharpHoundRPC.Result<SecurityIdentifier>.Fail(error));
+            
+            var result = await _certAbuseProcessor.GetMachineSid(TargetName, TargetDomainSid);
+            
+            //Validate result
+            Assert.Null(result);
+            
+            //Validate CompStatus Log
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.GetMachineSid), _receivedCompStatus.Task);
+            Assert.Equal(error, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_GetMachineSid_ReturnsSid() {
+            var mockSamServer = new Mock<ISAMServer>();
+            
+            _mockSAMServerAccessor.Setup(x => x.OpenServer(It.IsAny<string>(), It.IsAny<SAMEnums.SamAccessMasks>()))
+                .Returns(SharpHoundRPC.Result<ISAMServer>.Ok(mockSamServer.Object));
+            mockSamServer.Setup(x => x.GetMachineSid(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(new SecurityIdentifier(TargetDomainSid));
+            
+            var result = await _certAbuseProcessor.GetMachineSid(TargetName, TargetDomainSid);
+            
+            //Validate result
+            Assert.Equal(TargetDomainSid, result.Value);
+            
+            //Validate CompStatus Log
+            Assert.Equal(TargetName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.GetMachineSid), _receivedCompStatus.Task);
+            Assert.Equal(ComputerStatus.Success, _receivedCompStatus.Status);
+            Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_NullOpaque_ReturnsFalse() {
+            var nullOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                false,
+                null
+            );
+            var sid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            
+            var result = await _certAbuseProcessor.CreateEnrollmentAgentRestriction(nullOpaqueAce, TargetName, DomainName, false, TargetDomainSid, sid);
+            
+            //Validate result
+            Assert.False(result.success);
+            Assert.Null(result.restriction);
+            _mockLdapUtils.VerifyNoOtherCalls();
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_UnresolvedTemplate_ReturnsFalse() {
+            var emptyOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[]
+                {
+                    1, 0, 0, 0, //sid count
+                    1, 0, 0, 0, 0, 0, 0, 0, //target sid
+                    0, 0, 0, 0 //template
+                }
+            );
+            var sid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            
+            _mockLdapUtils.Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((false, null));
+            
+            var result = await _certAbuseProcessor.CreateEnrollmentAgentRestriction(emptyOpaqueAce, TargetName, DomainName, false, TargetDomainSid, sid);
+            
+            //Validate result
+            Assert.False(result.success);
+            Assert.Null(result.restriction);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_NoTemplate_ReturnsAllTemplates() {
+            var emptyOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[] 
+                    {
+                        2, 0, 0, 0, //sid count
+                        1, 0, 0, 0, 0, 0, 0, 1, //target sid S-1-1
+                        1, 0, 0, 0, 0, 0, 0, 3  //target sid S-1-3
+                    }
+            );
+            var sid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            
+            _mockLdapUtils.Setup(x => x.ResolveIDAndType("S-1-1", It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal("S-1-1", Label.User)));
+            _mockLdapUtils.Setup(x => x.ResolveIDAndType("S-1-3", It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal("S-1-3", Label.User)));
+            
+            var result = await _certAbuseProcessor.CreateEnrollmentAgentRestriction(emptyOpaqueAce, nameof(Label.User), DomainName, false, TargetDomainSid, sid);
+            
+            //Validate result
+            Assert.True(result.success);
+            Assert.True(result.restriction.AllTemplates);
+            Assert.Null(result.restriction.Template);
+            Assert.Equal(2, result.restriction.Targets.Length);
+            Assert.Contains(result.restriction.Targets, t => t.ObjectIdentifier == "S-1-1");
+            Assert.Contains(result.restriction.Targets, t => t.ObjectIdentifier == "S-1-3");
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_WithCanonicalName_ReturnsTemplate() {
+            var expectedPrincipalType = Label.CertTemplate;
+            var templateOID = "E4B7F0B1-27E5-4C0F-A5C9-641A67171D05";
+            
+            var emptyOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[]
+                {
+                    1, 0, 0, 0, //sid count
+                    1, 0, 0, 0, 0, 0, 0, 0, //target sid
+                    77, 0, 97, 0, 99, 0, 104, 0, 105, 0, 110, 0, 101, 0, 0, 0 //Computer Template
+                }
+            );
+            var sid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            
+            _mockLdapUtils.Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), LDAPProperties.CanonicalName, It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(templateOID, expectedPrincipalType)));
+            
+            var result = await _certAbuseProcessor.CreateEnrollmentAgentRestriction(emptyOpaqueAce, TargetName, DomainName, false, TargetDomainSid, sid);
+            
+            Assert.True(result.success);
+            Assert.False(result.restriction.AllTemplates);
+            Assert.NotNull(result.restriction.Template);
+            _mockLdapUtils.Verify(
+                x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Once);
+        }
+        
+        [WindowsOnlyFact]
+        public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_WithCertTemplateOID_ReturnsTemplate() {
+            var expectedPrincipalType = Label.CertTemplate;
+            var templateOID = "E4B7F0B1-27E5-4C0F-A5C9-641A67171D05";
+            
+            var emptyOpaqueAce = new CommonAce(
+                AceFlags.None,
+                AceQualifier.AccessAllowed,
+                0x0000,
+                new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null),
+                true,
+                new byte[]
+                {
+                    1, 0, 0, 0, //sid count
+                    1, 0, 0, 0, 0, 0, 0, 0, //target sid
+                    77, 0, 97, 0, 99, 0, 104, 0, 105, 0, 110, 0, 101, 0, 0, 0 //Computer Template
+                }
+            );
+            var sid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+            
+            _mockLdapUtils.Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), LDAPProperties.CanonicalName, It.IsAny<string>()))
+                .ReturnsAsync((false, null));
+            _mockLdapUtils.Setup(x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), LDAPProperties.CertTemplateOID, It.IsAny<string>()))
+                .ReturnsAsync((true, new TypedPrincipal(templateOID, expectedPrincipalType)));
+            
+            var result = await _certAbuseProcessor.CreateEnrollmentAgentRestriction(emptyOpaqueAce, TargetName, DomainName, false, TargetDomainSid, sid);
+            
+            //Validate result
+            Assert.True(result.success);
+            Assert.False(result.restriction.AllTemplates);
+            Assert.NotNull(result.restriction.Template);
+            _mockLdapUtils.Verify(
+                x => x.ResolveCertTemplateByProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+                Times.Exactly(2));
         }
     }
 }

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,107 +1,286 @@
-﻿using System;
-using System.DirectoryServices;
-using System.Runtime.Versioning;
+﻿using System.Security.Principal;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using Moq;
-using Newtonsoft.Json;
 using SharpHoundCommonLib;
 using SharpHoundCommonLib.Processors;
 using Xunit;
-using Xunit.Abstractions;
-using FluentAssertions.Events;
 using Microsoft.Extensions.Logging;
+using SharpHoundCommonLib.Enums;
+using SharpHoundCommonLib.OutputTypes;
 
 namespace CommonLibTest 
 {
     public class CertAbuseProcessorTest 
     {
-        // private const string CASecurityFixture =
-        //     "AQAUhCABAAAwAQAAFAAAAEQAAAACADAAAgAAAALAFAD//wAAAQEAAAAAAAEAAAAAAsAUAP//AAABAQAAAAAABQcAAAACANwABwAAAAADGAABAAAAAQIAAAAAAAUgAAAAIAIAAAADGAACAAAAAQIAAAAAAAUgAAAAIAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQAAIAAAADJAABAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADJAACAAAAAQUAAAAAAAUVAAAAIE+Qun9GhKV2SBaQBwIAAAADFAAAAgAAAQEAAAAAAAULAAAAAQIAAAAAAAUgAAAAIAIAAAECAAAAAAAFIAAAACACAAA=";
+        private readonly Mock<IRegistryAccessor> _mockRegistryAccessor;
+        private readonly CertAbuseProcessor _certAbuseProcessor;
+        
+        private const string Target = "target.test.local";
+        private const string CAName = "TEST-CA";
+        private const string DomainName = "TEST.LOCAL";
+        private const string HostSid = "S-1-5-21-TEST-ENTERPRISE-CA";
+        private const string FailureReason = "Registry Lookup Failure";
+        
+        private CSVComputerStatus _receivedCompStatus;
+        
+        public CertAbuseProcessorTest() {
+            _mockRegistryAccessor = new Mock<IRegistryAccessor>();
+            _certAbuseProcessor = new CertAbuseProcessor(new MockLdapUtils(), _mockRegistryAccessor.Object);
+            
+            _certAbuseProcessor.ComputerStatusEvent += status =>
+            {
+                _receivedCompStatus = status;
+                return Task.CompletedTask;
+            };
+        }
         
         [Theory]
         [InlineData(0x00040000, true)]
         [InlineData(0x00020000, false)]
         public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_ChecksKey(int editFlags, bool expectedResult) {
-            const string target = "target machine name";
-            const string caName = "TEST-CA";
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
-            const string hostSid = "S-1-5-21-ENTERPRISE-CA";
             
-            var mockRegistryAccessor = new Mock<IRegistryAccessor>();
-            mockRegistryAccessor
+            _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    target,
+                    Target,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
                 .Returns(new RegistryResult { Collected =  true, Value = editFlags });
-            
-            var processor = new CertAbuseProcessor(new MockLdapUtils(), mockRegistryAccessor.Object);
-            
-            CSVComputerStatus capturedStatus = null;
-            processor.ComputerStatusEvent += status =>
-            {
-                capturedStatus = status;
-                return Task.CompletedTask;
-            };
 
-            var results = await processor.IsUserSpecifiesSanEnabled(target, caName, hostSid);
+            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(Target, CAName, HostSid);
 
             //Validate result
-            Assert.Null(results.FailureReason);
             Assert.True(results.Collected);
             Assert.Equal(expectedResult, results.Value);
+            Assert.Null(results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(caName, capturedStatus.ComputerName);
-            Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
-            Assert.Equal(CSVComputerStatus.StatusSuccess, capturedStatus.Status);
-            Assert.Equal(hostSid, capturedStatus.ObjectId);
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.IsUserSpecifiesSanEnabled), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
         }
         
         [Fact]
         public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_FailsLookup() {
-            const string target = "target machine name";
-            const string caName = "TEST-CA";
-            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{caName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}\\PolicyModules\\CertificateAuthority_MicrosoftDefault.Policy";
             const string subValue = "EditFlags";
-            const string hostSid = "S-1-5-21-ENTERPRISE-CA";
             
-            
-            const string failureReason = "Registry Lookup Failure";
-            
-            var mockRegistryAccessor = new Mock<IRegistryAccessor>();
-            mockRegistryAccessor
+            _mockRegistryAccessor
                 .Setup(ra => ra.GetRegistryKeyData(
-                    target,
+                    Target,
                     subKey,
                     subValue,
                     It.IsAny<ILogger>()))
-                .Returns(new RegistryResult { Collected =  false, FailureReason = failureReason });
-            
-            var processor = new CertAbuseProcessor(new MockLdapUtils(), mockRegistryAccessor.Object);
-            
-            CSVComputerStatus capturedStatus = null;
-            processor.ComputerStatusEvent += status =>
-            {
-                capturedStatus = status;
-                return Task.CompletedTask;
-            };
+                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
-            var results = await processor.IsUserSpecifiesSanEnabled(target, caName, hostSid);
+            var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(Target, CAName, HostSid);
 
             //Validate result
-            Assert.Equal(failureReason, results.FailureReason);
             Assert.False(results.Collected);
+            Assert.Equal(FailureReason, results.FailureReason);
 
             //Validate CompStatus Log
-            Assert.Equal(caName, capturedStatus.ComputerName);
-            Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
-            Assert.Equal(failureReason, capturedStatus.Status);
-            Assert.Equal(hostSid, capturedStatus.ObjectId);
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.IsUserSpecifiesSanEnabled), _receivedCompStatus.Task);
+            Assert.Equal(FailureReason, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
         }
+        
+        [Theory]
+        [InlineData(1, true)]
+        [InlineData(0, false)]
+        public async Task CertAbuseProcessor_RoleSeparationEnabled_ChecksKey(int regValue, bool expectedResult) {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "RoleSeparationEnabled";
+            
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    Target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  true, Value = regValue });
+
+            var results = await _certAbuseProcessor.RoleSeparationEnabled(Target, CAName, HostSid);
+
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Equal(expectedResult, results.Value);
+            Assert.Null(results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(CertAbuseProcessor.RoleSeparationEnabled), _receivedCompStatus.Task);
+            Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_RoleSeparationEnabled_FailsLookup() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "RoleSeparationEnabled";
+            
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    Target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+
+            var results = await _certAbuseProcessor.RoleSeparationEnabled(Target, CAName, HostSid);
+
+            //Validate result
+            Assert.False(results.Collected);
+            Assert.Equal(FailureReason, results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.RoleSeparationEnabled), _receivedCompStatus.Task);
+            Assert.Equal(FailureReason, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        }
+        
+        //TODO: test happy path
+        // [Fact]
+        // public async Task CertAbuseProcessor_ProcessEAPermissions_ChecksKey() {
+        //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+        //     const string subValue = "EnrollmentAgentRights";
+        //     
+        //     _mockRegistryAccessor
+        //         .Setup(ra => ra.GetRegistryKeyData(
+        //             Target,
+        //             subKey,
+        //             subValue,
+        //             It.IsAny<ILogger>()))
+        //         .Returns(new RegistryResult { Collected =  true, Value = "regValue" });
+        //
+        //     var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, Target, HostSid);
+        //
+        //     //Validate result
+        //     Assert.True(results.Collected);
+        //     Assert.Equal(new EnrollmentAgentRestriction[0], results.Restrictions);
+        //     Assert.Null(results.FailureReason);
+        //
+        //     //Validate CompStatus Log
+        //     Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+        //     Assert.Equal(nameof(CertAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+        //     Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+        //     Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        // }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessEAPermissions_FailsLookup() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "EnrollmentAgentRights";
+            
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    Target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+
+            var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, Target, HostSid);
+
+            //Validate result
+            Assert.False(results.Collected);
+            Assert.Equal(FailureReason, results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.ProcessEAPermissions), _receivedCompStatus.Task);
+            Assert.Equal(FailureReason, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        }
+        
+        //TODO: test happy path
+        // [Fact]
+        // public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ChecksKey() {
+        //     const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+        //     const string subValue = "Security";
+        //     
+        //     _mockRegistryAccessor
+        //         .Setup(ra => ra.GetRegistryKeyData(
+        //             Target,
+        //             subKey,
+        //             subValue,
+        //             It.IsAny<ILogger>()))
+        //         .Returns(new RegistryResult { Collected =  true, Value = "regValue" });
+        //
+        //     var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, Target, HostSid);
+        //
+        //     //Validate result
+        //     Assert.True(results.Collected);
+        //     Assert.Equal(new ACE[0], results.Data);
+        //     Assert.Null(results.FailureReason);
+        //
+        //     //Validate CompStatus Log
+        //     Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+        //     Assert.Equal(nameof(CertAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
+        //     Assert.Equal(CSVComputerStatus.StatusSuccess, _receivedCompStatus.Status);
+        //     Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        // }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_FailsLookup() {
+            const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
+            const string subValue = "Security";
+            
+            _mockRegistryAccessor
+                .Setup(ra => ra.GetRegistryKeyData(
+                    Target,
+                    subKey,
+                    subValue,
+                    It.IsAny<ILogger>()))
+                .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
+
+            var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, Target, HostSid);
+
+            //Validate result
+            Assert.False(results.Collected);
+            Assert.Equal(FailureReason, results.FailureReason);
+
+            //Validate CompStatus Log
+            Assert.Equal(CAName, _receivedCompStatus.ComputerName);
+            Assert.Equal(nameof(_certAbuseProcessor.ProcessRegistryEnrollmentPermissions), _receivedCompStatus.Task);
+            Assert.Equal(FailureReason, _receivedCompStatus.Status);
+            Assert.Equal(HostSid, _receivedCompStatus.ObjectId);
+        }
+        
+        [Fact]
+        public async Task CertAbuseProcessor_ProcessCertTemplates_ReturnResolvedAndUnresolvedTemplates() {
+            const string validCN = "ValidCN";
+            const string invalidCN = "InvalidCN";
+            
+            var results = await _certAbuseProcessor.ProcessCertTemplates([validCN, invalidCN], DomainName);
+
+            var expectedTemplate = new TypedPrincipal("guid", Label.CertTemplate);
+            Assert.Single(results.resolvedTemplates);
+            Assert.Contains(expectedTemplate, results.resolvedTemplates);
+            Assert.Single(results.unresolvedTemplates);
+            Assert.Contains(invalidCN, results.unresolvedTemplates);
+        }
+        
+        [WindowsOnlyTheory]
+        [InlineData("S-1-5-80")]
+        [InlineData("S-1-5-82")]
+        [InlineData("S-1-5-90")] 
+        [InlineData("S-1-5-96")]
+        public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID(string sidValue) {
+            var sid = new SecurityIdentifier(sidValue);
+            
+            var results = await _certAbuseProcessor.GetRegistryPrincipal(sid, DomainName, Target, true,  "compId", sid);
+
+            Assert.Equal((false, null), results);
+        }
+        
+        //TODO finish testing GetRegistryPrincipal
 
         // [Fact]
         // public void CertAbuseProcessor_GetCASecurity_HappyPath()
@@ -116,52 +295,6 @@ namespace CommonLibTest
         //     var processor = mockProcessor.Object;
         //     var results = processor.GetCASecurity("testlab.local", "blah");
         //     Assert.True(results.Collected);
-        // }
-
-        // [Fact]
-        // public void CertAbuseProcessor_GetTrustedCerts_EmptyForNonRoot()
-        // {
-        //     var mockUtils = new Mock<MockLDAPUtils>();
-        //     mockUtils.Setup(x => x.IsForestRoot(It.IsAny<string>())).Returns(false);
-        //     var processor = new CertAbuseProcessor(mockUtils.Object);
-        //
-        //     var results = processor.GetTrustedCerts("testlab.local");
-        //     Assert.Empty(results);
-        // }
-        //
-        // [Fact]
-        // public void CertAbuseProcessor_GetTrustedCerts_NullConfigPath_ReturnsEmpty()
-        // {
-        //     var mockUtils = new Mock<MockLDAPUtils>();
-        //     mockUtils.Setup(x => x.IsForestRoot(It.IsAny<string>())).Returns(true);
-        //     mockUtils.Setup(x => x.GetConfigurationPath(It.IsAny<string>())).Returns((string)null);
-        //     var processor = new CertAbuseProcessor(mockUtils.Object);
-        //
-        //     var results = processor.GetTrustedCerts("testlab.local");
-        //     Assert.Empty(results);
-        // }
-        //
-        // [Fact]
-        // public void CertAbuseProcessor_GetRootCAs_EmptyForNonRoot()
-        // {
-        //     var mockUtils = new Mock<MockLDAPUtils>();
-        //     mockUtils.Setup(x => x.IsForestRoot(It.IsAny<string>())).Returns(false);
-        //     var processor = new CertAbuseProcessor(mockUtils.Object);
-        //
-        //     var results = processor.GetRootCAs("testlab.local");
-        //     Assert.Empty(results);
-        // }
-        //
-        // [Fact]
-        // public void CertAbuseProcessor_GetRootCAs_NullConfigPath_ReturnsEmpty()
-        // {
-        //     var mockUtils = new Mock<MockLDAPUtils>();
-        //     mockUtils.Setup(x => x.IsForestRoot(It.IsAny<string>())).Returns(true);
-        //     mockUtils.Setup(x => x.GetConfigurationPath(It.IsAny<string>())).Returns((string)null);
-        //     var processor = new CertAbuseProcessor(mockUtils.Object);
-        //
-        //     var results = processor.GetRootCAs("testlab.local");
-        //     Assert.Empty(results);
         // }
 
         // [Fact]
@@ -187,72 +320,6 @@ namespace CommonLibTest
         //     Assert.Equal("test", capturedStatus.ObjectId);
         //     Assert.Equal("Value cannot be null. (Parameter 'machineName')", capturedStatus.Status);
         //     Assert.Equal(nameof(processor.ProcessRegistryEnrollmentPermissions), capturedStatus.Task);
-        // }
-
-        // [WindowsOnlyFact]
-        // public void CertAbuseProcessor_ProcessCAPermissions_ReturnsCorrectValues()
-        // {
-        //     var mockUtils = new Mock<MockLdapUtils>();
-        //     var sd = new ActiveDirectorySecurityDescriptor(new ActiveDirectorySecurity());
-        //     mockUtils.Setup(x => x.MakeSecurityDescriptor()).Returns(sd);
-        //     var processor = new CertAbuseProcessor(mockUtils.Object);
-        //     var bytes = Helpers.B64ToBytes(CASecurityFixture);
-        //
-        //     var results = processor.ProcessCAPermissions(bytes, "TESTLAB.LOCAL", "test", false);
-        //     _testOutputHelper.WriteLine(JsonConvert.SerializeObject(results, Formatting.Indented));
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.Owns && x.PrincipalSID == "TESTLAB.LOCAL-S-1-5-32-544" &&
-        //              x.PrincipalType == Label.Group && !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.Enroll && x.PrincipalSID == "TESTLAB.LOCAL-S-1-5-11" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCA && x.PrincipalSID == "TESTLAB.LOCAL-S-1-5-32-544" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCertificates && x.PrincipalSID == "TESTLAB.LOCAL-S-1-5-32-544" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCA &&
-        //              x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-512" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCertificates &&
-        //              x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-512" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCA &&
-        //              x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-519" &&
-        //              !x.IsInherited);
-        //     Assert.Contains(results,
-        //         x => x.RightName == EdgeNames.ManageCertificates &&
-        //              x.PrincipalSID == "S-1-5-21-3130019616-2776909439-2417379446-519" &&
-        //              !x.IsInherited);
-        // }
-
-        // [Fact]
-        // public async Task CertAbuseProcessor_IsUserSpecifiesSanEnabled_HandlesFailure()
-        // {
-        //   var processor = new CertAbuseProcessor(new MockLdapUtils());
-        //     
-        //   CSVComputerStatus capturedStatus = null;
-        //
-        //   processor.ComputerStatusEvent += status =>
-        //   {
-        //     capturedStatus = status;
-        //     return Task.CompletedTask;
-        //   };
-        //
-        //   var results = await processor.IsUserSpecifiesSanEnabled("target", "DUMPSTER.FIRE", "sid");
-        //
-        //   Assert.Equal("Target machine was not found or not connectable", results.FailureReason);
-        //   Assert.False(results.Collected);
-        //   Assert.False(results.Value);
-        //     
-        //   Assert.Equal("DUMPSTER.FIRE", capturedStatus.ComputerName);
-        //   Assert.Equal("sid", capturedStatus.ObjectId);
-        //   Assert.Equal("Target machine was not found or not connectable", capturedStatus.Status);
-        //   Assert.Equal(nameof(processor.IsUserSpecifiesSanEnabled), capturedStatus.Task);
         // }
     }
 }

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -50,8 +50,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  true, Value = editFlags });
 
             var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
@@ -77,8 +76,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
             var results = await _certAbuseProcessor.IsUserSpecifiesSanEnabled(TargetName, CAName, TargetDomainSid);
@@ -105,8 +103,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  true, Value = roleSeparationEnabled });
 
             var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
@@ -132,8 +129,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
             var results = await _certAbuseProcessor.IsRoleSeparationEnabled(TargetName, CAName, TargetDomainSid);
@@ -183,7 +179,6 @@ namespace CommonLibTest
             };
         }
         
-        //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyTheory]
         [MemberData(nameof(ProcessEAPermissionsTestData))]
         public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty(RawAcl dacl) {
@@ -205,8 +200,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     "localhost",
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  true, Value = regValue });
         
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, "localhost", TargetDomainSid);
@@ -232,8 +226,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
             var results = await _certAbuseProcessor.ProcessEAPermissions(CAName, DomainName, TargetName, TargetDomainSid);
@@ -249,7 +242,6 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
-        //TODO: mock SAM server for sid lookups instead of fetching from localhost
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerAndNoRules() {
             const string subKey = $"SYSTEM\\CurrentControlSet\\Services\\CertSvc\\Configuration\\{CAName}";
@@ -270,8 +262,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     "localhost",
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  true, Value = regValue});
         
             //get access rules returns empty
@@ -303,8 +294,7 @@ namespace CommonLibTest
                 .Setup(ra => ra.GetRegistryKeyData(
                     TargetName,
                     subKey,
-                    subValue,
-                    It.IsAny<ILogger>()))
+                    subValue))
                 .Returns(new RegistryResult { Collected =  false, FailureReason = FailureReason });
 
             var results = await _certAbuseProcessor.ProcessRegistryEnrollmentPermissions(CAName, DomainName, TargetName, TargetDomainSid);
@@ -349,7 +339,6 @@ namespace CommonLibTest
         public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID(string sidValue) {
             var sid = new SecurityIdentifier(sidValue);
             
-            //TODO: check inputs
             var results = await _certAbuseProcessor.GetRegistryPrincipal(
                 sid,
                 DomainName,
@@ -382,47 +371,5 @@ namespace CommonLibTest
 
             Assert.Equal((true, new TypedPrincipal(expectedPrincipalSID, expectedPrincipalType)), results);
         }
-        
-        //TODO finish testing GetRegistryPrincipal
-
-        // [Fact]
-        // public void CertAbuseProcessor_GetCASecurity_HappyPath()
-        // {
-        //     var mockProcessor = new Mock<CertAbuseProcessor>(new MockLDAPUtils(), null);
-        //     
-        //     var mockRegistryKey = new Mock<IRegistryKey>();
-        //     mockRegistryKey.Setup(x => x.GetValue(It.IsAny<string>(), It.IsAny<string>()))
-        //         .Returns(new byte[] { 0x20, 0x20 });
-        //     mockProcessor.Setup(x => x.OpenRemoteRegistry(It.IsAny<string>())).Returns(mockRegistryKey.Object);
-        //
-        //     var processor = mockProcessor.Object;
-        //     var results = processor.GetCASecurity("testlab.local", "blah");
-        //     Assert.True(results.Collected);
-        // }
-
-        // [Fact]
-        // public async Task CertAbuseProcessor_ProcessCAPermissions_NullSecurity_ReturnsNull()
-        // {
-        //     var processor = new CertAbuseProcessor(new MockLdapUtils());
-        //     
-        //     CSVComputerStatus capturedStatus = null;
-        //
-        //     processor.ComputerStatusEvent += status =>
-        //     {
-        //       capturedStatus = status;
-        //       return Task.CompletedTask;
-        //     };
-        //
-        //     var results = await processor.ProcessRegistryEnrollmentPermissions(null, "DUMPSTER.FIRE", null, "test");
-        //
-        //     Assert.Equal("Value cannot be null. (Parameter 'machineName')", results.FailureReason);
-        //     Assert.False(results.Collected);
-        //     Assert.Empty(results.Data);
-        //     
-        //     Assert.Equal(null, capturedStatus.ComputerName);
-        //     Assert.Equal("test", capturedStatus.ObjectId);
-        //     Assert.Equal("Value cannot be null. (Parameter 'machineName')", capturedStatus.Status);
-        //     Assert.Equal(nameof(processor.ProcessRegistryEnrollmentPermissions), capturedStatus.Task);
-        // }
     }
 }

--- a/test/unit/Facades/MockLdapUtils.cs
+++ b/test/unit/Facades/MockLdapUtils.cs
@@ -745,9 +745,12 @@ namespace CommonLibTest.Facades
             return (!results.IsNullOrEmpty(), results);
         }
 
-        public Task<(bool Success, TypedPrincipal Principal)> ResolveCertTemplateByProperty(string propValue, string propName, string domainName) {
-            throw new NotImplementedException();
-        }
+        public async Task<(bool Success, TypedPrincipal Principal)> ResolveCertTemplateByProperty(string propValue, string propName, string domainName) =>
+            propValue switch
+            {
+                "ValidCN" => (true, new TypedPrincipal("guid", Label.CertTemplate)),
+                _ => (false, null),
+            };
 
         public async Task<string> ConvertWellKnownPrincipal(string sid, string domain)
         {

--- a/test/unit/Facades/MockLdapUtils.cs
+++ b/test/unit/Facades/MockLdapUtils.cs
@@ -744,13 +744,10 @@ namespace CommonLibTest.Facades
 
             return (!results.IsNullOrEmpty(), results);
         }
-
-        public async Task<(bool Success, TypedPrincipal Principal)> ResolveCertTemplateByProperty(string propValue, string propName, string domainName) =>
-            propValue switch
-            {
-                "ValidCN" => (true, new TypedPrincipal("guid", Label.CertTemplate)),
-                _ => (false, null),
-            };
+        
+        public Task<(bool Success, TypedPrincipal Principal)> ResolveCertTemplateByProperty(string propValue, string propName, string domainName) {
+            throw new NotImplementedException();
+        }
 
         public async Task<string> ConvertWellKnownPrincipal(string sid, string domain)
         {

--- a/test/unit/Utils.cs
+++ b/test/unit/Utils.cs
@@ -90,4 +90,12 @@ namespace CommonLibTest
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) Skip = "Ignore on non-Windows platforms";
         }
     }
+    
+    public sealed class WindowsOnlyTheory : TheoryAttribute
+    {
+        public WindowsOnlyTheory()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) Skip = "Ignore on non-Windows platforms";
+        }
+    }
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Update CertAbuseProcessor to write contacted machines to the compstatus log.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[BED-6967](https://specterops.atlassian.net/browse/BED-6967)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new unit tests and manually tested SHCE and SHE in a lab.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable abstractions for remote registry and SAM access integrated across processors for more resilient remote queries.
* **Bug Fixes**
  * Improved null-safety, early exits, and richer success/failure status reporting for certificate and registry/SAM checks.
* **Refactor**
  * Replaced direct registry/SAM helpers with accessor-based calls and adjusted public interfaces to support dependency injection.
* **Tests**
  * Large expansion of unit tests for certificate abuse flows and added a Windows-only theory attribute for platform-gated tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-6967]: https://specterops.atlassian.net/browse/BED-6967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ