### PR TITLE
fix: Process objectguid as common property - BED-7397

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -53,6 +53,21 @@ namespace SharpHoundCommonLib.Processors {
                 ret["whencreated"] = Helpers.ConvertTimestampToUnixEpoch(wc);
             }
 
+            if (entry.TryGetByteProperty(LDAPProperties.objectguid, out var objectguid)) {
+                if (objectguid != null && objectguid.Length == 16)
+                {
+                    try
+                    {
+                        Guid guid = new Guid(objectguid);
+                        ret["objectguid"](LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
+                    }
+                    catch
+                    {
+                        // Skip malformed GUID bytes
+                    }
+                }
+            }
+
             return ret;
         }
 
@@ -438,20 +453,6 @@ namespace SharpHoundCommonLib.Processors {
                 foreach (var dn in hsa) {
                     if (await _utils.ResolveDistinguishedName(dn) is (true, var resolvedPrincipal))
                         smsaPrincipals.Add(resolvedPrincipal);
-                }
-            }
-
-            var objectGuidBytes = entry.GetByteProperty(LDAPProperties.ObjectGUID);
-            if (objectGuidBytes != null && objectGuidBytes.Length == 16)
-            {
-                try
-                {
-                    Guid guid = new Guid(objectGuidBytes);
-                    props.Add(LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
-                }
-                catch
-                {
-                    // Skip malformed GUID bytes
                 }
             }
 

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -59,7 +59,7 @@ namespace SharpHoundCommonLib.Processors {
                     try
                     {
                         var guid = new Guid(objectguid);
-                        ret["objectguid"](LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
+                        ret["objectguid"] = guid.ToString().ToUpperInvariant();
                     }
                     catch
                     {

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -53,7 +53,7 @@ namespace SharpHoundCommonLib.Processors {
                 ret["whencreated"] = Helpers.ConvertTimestampToUnixEpoch(wc);
             }
 
-            if (entry.TryGetByteProperty(LDAPProperties.objectguid, out var objectguid)) {
+            if (entry.TryGetByteProperty(LDAPProperties.ObjectGUID, out var objectguid)) {
                 if (objectguid != null && objectguid.Length == 16)
                 {
                     try

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -58,7 +58,7 @@ namespace SharpHoundCommonLib.Processors {
                 {
                     try
                     {
-                        Guid guid = new Guid(objectguid);
+                        var guid = new Guid(objectguid);
                         ret["objectguid"](LDAPProperties.ObjectGUID, guid.ToString().ToUpper());
                     }
                     catch

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -58,7 +58,7 @@ namespace SharpHoundCommonLib.Processors {
                 {
                     try
                     {
-                        var guid = new Guid(objectguid);
+                        Guid guid = new Guid(objectguid);
                         ret["objectguid"] = guid.ToString().ToUpperInvariant();
                     }
                     catch

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -302,7 +302,7 @@ namespace CommonLibTest {
             Assert.Equal("DC=test,DC=local", result);
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("S-1-5-32-544", "\\01\\02\\00\\00\\00\\00\\00\\05\\20\\00\\00\\00\\20\\02\\00\\00")]
         public void ConvertSidToHexSid_ValidSid_MatchesSecurityIdentifierBinaryForm(string sid, string expectedHexSid)
         {
@@ -322,7 +322,7 @@ namespace CommonLibTest {
             }
         }
 
-        [Fact]
+        [WindowsOnlyFact]
         public void ConvertSidToHexSid_InvalidSid_Throws()
         {
             Assert.ThrowsAny<ArgumentException>(() => Helpers.ConvertSidToHexSid("NOT-A-SID"));


### PR DESCRIPTION
## Description

Adds ObjectGUID processing support as a common property

## Motivation and Context

Resolves: BED-7397

## How Has This Been Tested?

Help me team!

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [X] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GUID handling for LDAP properties is more consistent: duplicate extraction removed, malformed GUID bytes skipped, and object GUIDs are recorded reliably—reducing related errors.

* **Tests**
  * Two unit tests updated to run only on Windows environments to reflect platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->