### PR TITLE
Improve NTLM Collection Logging BED-7374

### DIFF
--- a/RPCTest/RPCTest.csproj
+++ b/RPCTest/RPCTest.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\src\SharpHoundRPC\SharpHoundRPC.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/RPCTest/RPCTest.csproj
+++ b/RPCTest/RPCTest.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
             <PrivateAssets>all</PrivateAssets>

--- a/RPCTest/Registry/StrategyExecutorTests.cs
+++ b/RPCTest/Registry/StrategyExecutorTests.cs
@@ -1,0 +1,130 @@
+using SharpHoundRPC.Registry;
+using Xunit;
+
+namespace RPCTest.Registry;
+
+public class StrategyExecutorTests {
+    private readonly StrategyExecutor _strategyExecutor = new();
+    
+    [Fact]
+    public async Task CollectAsync_NoStrategies_ReturnsFailure_WithNoAttempts() {
+        // Act
+        var result = await _strategyExecutor.CollectAsync<RegistryQueryResult, RegistryQuery>("target machine", [], []);
+        
+        // Assert
+        Assert.NotNull(result);
+        Assert.False(result.WasSuccessful);
+        Assert.Empty(result.FailureAttempts!);
+        Assert.Null(result.Results);
+        Assert.Null(result.SuccessfulStrategy);
+    }
+    
+    [Fact]
+    public async Task CollectAsync_CanExecuteIsFalse_ReturnsFailure_WithAttempt() {
+        //Arrange
+        var strategy = new FakeCollectionStrategy(false, "well now I am not doing it");
+        
+        // Act
+        var result = await _strategyExecutor.CollectAsync("target machine", [], [strategy]);
+        
+        // Assert
+        Assert.False(result.WasSuccessful);
+        Assert.Null(result.Results);
+        Assert.Null(result.SuccessfulStrategy);
+        
+        var attempt = result.FailureAttempts?.Single();
+        Assert.Equal("well now I am not doing it", attempt?.FailureReason);
+        Assert.Equal(strategy.GetType(), attempt?.StrategyType);
+    }
+    
+    [Theory]
+    [MemberData(nameof(StrategyExceptions))]
+    public async Task CollectAsync_ThrowsException_ReturnsFailure_WithExceptionMessage(Exception strategyException) {
+        //Arrange
+        var strategy = new FakeCollectionStrategy(
+            canExecute: true,
+            exception: strategyException
+        );
+        
+        // Act
+        var result = await _strategyExecutor.CollectAsync("target machine", [], [strategy]);
+        
+        // Assert
+        Assert.False(result.WasSuccessful);
+        Assert.Null(result.Results);
+        Assert.Null(result.SuccessfulStrategy);
+        
+        var attempt = result.FailureAttempts?.Single();
+        Assert.Contains($"Collector failed: {strategyException.Message}.", attempt!.FailureReason!); 
+        
+        if (strategyException.InnerException is not null) 
+            Assert.Contains($"\nInner Exception: {strategyException.InnerException}", attempt!.FailureReason!); 
+        else 
+            Assert.DoesNotContain("Inner Exception:", attempt!.FailureReason!);
+    }
+    
+    public static IEnumerable<object[]> StrategyExceptions =>
+    [
+        [new Exception("Outer Exception")],
+        [new Exception("Outer Exception", new Exception("Inner Exception"))]
+    ];
+    
+    [Fact]
+    public async Task CollectAsync_FirstStrategySuccessful_ReturnsSuccess_WithNoAttempts() {
+        //Arrange
+        var strategyResult = new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", 1, null, true);
+        var strategy = new FakeCollectionStrategy(
+            true,
+            results: [strategyResult]
+        );
+        
+        // Act
+        var result = await _strategyExecutor.CollectAsync("target machine", [], [strategy]);
+        
+        // Assert
+        Assert.True(result.WasSuccessful);
+        Assert.Empty(result.FailureAttempts!);
+        Assert.Equal(strategy.GetType(), result.SuccessfulStrategy);
+        Assert.Equal(strategyResult, result.Results?.Single());
+    }
+    
+    [Fact]
+    public async Task CollectAsync_SecondStrategySuccessful_ReturnsSuccess_WithAttempt() {
+        //Arrange
+        var failedStrategy = new FakeCollectionStrategy(false, "well now I am not doing it");
+        var strategyResult = new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", 1, null, true);
+        var successfulStrategy = new FakeCollectionStrategy(
+            true,
+            results: [strategyResult]
+        );
+        
+        // Act
+        var result = await _strategyExecutor.CollectAsync("target machine", [], [failedStrategy, successfulStrategy]);
+        
+        // Assert
+        Assert.True(result.WasSuccessful);
+        Assert.Single(result.FailureAttempts!);
+        Assert.Equal(successfulStrategy.GetType(), result.SuccessfulStrategy);
+        Assert.Equal(strategyResult, result.Results?.Single());
+    }
+}
+
+internal sealed class FakeCollectionStrategy(
+    bool canExecute,
+    string failureReason = "",
+    Exception? exception = null,
+    IEnumerable<RegistryQueryResult>? results = null
+) : ICollectionStrategy<RegistryQueryResult, RegistryQuery> 
+{
+    public Task<(bool, string)> CanExecute(string target)
+        => Task.FromResult((canExecute, failureReason));
+
+    public Task<IEnumerable<RegistryQueryResult>> ExecuteAsync(
+        string target,
+        IEnumerable<RegistryQuery> queries) {
+        if (exception is not null)
+            throw exception;
+
+        return Task.FromResult(results ?? []);
+    }
+}

--- a/SharpHoundCommon.sln
+++ b/SharpHoundCommon.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Docfx", "docfx\Docfx.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpHoundRPC", "src\SharpHoundRPC\SharpHoundRPC.csproj", "{4F06116D-88A7-4601-AB28-B48F2857D458}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RPCTest", "RPCTest\RPCTest.csproj", "{F1E6714E-72B3-4295-9940-0EAA69695201}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,5 +33,9 @@ Global
 		{4F06116D-88A7-4601-AB28-B48F2857D458}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F06116D-88A7-4601-AB28-B48F2857D458}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F06116D-88A7-4601-AB28-B48F2857D458}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1E6714E-72B3-4295-9940-0EAA69695201}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1E6714E-72B3-4295-9940-0EAA69695201}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1E6714E-72B3-4295-9940-0EAA69695201}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1E6714E-72B3-4295-9940-0EAA69695201}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/CommonLib/Processors/ComputerAvailability.cs
+++ b/src/CommonLib/Processors/ComputerAvailability.cs
@@ -95,11 +95,19 @@ namespace SharpHoundCommonLib.Processors {
                 };
             }
 
-            if (_skipPortScan)
+            if (_skipPortScan) {
+                await SendComputerStatus(new CSVComputerStatus {
+                    Status = CSVComputerStatus.StatusSuccess,
+                    Task = "ComputerAvailability",
+                    ComputerName = computerName,
+                    ObjectId = objectId,
+                });
+            
                 return new ComputerStatus {
                     Connectable = true,
                     Error = null
                 };
+            }
 
             if (!await _scanner.CheckPort(computerName)) {
                 _log.LogTrace("{ComputerName} is not available because port 445 is unavailable", computerName);

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -5,12 +5,14 @@ using SharpHoundRPC.PortScanner;
 using SharpHoundRPC.Registry;
 using System;
 using System.Linq;
+using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
-using static SharpHoundCommonLib.Helpers;
 
 namespace SharpHoundCommonLib.Processors;
 
 public class RegistryProcessor {
+    public delegate Task ComputerStatusDelegate(CSVComputerStatus status);
+    
     private readonly ILogger _log;
     private readonly IPortScanner _portScanner;
     private readonly ICollectionStrategy<RegistryQueryResult, RegistryQuery>[] _strategies;
@@ -50,6 +52,8 @@ public class RegistryProcessor {
         ];
     }
 
+    public event ComputerStatusDelegate ComputerStatusEvent;
+
     public async Task<APIResult<RegistryData>> ReadRegistrySettings(string targetMachine) {
         var output = new RegistryData();
 
@@ -64,6 +68,22 @@ public class RegistryProcessor {
             }
 
             var collectedData = result.Value;
+
+            foreach (var attempt in collectedData.FailureAttempts ?? []) {
+                _log.LogTrace("ReadRegistry failed on {ComputerName} using {Strategy}: {Error}", targetMachine, attempt.StrategyType, attempt.FailureReason);
+                await SendComputerStatus(new CSVComputerStatus
+                {
+                    Status = attempt.FailureReason,
+                    ComputerName = targetMachine,
+                    Task = nameof(ReadRegistrySettings)
+                });
+            }
+
+            if (!collectedData.WasSuccessful) {
+                string msg = string.Join("\n",
+                    collectedData.FailureAttempts.Select(a => $"{a.StrategyType.Name}: {a.FailureReason ?? ""}"));
+                return APIResult<RegistryData>.Failure(msg);
+            }
 
             foreach (var key in collectedData.Results ?? []) {
                 if (!key.ValueExists)
@@ -100,13 +120,14 @@ public class RegistryProcessor {
                         break;
                 }
             }
-
-            // If all strategies failed, need to report errors.
-            if (collectedData.FailureAttempts.Count() == _strategies.Length) {
-                string msg = string.Join("\n",
-                    collectedData.FailureAttempts.Select(a => $"{a.StrategyType.Name}: {a.FailureReason ?? ""}"));
-                return APIResult<RegistryData>.Failure(msg);
-            }
+            
+            await SendComputerStatus(new CSVComputerStatus
+            {
+                Status = CSVComputerStatus.StatusSuccess,
+                ComputerName = targetMachine,
+                Task = nameof(ReadRegistrySettings),
+                // ObjectId = computerObjectId, //TODO: can we get a compId?
+            });
 
             return APIResult<RegistryData>.Success(output);
         } catch (Exception ex) {
@@ -117,5 +138,9 @@ public class RegistryProcessor {
 
             return APIResult<RegistryData>.Failure(ex.ToString());
         }
+    }
+
+    private async Task SendComputerStatus(CSVComputerStatus status) {
+        if (ComputerStatusEvent is not null) await ComputerStatusEvent.Invoke(status);
     }
 }

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -71,7 +71,7 @@ public class RegistryProcessor {
             var collectedData = result.Value;
 
             foreach (var attempt in collectedData.FailureAttempts ?? []) {
-                _log.LogTrace("ReadRegistry failed on {ComputerName} using {Strategy}: {Error}", targetMachine, attempt.StrategyType, attempt.FailureReason);
+                _log.LogTrace("ReadRegistry failed on {ComputerName} using {Strategy}: {Error}", targetMachine, attempt.StrategyType.Name, attempt.FailureReason);
                 await SendComputerStatus(new CSVComputerStatus
                 {
                     Task = $"{nameof(ReadRegistrySettings)} - {attempt.StrategyType.Name}",

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -5,7 +5,6 @@ using SharpHoundRPC.PortScanner;
 using SharpHoundRPC.Registry;
 using System;
 using System.Linq;
-using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 
 namespace SharpHoundCommonLib.Processors;
@@ -15,13 +14,16 @@ public class RegistryProcessor {
     
     private readonly ILogger _log;
     private readonly IPortScanner _portScanner;
+    private readonly IStrategyExecutor _registryCollector; 
+    private readonly AdaptiveTimeout _registryAdaptiveTimeout = new(maxTimeout:TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ReadRegistrySettings)));
     private readonly ICollectionStrategy<RegistryQueryResult, RegistryQuery>[] _strategies;
     private readonly RegistryQuery[] _queries;
-    private readonly AdaptiveTimeout _registryAdaptiveTimeout = new(maxTimeout:TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ReadRegistrySettings)));
 
-    public RegistryProcessor(ILogger log, string domain) {
+    public RegistryProcessor(ILogger log, IStrategyExecutor registryCollector, string domain) {
         _log = log ?? Logging.LogProvider.CreateLogger("RegistryProcessor");
         _portScanner = new PortScanner();
+        _registryCollector = registryCollector;
+        
         _strategies = [
             // Higher priority at the top of the list
             new DotNetWmiRegistryStrategy(_portScanner, domain),
@@ -58,8 +60,7 @@ public class RegistryProcessor {
         var output = new RegistryData();
 
         try {
-            var registryCollector = new StrategyExecutor();
-            var result = await _registryAdaptiveTimeout.ExecuteWithTimeout(async (_) => await registryCollector
+            var result = await _registryAdaptiveTimeout.ExecuteWithTimeout(async (_) => await _registryCollector
                 .CollectAsync(targetMachine, _queries, _strategies)
                 .ConfigureAwait(false));
 
@@ -73,9 +74,9 @@ public class RegistryProcessor {
                 _log.LogTrace("ReadRegistry failed on {ComputerName} using {Strategy}: {Error}", targetMachine, attempt.StrategyType, attempt.FailureReason);
                 await SendComputerStatus(new CSVComputerStatus
                 {
-                    Status = attempt.FailureReason,
+                    Task = nameof(ReadRegistrySettings),
                     ComputerName = targetMachine,
-                    Task = nameof(ReadRegistrySettings)
+                    Status = attempt.StrategyType.Name + " Failed: " + attempt.FailureReason
                 });
             }
 
@@ -84,6 +85,13 @@ public class RegistryProcessor {
                     collectedData.FailureAttempts.Select(a => $"{a.StrategyType.Name}: {a.FailureReason ?? ""}"));
                 return APIResult<RegistryData>.Failure(msg);
             }
+            
+            await SendComputerStatus(new CSVComputerStatus
+            {
+                Task = nameof(ReadRegistrySettings),
+                ComputerName = targetMachine,
+                Status = CSVComputerStatus.StatusSuccess
+            });
 
             foreach (var key in collectedData.Results ?? []) {
                 if (!key.ValueExists)
@@ -120,14 +128,6 @@ public class RegistryProcessor {
                         break;
                 }
             }
-            
-            await SendComputerStatus(new CSVComputerStatus
-            {
-                Status = CSVComputerStatus.StatusSuccess,
-                ComputerName = targetMachine,
-                Task = nameof(ReadRegistrySettings),
-                // ObjectId = computerObjectId, //TODO: can we get a compId?
-            });
 
             return APIResult<RegistryData>.Success(output);
         } catch (Exception ex) {

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -91,7 +91,7 @@ public class RegistryProcessor {
             
             await SendComputerStatus(new CSVComputerStatus
             {
-                Task = $"{nameof(ReadRegistrySettings)} - {_strategies[collectedData.FailureAttempts?.Count() ?? 0].GetType().Name}",
+                Task = $"{nameof(ReadRegistrySettings)} - {collectedData.SuccessfulStrategy?.Name ?? ""}",
                 ComputerName = targetMachine,
                 Status = CSVComputerStatus.StatusSuccess
             });

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -79,10 +79,13 @@ public class RegistryProcessor {
                     Status = attempt.StrategyType.Name + " Failed: " + attempt.FailureReason
                 });
             }
-
+            
             if (!collectedData.WasSuccessful) {
-                string msg = string.Join("\n",
-                    collectedData.FailureAttempts.Select(a => $"{a.StrategyType.Name}: {a.FailureReason ?? ""}"));
+                var msg = collectedData.FailureAttempts is null 
+                    ? "Failed to read registry settings"
+                    : string.Join("\n",
+                        collectedData.FailureAttempts.Select(a => $"{a.StrategyType.Name}: {a.FailureReason ?? ""}"));
+                
                 return APIResult<RegistryData>.Failure(msg);
             }
             

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -74,9 +74,9 @@ public class RegistryProcessor {
                 _log.LogTrace("ReadRegistry failed on {ComputerName} using {Strategy}: {Error}", targetMachine, attempt.StrategyType, attempt.FailureReason);
                 await SendComputerStatus(new CSVComputerStatus
                 {
-                    Task = nameof(ReadRegistrySettings),
+                    Task = $"{nameof(ReadRegistrySettings)} - {attempt.StrategyType.Name}",
                     ComputerName = targetMachine,
-                    Status = attempt.StrategyType.Name + " Failed: " + attempt.FailureReason
+                    Status = attempt.FailureReason
                 });
             }
             

--- a/src/CommonLib/Processors/RegistryProcessor.cs
+++ b/src/CommonLib/Processors/RegistryProcessor.cs
@@ -91,7 +91,7 @@ public class RegistryProcessor {
             
             await SendComputerStatus(new CSVComputerStatus
             {
-                Task = nameof(ReadRegistrySettings),
+                Task = $"{nameof(ReadRegistrySettings)} - {_strategies[collectedData.FailureAttempts?.Count() ?? 0].GetType().Name}",
                 ComputerName = targetMachine,
                 Status = CSVComputerStatus.StatusSuccess
             });

--- a/src/SharpHoundRPC/Registry/DotNetWmiRegistryStrategy.cs
+++ b/src/SharpHoundRPC/Registry/DotNetWmiRegistryStrategy.cs
@@ -26,7 +26,6 @@ namespace SharpHoundRPC.Registry {
         /// </summary>
         public bool UseKerberos { get; set; } = true;
 
-
         /// <summary>
         /// Creates a new WMI registry strategy
         /// </summary>

--- a/src/SharpHoundRPC/Registry/DotNetWmiRegistryStrategy.cs
+++ b/src/SharpHoundRPC/Registry/DotNetWmiRegistryStrategy.cs
@@ -38,6 +38,9 @@ namespace SharpHoundRPC.Registry {
         }
 
         public async Task<(bool, string)> CanExecute(string targetMachine) {
+            if (string.IsNullOrEmpty(targetMachine)) {
+                throw new ArgumentException("Target machine cannot be null or empty", nameof(targetMachine));
+            }
             try {
                 var isOpen = await _portScanner.CheckPort(targetMachine, EpMapperPort, throwError: true);
                 return (isOpen, string.Empty);

--- a/src/SharpHoundRPC/Registry/NativeUtils.cs
+++ b/src/SharpHoundRPC/Registry/NativeUtils.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 using static SharpHoundRPC.NetAPINative.NetAPIEnums;
 
 namespace SharpHoundRPC.Registry {

--- a/src/SharpHoundRPC/Registry/RemoteRegistryStrategy.cs
+++ b/src/SharpHoundRPC/Registry/RemoteRegistryStrategy.cs
@@ -1,7 +1,7 @@
 ﻿#nullable enable
 namespace SharpHoundRPC.Registry {
     using Microsoft.Win32;
-    using SharpHoundRPC.PortScanner;
+    using PortScanner;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -37,7 +37,6 @@ namespace SharpHoundRPC.Registry {
 
             if (queries == null || !queries.Any())
                 throw new ArgumentException("Queries cannot be null or empty", nameof(queries));
-
 
             return await Task.Run(() => {
                 var results = new List<RegistryQueryResult>();

--- a/src/SharpHoundRPC/Registry/StrategyExecutor.cs
+++ b/src/SharpHoundRPC/Registry/StrategyExecutor.cs
@@ -4,7 +4,6 @@ namespace SharpHoundRPC.Registry {
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-
     public class StrategyExecutor {
         public async Task<StrategyExecutorResult<T>> CollectAsync<T, TQuery>(
             string targetMachine,
@@ -24,9 +23,6 @@ namespace SharpHoundRPC.Registry {
 
                 try {
                     var results = await strategy.ExecuteAsync(targetMachine, queries).ConfigureAwait(false);
-
-                    attempt.WasSuccessful = true;
-                    attempt.Results = results;
 
                     return new StrategyExecutorResult<T> {
                         Results = results,

--- a/src/SharpHoundRPC/Registry/StrategyExecutor.cs
+++ b/src/SharpHoundRPC/Registry/StrategyExecutor.cs
@@ -4,7 +4,15 @@ namespace SharpHoundRPC.Registry {
     using System.Collections.Generic;
     using System.Threading.Tasks;
 
-    public class StrategyExecutor {
+    public interface IStrategyExecutor
+    {
+        Task<StrategyExecutorResult<T>> CollectAsync<T, TQuery>(
+            string targetMachine,
+            IEnumerable<TQuery> queries,
+            IEnumerable<ICollectionStrategy<T, TQuery>> strategies);
+    }
+    
+    public class StrategyExecutor : IStrategyExecutor {
         public async Task<StrategyExecutorResult<T>> CollectAsync<T, TQuery>(
             string targetMachine,
             IEnumerable<TQuery> queries,

--- a/src/SharpHoundRPC/Registry/StrategyExecutor.cs
+++ b/src/SharpHoundRPC/Registry/StrategyExecutor.cs
@@ -35,7 +35,8 @@ namespace SharpHoundRPC.Registry {
                     return new StrategyExecutorResult<T> {
                         Results = results,
                         FailureAttempts = attempts,
-                        WasSuccessful = true
+                        WasSuccessful = true,
+                        SuccessfulStrategy =  strategy.GetType(),
                     };
                 } catch (Exception ex) {
                     attempt.FailureReason = $"Collector failed: {ex.Message}.\nInner Exception: {ex.InnerException}";

--- a/src/SharpHoundRPC/Registry/StrategyExecutor.cs
+++ b/src/SharpHoundRPC/Registry/StrategyExecutor.cs
@@ -36,18 +36,22 @@ namespace SharpHoundRPC.Registry {
                         Results = results,
                         FailureAttempts = attempts,
                         WasSuccessful = true,
-                        SuccessfulStrategy =  strategy.GetType(),
+                        SuccessfulStrategy =  strategy.GetType()
                     };
                 } catch (Exception ex) {
-                    attempt.FailureReason = $"Collector failed: {ex.Message}.\nInner Exception: {ex.InnerException}";
+                    var innerException = ex.InnerException != null
+                        ? $"\nInner Exception: {ex.InnerException}"
+                        : string.Empty;
+
+                    attempt.FailureReason = $"Collector failed: {ex.Message}.{innerException}";
                 }
 
                 attempts.Add(attempt);
             }
 
             return new StrategyExecutorResult<T> {
-                Results = null,
-                FailureAttempts = attempts
+                FailureAttempts = attempts,
+                WasSuccessful = false,
             };
         }
     }

--- a/src/SharpHoundRPC/Registry/StrategyExecutorResult.cs
+++ b/src/SharpHoundRPC/Registry/StrategyExecutorResult.cs
@@ -1,12 +1,16 @@
 ﻿#nullable enable
-namespace SharpHoundRPC.Registry {
-    using System.Collections.Generic;
 
+using System;
+using System.Collections.Generic;
+
+namespace SharpHoundRPC.Registry {
 
     public class StrategyExecutorResult<T> {
         public IEnumerable<T>? Results { get; set; } = null;
         public IEnumerable<StrategyResult<T>>? FailureAttempts { get; set; } = null;
         public bool WasSuccessful = false;
+        public Type? SuccessfulStrategy { get; set; } = null;
     }
-#nullable disable
 }
+
+#nullable disable

--- a/test/unit/Facades/MockExtensions.cs
+++ b/test/unit/Facades/MockExtensions.cs
@@ -44,7 +44,7 @@ public static class MockExtensions
                 It.IsAny<EventId>(),
                 It.IsAny<It.IsAnyType>(),
                 It.IsAny<Exception>(),
-                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Never);
     }
 }

--- a/test/unit/Facades/MockExtentions.cs
+++ b/test/unit/Facades/MockExtentions.cs
@@ -32,4 +32,16 @@ public static class MockExtentions
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
     }
+    
+    public static void VerifyNoLogs<T>(this Mock<ILogger<T>> mockLogger, LogLevel logLevel)
+    {
+        mockLogger.Verify(
+            x => x.Log(
+                logLevel,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+            Times.Never);
+    }
 }

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -36,7 +36,7 @@ namespace CommonLibTest
         }
 
         [Fact]
-        public async Task RegistryProcessor_ReadRegistrySettings_CollectionNotSuccessful() {
+        public async Task RegistryProcessor_ReadRegistrySettings_CollectionFailed() {
             const string failureReason = "No such host is known.";
             var attempts = new List<StrategyResult<RegistryQueryResult>>
             {
@@ -73,7 +73,7 @@ namespace CommonLibTest
             VerifyFailureLog<RemoteRegistryStrategy>(TargetName, failureReason);
             Assert.Equal(2, _receivedCompStatuses.Count);
             foreach (var attempt in attempts) {
-                VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, $"{attempt.StrategyType.Name} Failed: {failureReason}");
+                VerifyCompStatusLog($"{nameof(_registryProcessor.ReadRegistrySettings)} - {attempt.StrategyType.Name}", TargetName, failureReason);
             }
         }
 
@@ -143,7 +143,7 @@ namespace CommonLibTest
             //Validate logs
             VerifyFailureLog<DotNetWmiRegistryStrategy>(TargetName, failureReason);
             Assert.Equal(2, _receivedCompStatuses.Count);
-            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, $"{attempts[0].StrategyType.Name} Failed: {failureReason}");
+            VerifyCompStatusLog($"{nameof(_registryProcessor.ReadRegistrySettings)} - {attempts[0].StrategyType.Name}", TargetName, failureReason);
             VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
         }
 

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CommonLibTest.Facades;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+using Moq;
+using SharpHoundCommonLib;
+using SharpHoundCommonLib.Processors;
+using Xunit;
+using SharpHoundRPC.Registry;
+
+namespace CommonLibTest 
+{
+    public class RegistryProcessorTest
+    {
+        private readonly Mock<ILogger<RegistryProcessor>> _mockLogger;
+        private readonly Mock<IStrategyExecutor> _mockStrategyExecutor;
+        private readonly RegistryProcessor _registryProcessor;
+
+        private const string DomainName = "TEST.LOCAL";
+        private const string TargetName = "target.test.local";
+        
+        private readonly List<CSVComputerStatus> _receivedCompStatuses = [];
+
+        public RegistryProcessorTest() {
+            _mockLogger = new Mock<ILogger<RegistryProcessor>>();
+            _mockStrategyExecutor = new Mock<IStrategyExecutor>();
+            _registryProcessor = new RegistryProcessor(_mockLogger.Object, _mockStrategyExecutor.Object, DomainName);
+
+            _registryProcessor.ComputerStatusEvent += status => {
+                _receivedCompStatuses.Add(status);
+                return Task.CompletedTask;
+            };
+        }
+
+        [Fact]
+        public async Task RegistryProcessor_ReadRegistrySettings_CollectionNotSuccessful() {
+            const string failureReason = "No such host is known.";
+            var attempts = new List<StrategyResult<RegistryQueryResult>>
+            {
+                new(typeof(DotNetWmiRegistryStrategy))
+                {
+                    FailureReason = failureReason
+                },
+                new(typeof(RemoteRegistryStrategy))
+                {
+                    FailureReason = failureReason
+                }
+            };
+            
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .ReturnsAsync(
+                    new StrategyExecutorResult<RegistryQueryResult> {
+                        FailureAttempts = attempts,
+                        WasSuccessful = false
+                    }
+                );
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+
+            //Validate result
+            Assert.False(results.Collected);
+            var expectedFailureReason = string.Join("\n", attempts.Select(a => $"{a.StrategyType.Name}: {failureReason}"));
+            Assert.Equal(expectedFailureReason, results.FailureReason);
+            
+            //Validate logs
+            VerifyFailureLog<DotNetWmiRegistryStrategy>(TargetName, failureReason);
+            VerifyFailureLog<RemoteRegistryStrategy>(TargetName, failureReason);
+            Assert.Equal(2, _receivedCompStatuses.Count);
+            foreach (var attempt in attempts) {
+                VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, $"{attempt.StrategyType.Name} Failed: {failureReason}");
+            }
+        }
+
+        [WindowsOnlyFact]
+        public async Task RegistryProcessor_ReadRegistrySettings_FirstStrategySuccessful() {
+            const uint minClientSecValue = 536870912;
+            
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .ReturnsAsync(
+                    new StrategyExecutorResult<RegistryQueryResult> {
+                        Results = [
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", null, null, false),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
+                        ],
+                        WasSuccessful = true,
+                    }
+                );
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Null(results.Result.ClientAllowedNTLMServers);
+            Assert.Equal(minClientSecValue, results.Result.NtlmMinClientSec);
+            
+            //Validate logs
+            _mockLogger.VerifyNoLogs(LogLevel.Trace);
+            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+        }
+
+        [WindowsOnlyFact]
+        public async Task RegistryProcessor_ReadRegistrySettings_SecondStrategySuccessful() {
+            const string failureReason = "No such host is known.";
+            const uint minClientSecValue = 536870912;
+            
+            var attempts = new List<StrategyResult<RegistryQueryResult>>
+            {
+                new(typeof(DotNetWmiRegistryStrategy))
+                {
+                    FailureReason = failureReason
+                }
+            };
+            
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .ReturnsAsync(
+                    new StrategyExecutorResult<RegistryQueryResult> {
+                        FailureAttempts = attempts,
+                        Results = [
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
+                        ],
+                        WasSuccessful = true
+                    }
+                );
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Equal(minClientSecValue, results.Result.NtlmMinClientSec);
+            
+            //Validate logs
+            VerifyFailureLog<DotNetWmiRegistryStrategy>(TargetName, failureReason);
+            Assert.Equal(2, _receivedCompStatuses.Count);
+            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, $"{attempts[0].StrategyType.Name} Failed: {failureReason}");
+            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+        }
+
+        [WindowsOnlyFact]
+        public async Task RegistryProcessor_ReadRegistrySettings_HandlesException() {
+            var exception = new Exception("test exception");
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .Throws(exception);
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+
+            //Validate result
+            Assert.False(results.Collected);
+            Assert.Equal(results.FailureReason, exception.ToString());
+            
+            //Validate logs
+            _mockLogger.VerifyLogContains(LogLevel.Error, $"Unhandled Registry Processor exception {TargetName}: {exception}");
+            Assert.Empty(_receivedCompStatuses);
+        }
+
+        [WindowsOnlyFact]
+        public async Task RegistryProcessor_ReadRegistrySettings_SetsAllValues() {
+            var allowedServers = new[] {"server"};
+            const uint keyValue = 1;
+            
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .ReturnsAsync(
+                    new StrategyExecutorResult<RegistryQueryResult> {
+                        Results = [
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", allowedServers, RegistryValueKind.MultiString, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinServerSec", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictSendingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictReceivingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "LMCompatibilityLevel", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "UseMachineId", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "RequireSecuritySignature", keyValue, RegistryValueKind.DWord, true),
+                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "EnableSecuritySignature", keyValue, RegistryValueKind.DWord, true),
+                        ],
+                        WasSuccessful = true,
+                    }
+                );
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+        
+            //Validate result
+            Assert.True(results.Collected);
+            Assert.Equal(allowedServers, results.Result.ClientAllowedNTLMServers);
+            Assert.Equal(keyValue, results.Result.NtlmMinClientSec);
+            Assert.Equal(keyValue, results.Result.NtlmMinServerSec);
+            Assert.Equal(keyValue, results.Result.RestrictSendingNtlmTraffic);
+            Assert.Equal(keyValue, results.Result.RestrictReceivingNtlmTraffic);
+            Assert.Equal(keyValue, results.Result.LmCompatibilityLevel);
+            Assert.Equal(keyValue, results.Result.UseMachineId);
+            Assert.Equal(keyValue, results.Result.RequireSecuritySignature);
+            Assert.Equal(keyValue, results.Result.EnableSecuritySignature);
+            
+            //Validate logs
+            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+        }
+
+        private void VerifyFailureLog<TStrategy>(string target, string reason) {
+            var expected = $"ReadRegistry failed on {target} using {typeof(TStrategy)}: {reason}"; 
+            _mockLogger.VerifyLogContains(LogLevel.Trace, expected);
+        }
+        
+        private void VerifyCompStatusLog(string task, string computerName, string status) {
+            Assert.Contains(_receivedCompStatuses, 
+                compStat => compStat.Task == task && 
+                          compStat.ComputerName == computerName &&
+                          compStat.Status == status );
+        }
+    }
+}

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -147,7 +147,7 @@ namespace CommonLibTest
             VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public async Task RegistryProcessor_ReadRegistrySettings_HandlesException() {
             var exception = new Exception("test exception");
             _mockStrategyExecutor.Setup(se => se.CollectAsync(

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -38,28 +38,25 @@ namespace CommonLibTest
         [Fact]
         public async Task RegistryProcessor_ReadRegistrySettings_CollectionFailed() {
             const string failureReason = "No such host is known.";
-            var attempts = new List<StrategyResult<RegistryQueryResult>>
-            {
-                new(typeof(DotNetWmiRegistryStrategy))
-                {
+            
+            var attempts = new List<StrategyResult<RegistryQueryResult>> {
+                new(typeof(DotNetWmiRegistryStrategy)) {
                     FailureReason = failureReason
                 },
-                new(typeof(RemoteRegistryStrategy))
-                {
+                new(typeof(RemoteRegistryStrategy)) {
                     FailureReason = failureReason
                 }
+            };
+            var executorResult = new StrategyExecutorResult<RegistryQueryResult> {
+                FailureAttempts = attempts,
+                WasSuccessful = false
             };
             
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
                     It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
-                .ReturnsAsync(
-                    new StrategyExecutorResult<RegistryQueryResult> {
-                        FailureAttempts = attempts,
-                        WasSuccessful = false
-                    }
-                );
+                .ReturnsAsync(executorResult);
             
             var results = await _registryProcessor.ReadRegistrySettings(TargetName);
 
@@ -81,19 +78,20 @@ namespace CommonLibTest
         public async Task RegistryProcessor_ReadRegistrySettings_FirstStrategySuccessful() {
             const uint minClientSecValue = 536870912;
             
+            var executorResult = new StrategyExecutorResult<RegistryQueryResult> {
+                Results = [
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", null, null, false),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
+                ],
+                WasSuccessful = true,
+                SuccessfulStrategy = typeof(DotNetWmiRegistryStrategy)
+            };
+            
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
                     It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
-                .ReturnsAsync(
-                    new StrategyExecutorResult<RegistryQueryResult> {
-                        Results = [
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", null, null, false),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
-                        ],
-                        WasSuccessful = true,
-                    }
-                );
+                .ReturnsAsync(executorResult);
             
             var results = await _registryProcessor.ReadRegistrySettings(TargetName);
         
@@ -113,27 +111,25 @@ namespace CommonLibTest
             const string failureReason = "No such host is known.";
             const uint minClientSecValue = 536870912;
             
-            var attempts = new List<StrategyResult<RegistryQueryResult>>
-            {
-                new(typeof(DotNetWmiRegistryStrategy))
-                {
+            var attempts = new List<StrategyResult<RegistryQueryResult>> {
+                new(typeof(DotNetWmiRegistryStrategy)) {
                     FailureReason = failureReason
                 }
+            };
+            var executorResult = new StrategyExecutorResult<RegistryQueryResult> {
+                FailureAttempts = attempts,
+                Results = [
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
+                ],
+                WasSuccessful = true,
+                SuccessfulStrategy = typeof(RemoteRegistryStrategy)
             };
             
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
                     It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
-                .ReturnsAsync(
-                    new StrategyExecutorResult<RegistryQueryResult> {
-                        FailureAttempts = attempts,
-                        Results = [
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", minClientSecValue, RegistryValueKind.DWord, true)
-                        ],
-                        WasSuccessful = true
-                    }
-                );
+                .ReturnsAsync(executorResult);
             
             var results = await _registryProcessor.ReadRegistrySettings(TargetName);
 
@@ -152,6 +148,7 @@ namespace CommonLibTest
         [Fact]
         public async Task RegistryProcessor_ReadRegistrySettings_HandlesException() {
             var exception = new Exception("test exception");
+            
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
@@ -162,7 +159,7 @@ namespace CommonLibTest
 
             //Validate result
             Assert.False(results.Collected);
-            Assert.Equal(results.FailureReason, exception.ToString());
+            Assert.Equal(exception.ToString(), results.FailureReason);
             
             //Validate logs
             _mockLogger.VerifyLogContains(LogLevel.Error, $"Unhandled Registry Processor exception {TargetName}: {exception}");
@@ -173,27 +170,28 @@ namespace CommonLibTest
         public async Task RegistryProcessor_ReadRegistrySettings_SetsAllValues() {
             var allowedServers = new[] {"server"};
             const uint keyValue = 1;
+
+            var executorResult = new StrategyExecutorResult<RegistryQueryResult> {
+                Results = [
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", allowedServers, RegistryValueKind.MultiString, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinServerSec", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictSendingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictReceivingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "LMCompatibilityLevel", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "UseMachineId", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "RequireSecuritySignature", keyValue, RegistryValueKind.DWord, true),
+                    new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "EnableSecuritySignature", keyValue, RegistryValueKind.DWord, true),
+                ],
+                WasSuccessful = true,
+                SuccessfulStrategy = typeof(DotNetWmiRegistryStrategy)
+            };
             
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
                     It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
-                .ReturnsAsync(
-                    new StrategyExecutorResult<RegistryQueryResult> {
-                        Results = [
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "ClientAllowedNTLMServers", allowedServers, RegistryValueKind.MultiString, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinClientSec", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "NtlmMinServerSec", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictSendingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\MSV1_0", "RestrictReceivingNTLMTraffic", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "LMCompatibilityLevel", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Control\Lsa\", "UseMachineId", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "RequireSecuritySignature", keyValue, RegistryValueKind.DWord, true),
-                            new RegistryQueryResult(@"SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters", "EnableSecuritySignature", keyValue, RegistryValueKind.DWord, true),
-                        ],
-                        WasSuccessful = true,
-                    }
-                );
+                .ReturnsAsync(executorResult);
             
             var results = await _registryProcessor.ReadRegistrySettings(TargetName);
         
@@ -216,15 +214,15 @@ namespace CommonLibTest
         
         [Fact]
         public async Task RegistryProcessor_ReadRegistrySettings_HandlesFailureWithNoAttempts() {
+            var executorResult = new StrategyExecutorResult<RegistryQueryResult> {
+                WasSuccessful = false
+            };
+            
             _mockStrategyExecutor.Setup(se => se.CollectAsync(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<RegistryQuery>>(),
                     It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
-                .ReturnsAsync(
-                    new StrategyExecutorResult<RegistryQueryResult> {
-                        WasSuccessful = false
-                    }
-                );
+                .ReturnsAsync(executorResult);
             
             var results = await _registryProcessor.ReadRegistrySettings(TargetName);
 

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -104,7 +104,8 @@ namespace CommonLibTest
             
             //Validate logs
             _mockLogger.VerifyNoLogs(LogLevel.Trace);
-            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+            const string task = $"{nameof(_registryProcessor.ReadRegistrySettings)} - {nameof(DotNetWmiRegistryStrategy)}";
+            VerifyCompStatusLog(task, TargetName, CSVComputerStatus.StatusSuccess);
         }
 
         [WindowsOnlyFact]
@@ -144,7 +145,8 @@ namespace CommonLibTest
             VerifyFailureLog<DotNetWmiRegistryStrategy>(TargetName, failureReason);
             Assert.Equal(2, _receivedCompStatuses.Count);
             VerifyCompStatusLog($"{nameof(_registryProcessor.ReadRegistrySettings)} - {attempts[0].StrategyType.Name}", TargetName, failureReason);
-            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+            const string task = $"{nameof(_registryProcessor.ReadRegistrySettings)} - {nameof(RemoteRegistryStrategy)}";
+            VerifyCompStatusLog(task, TargetName, CSVComputerStatus.StatusSuccess);
         }
 
         [Fact]
@@ -208,7 +210,8 @@ namespace CommonLibTest
             Assert.Equal(keyValue, results.Result.EnableSecuritySignature);
             
             //Validate logs
-            VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
+            const string task = $"{nameof(_registryProcessor.ReadRegistrySettings)} - {nameof(DotNetWmiRegistryStrategy)}";
+            VerifyCompStatusLog(task, TargetName, CSVComputerStatus.StatusSuccess);
         }
         
         [Fact]

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -238,7 +238,7 @@ namespace CommonLibTest
         }
 
         private void VerifyFailureLog<TStrategy>(string target, string reason) {
-            var expected = $"ReadRegistry failed on {target} using {typeof(TStrategy)}: {reason}"; 
+            var expected = $"ReadRegistry failed on {target} using {typeof(TStrategy).Name}: {reason}"; 
             _mockLogger.VerifyLogContains(LogLevel.Trace, expected);
         }
         

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -210,6 +210,29 @@ namespace CommonLibTest
             //Validate logs
             VerifyCompStatusLog(nameof(_registryProcessor.ReadRegistrySettings), TargetName, CSVComputerStatus.StatusSuccess);
         }
+        
+        [Fact]
+        public async Task RegistryProcessor_ReadRegistrySettings_HandlesFailureWithNoAttempts() {
+            _mockStrategyExecutor.Setup(se => se.CollectAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IEnumerable<RegistryQuery>>(),
+                    It.IsAny<IEnumerable<ICollectionStrategy<RegistryQueryResult, RegistryQuery>>>()))
+                .ReturnsAsync(
+                    new StrategyExecutorResult<RegistryQueryResult> {
+                        WasSuccessful = false
+                    }
+                );
+            
+            var results = await _registryProcessor.ReadRegistrySettings(TargetName);
+
+            //Validate result
+            Assert.False(results.Collected);
+            Assert.Equal("Failed to read registry settings", results.FailureReason);
+            
+            //Validate logs
+            _mockLogger.VerifyNoLogs(LogLevel.Trace);
+            Assert.Empty(_receivedCompStatuses);
+        }
 
         private void VerifyFailureLog<TStrategy>(string target, string reason) {
             var expected = $"ReadRegistry failed on {target} using {typeof(TStrategy)}: {reason}"; 


### PR DESCRIPTION
## Description

Add CompStatus Logging To Registry Processor
RunLog on Collection Failure
RegistryProcessor Unit Tests

## Motivation and Context

[BED-7374](https://specterops.atlassian.net/browse/BED-7374)

## How Has This Been Tested?

Unit Tests Pass

Validated in lab that:
Comp Status Logs on Success
<img width="771" height="58" alt="image" src="https://github.com/user-attachments/assets/4eba25e3-abc8-49d5-9a80-ca8d0fc76d08" />

RunLog and CompStatus Log on Failure
<img width="1410" height="70" alt="image" src="https://github.com/user-attachments/assets/ac9dd828-fdc7-4d4e-9503-ca8f047e73fc" />
<img width="1408" height="59" alt="image" src="https://github.com/user-attachments/assets/6487f03e-349e-41bd-ace3-8955bee16766" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-7374]: https://specterops.atlassian.net/browse/BED-7374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added status event reporting for registry operations
  * Exposes which collection strategy succeeded
  * Immediate status reporting when port-scan is skipped

* **Bug Fixes**
  * Improved input validation for registry operations
  * Enhanced error messages to include inner-exception details

* **Tests**
  * Added comprehensive test suites for registry and strategy behavior

* **Chores**
  * Cleaned up unused imports and added test infrastructure and helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->