### PR TITLE
Include Membership property set in AddSelf and AddMember edges

### DIFF
--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -8,6 +8,7 @@
         public const string UserForceChangePassword = "00299570-246d-11d0-a768-00aa006e0529";
         public const string AllGuid = "00000000-0000-0000-0000-000000000000";
         public const string WriteMember = "bf9679c0-0de6-11d0-a285-00aa003049e2";
+        public const string WriteMembership = "bc0ac240-79a9-11d0-9020-00c04fc2d4cf";  // property set https://learn.microsoft.com/en-us/windows/win32/adschema/r-membership
         public const string WriteAllowedToAct = "3f78c3e5-f79a-46bd-a0b8-9d18116ddc79";
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";

--- a/src/CommonLib/Processors/ACEGuids.cs
+++ b/src/CommonLib/Processors/ACEGuids.cs
@@ -8,7 +8,7 @@
         public const string UserForceChangePassword = "00299570-246d-11d0-a768-00aa006e0529";
         public const string AllGuid = "00000000-0000-0000-0000-000000000000";
         public const string WriteMember = "bf9679c0-0de6-11d0-a285-00aa003049e2";
-        public const string WriteMembership = "bc0ac240-79a9-11d0-9020-00c04fc2d4cf";  // property set https://learn.microsoft.com/en-us/windows/win32/adschema/r-membership
+        public const string MembershipPropertySet = "bc0ac240-79a9-11d0-9020-00c04fc2d4cf";  // property set https://learn.microsoft.com/en-us/windows/win32/adschema/r-membership
         public const string WriteAllowedToAct = "3f78c3e5-f79a-46bd-a0b8-9d18116ddc79";
         public const string WriteSPN = "f3a64788-5306-11d1-a9c5-0000f80367c1";
         public const string AddKeyPrincipal = "5b47d60f-6090-40b2-9f37-2a4de88f3063";

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -584,7 +584,7 @@ namespace SharpHoundCommonLib.Processors {
                 if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
                     !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
                     !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                    aceType is ACEGuids.WriteMember or ACEGuids.AllGuid)
+                    aceType is ACEGuids.WriteMember or ACEGuids.WriteMembership or ACEGuids.AllGuid)
                     yield return new ACE {
                         PrincipalType = resolvedPrincipal.ObjectType,
                         PrincipalSID = resolvedPrincipal.ObjectIdentifier,
@@ -786,7 +786,7 @@ namespace SharpHoundCommonLib.Processors {
                             IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                             IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                         };
-                    else if (objectType == Label.Group && aceType == ACEGuids.WriteMember)
+                    else if (objectType == Label.Group && (aceType == ACEGuids.WriteMember || aceType == ACEGuids.WriteMembership))
                         yield return new ACE {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -786,7 +786,7 @@ namespace SharpHoundCommonLib.Processors {
                             IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                             IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                         };
-                    else if (objectType == Label.Group && (aceType == ACEGuids.WriteMember || aceType == ACEGuids.WriteMembership))
+                    else if (objectType == Label.Group && (aceType is ACEGuids.WriteMember or ACEGuids.WriteMembership))
                         yield return new ACE {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,

--- a/src/CommonLib/Processors/ACLProcessor.cs
+++ b/src/CommonLib/Processors/ACLProcessor.cs
@@ -584,7 +584,7 @@ namespace SharpHoundCommonLib.Processors {
                 if (aceRights.HasFlag(ActiveDirectoryRights.Self) &&
                     !aceRights.HasFlag(ActiveDirectoryRights.WriteProperty) &&
                     !aceRights.HasFlag(ActiveDirectoryRights.GenericWrite) && objectType == Label.Group &&
-                    aceType is ACEGuids.WriteMember or ACEGuids.WriteMembership or ACEGuids.AllGuid)
+                    aceType is ACEGuids.WriteMember or ACEGuids.MembershipPropertySet or ACEGuids.AllGuid)
                     yield return new ACE {
                         PrincipalType = resolvedPrincipal.ObjectType,
                         PrincipalSID = resolvedPrincipal.ObjectIdentifier,
@@ -786,7 +786,7 @@ namespace SharpHoundCommonLib.Processors {
                             IsPermissionForOwnerRightsSid = isPermissionForOwnerRightsSid,
                             IsInheritedPermissionForOwnerRightsSid = isInheritedPermissionForOwnerRightsSid,
                         };
-                    else if (objectType == Label.Group && (aceType is ACEGuids.WriteMember or ACEGuids.WriteMembership))
+                    else if (objectType == Label.Group && (aceType is ACEGuids.WriteMember or ACEGuids.MembershipPropertySet))
                         yield return new ACE {
                             PrincipalType = resolvedPrincipal.ObjectType,
                             PrincipalSID = resolvedPrincipal.ObjectIdentifier,


### PR DESCRIPTION
## Description

Includes the Membership property set as an additional object ACE guid for AddSelf and AddMember edges.

## Motivation and Context

This change adds additional coverage for ACL abuse related to changing the membership of group nodes by introducing the [Membership property set](https://learn.microsoft.com/en-us/windows/win32/adschema/r-membership) ACEGuid to the edges.

Testing performed while researching AllValidatedWrites ACEs confirmed a gap in coverage for this property set:
<img width="1989" height="500" alt="image" src="https://github.com/user-attachments/assets/7678a937-eec1-4ad9-ac5f-8e989a584f3d" />

This diagram shows how the Membership property set fits into the possible ACE options that allow for modifying the member property of a group:
<img width="1541" height="812" alt="ModifyMembership" src="https://github.com/user-attachments/assets/8aad85d6-d9b2-4e4d-b509-962571a069e0" />

Fixes [BED-7069](https://specterops.atlassian.net/browse/BED-7069)

## How Has This Been Tested?

Created a matrix test in CORP1 domain of my lab using this [New-MembershipTest.ps1](https://github.com/JimSycurity/ACLchyually/blob/main/Membership/New-MembershipTest.ps1) script. This creates a group object for each possible ACE type that can modify group membership.  Prior to this change 9 of the 12 ACEs were created by SharpHound.  After implementing this change, all 12 ACEs were covered.

This change is limited to only 2 files and 3 lines of code in SharpHoundCommon. The functionality works as expected with no additional changes to SharpHound, SharpHoundEnterprise, BloodHound, or BloodHoundEnterprise.


## Screenshots (if appropriate):
BloodHound edges prior to change:
<img width="3348" height="1781" alt="Screenshot 2025-12-12 094632" src="https://github.com/user-attachments/assets/5a340f9c-9e39-490b-907b-d79fb19643cb" />

BloodHound edges after SHC change:
<img width="3335" height="1780" alt="Screenshot 2025-12-18 183626" src="https://github.com/user-attachments/assets/d4f414d1-207d-4f23-a6f9-799c5bfeffca" />


## Types of changes
-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
-   [ ] Documentation updates are needed, and have been made accordingly.
-   [] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-7069]: https://specterops.atlassian.net/browse/BED-7069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced access control handling for group membership operations with improved support for membership property management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->