### PR TITLE
Resolve build warnings BED-7491

### DIFF
--- a/src/CommonLib/Logging/Logging.cs
+++ b/src/CommonLib/Logging/Logging.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
 namespace SharpHoundCommonLib

--- a/src/CommonLib/Ntlm/LdapTransport.cs
+++ b/src/CommonLib/Ntlm/LdapTransport.cs
@@ -1,4 +1,5 @@
-﻿
+﻿#nullable enable
+
 using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
 using System;
@@ -86,3 +87,5 @@ public class LdapTransport(ILogger logger, Uri ldapEndpoint) : INtlmTransport, I
         }
     }
 }
+
+#nullable disable

--- a/src/CommonLib/Processors/DCLdapProcessor.cs
+++ b/src/CommonLib/Processors/DCLdapProcessor.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+﻿#nullable enable
+
+using Microsoft.Extensions.Logging;
 using SharpHoundCommonLib.Enums;
 using SharpHoundCommonLib.Ntlm;
 using SharpHoundCommonLib.OutputTypes;
@@ -33,7 +35,7 @@ public class DCLdapProcessor {
     private readonly string SEC_E_BAD_BINDINGS = "80090346";
 
 
-    public DCLdapProcessor(int connectionTimeoutMs, string dcHostname, ILogger log = null) {
+    public DCLdapProcessor(int connectionTimeoutMs, string dcHostname, ILogger? log = null) {
         _log = log ?? Logging.LogProvider.CreateLogger("DCLdapProcessor");
         _scanner = new PortScanner(maxTimeout: connectionTimeoutMs);
         _ldapTimeout = connectionTimeoutMs / 1000;
@@ -43,7 +45,7 @@ public class DCLdapProcessor {
         _checkIsChannelBindingDisabledAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(1), Logging.LogProvider.CreateLogger(nameof(CheckIsChannelBindingDisabled)));
     }
     
-    public event ComputerStatusDelegate ComputerStatusEvent;
+    public event ComputerStatusDelegate? ComputerStatusEvent;
 
     public async Task<LdapService> Scan(string computerName, string computerObjectId) {
         var hasLdap = await TestLdapPort();
@@ -173,7 +175,7 @@ public class DCLdapProcessor {
     /// <param name="endpoint"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options, NtlmAuthenticationHandler ntlmAuth = null, LdapTransport ldapTransport = null, CancellationToken cancellationToken = default) {
+    protected internal virtual async Task<bool> Authenticate(Uri endpoint, LdapAuthOptions options, NtlmAuthenticationHandler? ntlmAuth = null, LdapTransport? ldapTransport = null, CancellationToken cancellationToken = default) {
         var host = endpoint.Host;
         var auth = ntlmAuth ?? new NtlmAuthenticationHandler($"LDAP/{host.ToUpper()}") {
             Options = options
@@ -230,3 +232,5 @@ public class DCLdapProcessor {
         if (ComputerStatusEvent is not null) await ComputerStatusEvent.Invoke(status);
     }
 }
+
+#nullable disable

--- a/src/CommonLib/SMB/NetBIOS/NetBIOSSessionType.cs
+++ b/src/CommonLib/SMB/NetBIOS/NetBIOSSessionType.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable  enable
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -127,3 +129,5 @@ namespace SharpHoundCommonLib.SMB.NetBIOS
             !(left == right);
     }
 }
+
+#nullable disable

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -18,7 +18,7 @@
         <DebugType>full</DebugType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AntiXSS" Version="4.3.0" />
+        <PackageReference Include="AntiXSS" Version="4.3.0" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/test/unit/ACLProcessorTest.cs
+++ b/test/unit/ACLProcessorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.DirectoryServices;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using System.Threading;
 using System.Threading.Tasks;
@@ -60,6 +61,7 @@ namespace CommonLibTest {
             Assert.False(result);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task ACLProcessor_TestKnownDataAddMember() {
             var mockLdapUtils = new MockLdapUtils();
@@ -1421,6 +1423,7 @@ namespace CommonLibTest {
             Assert.False(result);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void ACLProcessor_CalculateImplicitACLHash_ValidInput_ReturnsCorrectHash()
         {
@@ -1439,6 +1442,7 @@ namespace CommonLibTest {
             Assert.Equal(expectedHash, result);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void ACLProcessor_CalculateImplicitACLHash_DifferentInputs_ProducesUniqueHashes()
         {
@@ -1458,6 +1462,7 @@ namespace CommonLibTest {
             Assert.NotEqual(protectedResult, adminsdResult);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void ACLProcessor_NullAdminSDHolderHash_Returns_Null_Bool()
         {
@@ -1476,6 +1481,7 @@ namespace CommonLibTest {
         }
 
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void ACLProcessor_AdminSDHolderHash_Returns_Match()
         {

--- a/test/unit/AsyncEnumerableTests.cs
+++ b/test/unit/AsyncEnumerableTests.cs
@@ -76,6 +76,7 @@ public class AsyncEnumerableTests {
         Assert.Equal("d", test);
     }
 
+#pragma warning disable CS1998 //Async method lacks 'await' operators and will run synchronously, must be `async` to return IAsyncEnumerable
     private async IAsyncEnumerable<string> TestFunc() {
         var collection = new[] {
             "a", "b", "c"
@@ -85,8 +86,9 @@ public class AsyncEnumerableTests {
             yield return i;
         }
     }
-    
+
     private async IAsyncEnumerable<string> EmptyFunc() {
         yield break;
     }
+#pragma warning restore CS1998
 }

--- a/test/unit/CertAbuseProcessorTest.cs
+++ b/test/unit/CertAbuseProcessorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using System.Security.Principal;
 using System.Threading;
@@ -226,6 +227,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
+        [SupportedOSPlatform("windows")]
         public static IEnumerable<object[]> ProcessEAPermissionsTestData() {
             return new List<object[]>
             {
@@ -234,6 +236,7 @@ namespace CommonLibTest
             };
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyTheory]
         [MemberData(nameof(ProcessEAPermissionsTestData))]
         public async Task CertAbuseProcessor_ProcessEAPermissions_ReturnsEmpty(RawAcl dacl) {
@@ -335,6 +338,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_ProcessRegistryEnrollmentPermissions_ReturnsEmpty_WhenNoOwnerAndNoRules() {
             var mockSecurityDescriptor = new Mock<ActiveDirectorySecurityDescriptor>(null);
@@ -405,6 +409,7 @@ namespace CommonLibTest
             Assert.Contains(invalidCN, results.unresolvedTemplates);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetRegistryPrincipal_ReturnsFalseForFilteredSID() {
             var sid = new SecurityIdentifier("S-1-5-3");
@@ -422,6 +427,7 @@ namespace CommonLibTest
             _mockLdapUtils.VerifyNoOtherCalls();
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetRegistryPrincipal_CallsResolveIDAndType_ForDomainController() {
             var expectedPrincipalType = Label.Group;
@@ -450,6 +456,7 @@ namespace CommonLibTest
             _mockLdapUtils.VerifyNoOtherCalls();
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetRegistryPrincipal_CallsConvertLocalWellKnownPrincipal_ForNonDomainController() {
             var expectedPrincipalType = Label.Group;
@@ -477,6 +484,7 @@ namespace CommonLibTest
             _mockLdapUtils.VerifyNoOtherCalls();
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvesToLocalPrincipal_ForLocalSID() {
             var expectedPrincipalType = Label.LocalGroup;
@@ -504,6 +512,7 @@ namespace CommonLibTest
             _mockLdapUtils.VerifyNoOtherCalls();
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetRegistryPrincipal_ResolvesToDomainPrincipal() {
             var expectedPrincipalType = Label.Group;
@@ -558,6 +567,7 @@ namespace CommonLibTest
             Assert.IsType<SAMServer>(result.Value);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetMachineSid_ReturnsCachedValue() {
             Cache.AddMachineSid(TargetDomainSid, TargetDomainSid);
@@ -586,6 +596,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetMachineSid_GetMachineSidFailure_ReturnsNull() {
             var mockSamServer = new Mock<ISAMServer>();
@@ -608,6 +619,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_GetMachineSid_ReturnsSid() {
             var mockSamServer = new Mock<ISAMServer>();
@@ -629,6 +641,7 @@ namespace CommonLibTest
             Assert.Equal(TargetDomainSid, _receivedCompStatus.ObjectId);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_NullOpaque_ReturnsFalse() {
             var nullOpaqueAce = new CommonAce(
@@ -649,6 +662,7 @@ namespace CommonLibTest
             _mockLdapUtils.VerifyNoOtherCalls();
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_UnresolvedTemplate_ReturnsFalse() {
             var emptyOpaqueAce = new CommonAce(
@@ -676,6 +690,7 @@ namespace CommonLibTest
             Assert.Null(result.restriction);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_NoTemplate_ReturnsAllTemplates() {
             var emptyOpaqueAce = new CommonAce(
@@ -709,6 +724,7 @@ namespace CommonLibTest
             Assert.Contains(result.restriction.Targets, t => t.ObjectIdentifier == "S-1-3");
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_WithCanonicalName_ReturnsTemplate() {
             var expectedPrincipalType = Label.CertTemplate;
@@ -742,6 +758,7 @@ namespace CommonLibTest
                 Times.Once);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task CertAbuseProcessor_CreateEnrollmentAgentRestriction_WithCertTemplateOID_ReturnsTemplate() {
             var expectedPrincipalType = Label.CertTemplate;

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -312,15 +312,6 @@ namespace CommonLibTest {
 
             // Assert
             Assert.Equal(expectedHexSid, actual);
-            return;
-
-            static string BuildExpectedHexSid(string sid)
-            {
-                var securityIdentifier = new SecurityIdentifier(sid);
-                var sidBytes = new byte[securityIdentifier.BinaryLength];
-                securityIdentifier.GetBinaryForm(sidBytes, 0);
-                return $"\\{BitConverter.ToString(sidBytes).Replace('-', '\\')}";
-            }
         }
 
         [SupportedOSPlatform("windows")]

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Security.Principal;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
 using SharpHoundCommonLib;
@@ -302,6 +302,7 @@ namespace CommonLibTest {
             Assert.Equal("DC=test,DC=local", result);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyTheory]
         [InlineData("S-1-5-32-544", "\\01\\02\\00\\00\\00\\00\\00\\05\\20\\00\\00\\00\\20\\02\\00\\00")]
         public void ConvertSidToHexSid_ValidSid_MatchesSecurityIdentifierBinaryForm(string sid, string expectedHexSid)
@@ -322,6 +323,7 @@ namespace CommonLibTest {
             }
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void ConvertSidToHexSid_InvalidSid_Throws()
         {

--- a/test/unit/CommonLibTest.csproj
+++ b/test/unit/CommonLibTest.csproj
@@ -6,6 +6,8 @@
         <CollectCoverage>true</CollectCoverage>
         <CoverletOutput>..\..\docfx\coverage\</CoverletOutput>
         <CoverletOutputFormat>OpenCover</CoverletOutputFormat>
+        //Suppress cross-targeting warning when referencing net472 SharpHound projects in net8.0 tests
+        <NoWarn>$(NoWarn);NU1702</NoWarn> 
     </PropertyGroup>
 
     <!-- Project references -->

--- a/test/unit/CommonLibTest.csproj
+++ b/test/unit/CommonLibTest.csproj
@@ -6,7 +6,7 @@
         <CollectCoverage>true</CollectCoverage>
         <CoverletOutput>..\..\docfx\coverage\</CoverletOutput>
         <CoverletOutputFormat>OpenCover</CoverletOutputFormat>
-        //Suppress cross-targeting warning when referencing net472 SharpHound projects in net8.0 tests
+        <!-- Suppress cross-targeting warning when referencing net472 SharpHound projects in net8.0 tests -->
         <NoWarn>$(NoWarn);NU1702</NoWarn> 
     </PropertyGroup>
 

--- a/test/unit/DCLdapProcessorTest.cs
+++ b/test/unit/DCLdapProcessorTest.cs
@@ -138,7 +138,6 @@ namespace CommonLibTest {
 
         [Fact]
         public async Task DCLdapProcessor_Authenticate_InvalidCredentialsException_SEC_E_UNSUPPORTED_FUNCTION() {
-            var exception = "ErrorTest";
             var endpoint = "http://primary.testlab.local/";
             var expected = $"LDAP endpoint '{endpoint}' does not support NTLM";
 
@@ -153,7 +152,6 @@ namespace CommonLibTest {
 
         [Fact]
         public async Task DCLdapProcessor_Authenticate_InvalidCredentialsException_SEC_E_BAD_BINDINGS() {
-            var exception = "ErrorTest";
             var endpoint = "http://primary.testlab.local/";
             var expected = $"Bad bindings with the LDAPS endpoint '{endpoint}'. Server error: {SEC_E_BAD_BINDINGS}";
 

--- a/test/unit/DomainTrustProcessorTest.cs
+++ b/test/unit/DomainTrustProcessorTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
@@ -23,6 +24,7 @@ namespace CommonLibTest
             _testOutputHelper = testOutputHelper;
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task DomainTrustProcessor_EnumerateDomainTrusts_HappyPath()
         {

--- a/test/unit/Facades/FacadeHelpers.cs
+++ b/test/unit/Facades/FacadeHelpers.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 
 namespace CommonLibTest.Facades
 {
@@ -9,8 +9,8 @@ namespace CommonLibTest.Facades
         private const BindingFlags publicInstance = BindingFlags.Public | BindingFlags.Instance;
 
         internal static T GetUninitializedObject<T>()
-        {
-            return (T) FormatterServices.GetUninitializedObject(typeof(T));
+        { 
+            return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
         }
 
         internal static void SetField<T1, T2>(T1 obj, string propertyName, T2 propertyValue)

--- a/test/unit/Facades/MockExtensions.cs
+++ b/test/unit/Facades/MockExtensions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -5,7 +7,7 @@ using Moq;
 
 namespace CommonLibTest.Facades;
 
-public static class MockExtentions
+public static class MockExtensions
 {
     public static void VerifyLogContains<T>(this Mock<ILogger<T>> mockLogger, LogLevel logLevel, params string[] expected)
     {
@@ -13,8 +15,9 @@ public static class MockExtentions
             x => x.Log(
                 logLevel,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((o, t) =>
-                    expected.All(s => o.ToString().Contains(s, StringComparison.OrdinalIgnoreCase))),
+                It.Is<It.IsAnyType>((o, t) => 
+                    o != null &&
+                    expected.All(s => o.ToString()!.Contains(s, StringComparison.OrdinalIgnoreCase))),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
@@ -33,3 +36,5 @@ public static class MockExtentions
             Times.Once);
     }
 }
+
+#nullable disable

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.DirectoryServices.Protocols;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
@@ -295,6 +296,7 @@ namespace CommonLibTest {
             Assert.Empty(act3.LocalAdmins);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task GPOLocalGroupProcessor_ReadGPOLocalGroups() {
             var mockLDAPUtils = new Mock<ILdapUtils>(MockBehavior.Loose);

--- a/test/unit/GroupProcessorTest.cs
+++ b/test/unit/GroupProcessorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
@@ -53,6 +54,7 @@ namespace CommonLibTest
             Assert.Null(result);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void GroupProcessor_GetPrimaryGroupInfo_ReturnsCorrectSID()
         {
@@ -104,6 +106,7 @@ namespace CommonLibTest
             Assert.Equal(expected, results);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task GroupProcessor_ReadGroupMembers_ReturnsCorrectMembers()
         {

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.DirectoryServices.ActiveDirectory;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using Moq;
@@ -258,6 +259,7 @@ namespace CommonLibTest {
             Assert.False(success);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task EnterpriseDomainControllersGroup_CorrectValues() {
             var utilsMock = new Mock<LdapUtils>();

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1358,7 +1358,7 @@ namespace CommonLibTest
             Assert.Contains("rdpman/win10", atd);
 
             var atdr = test.AllowedToDelegate;
-            Assert.Equal(1, atdr.Length);
+            Assert.Single(atdr);
             var expected = new TypedPrincipal[]
             {
                 new()

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -232,7 +232,11 @@ namespace CommonLibTest
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var receivedStatus = new List<CSVComputerStatus>();
-            processor.ComputerStatusEvent += async status => { receivedStatus.Add(status); };
+            processor.ComputerStatusEvent += status =>
+            { 
+                receivedStatus.Add(status); 
+                return Task.CompletedTask;
+            };
             var test = await processor.ReadUserProperties(mock, "testlab.local");
             var props = test.Props;
             var keys = props.Keys;
@@ -477,7 +481,11 @@ namespace CommonLibTest
 
             var processor = new LdapPropertyProcessor(new MockLdapUtils());
             var receivedStatus = new List<CSVComputerStatus>();
-            processor.ComputerStatusEvent += async status => { receivedStatus.Add(status); };
+            processor.ComputerStatusEvent += status =>
+            {
+                receivedStatus.Add(status);
+                return Task.CompletedTask;
+            };
             var test = await processor.ReadComputerProperties(mock, "testlab.local");
             var props = test.Props;
             var keys = props.Keys;

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
@@ -174,6 +175,7 @@ namespace CommonLibTest
             Assert.False((bool)test["admincount"]);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LDAPPropertyProcessor_ReadGroupProperties_Returns_HasSIDHistory()
         {
@@ -300,6 +302,7 @@ namespace CommonLibTest
             Assert.False((bool)props["admincount"]);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LDAPPropertyProcessor_ReadUserProperties_HappyPath()
         {
@@ -427,6 +430,7 @@ namespace CommonLibTest
             Assert.DoesNotContain("trustedtoauth", keys);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LDAPPropertyProcessor_ReadComputerProperties_HappyPath()
         {
@@ -999,6 +1003,7 @@ namespace CommonLibTest
             Assert.Equal("\u0000", UTF8.GetString(usercert as byte[]));
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public void LDAPPropertyProcessor_ParseAllProperties_CollectionCountOne_SID() {
             var creatorSIDExpected = "S-1-5-21-2697957641-2271029196-387917394";
@@ -1364,6 +1369,8 @@ namespace CommonLibTest
             };
             Assert.Equal(expected, atdr);
         }
+        
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LDAPPropertyProcessor_ReadComputerProperties_TestDelegatesNull()
         {
@@ -1428,6 +1435,7 @@ namespace CommonLibTest
             Assert.Equal("A6F75BA4-F1AE-4B47-A606-E3A0A69AEC83", props["objectguid"]);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LDAPPropertyProcessor_ReadComputerProperties_AllowedToActOnBehalfOfOtherIdentity()
         {

--- a/test/unit/LocalGroupProcessorTest.cs
+++ b/test/unit/LocalGroupProcessorTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using Moq;
@@ -25,6 +26,7 @@ namespace CommonLibTest {
         public void Dispose() {
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_TestWorkstation() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -53,6 +55,7 @@ namespace CommonLibTest {
                 });
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_TestDomainController() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -201,6 +204,7 @@ namespace CommonLibTest {
             Assert.Equal("GetMachineSid", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_GetDomainsResultFailed() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -222,6 +226,7 @@ namespace CommonLibTest {
             Assert.Equal("GetDomains", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_OpenDomainResultFailed() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -243,6 +248,7 @@ namespace CommonLibTest {
             Assert.Equal("OpenDomain - BUILTIN", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_GetAliasesFailed() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -264,6 +270,7 @@ namespace CommonLibTest {
             Assert.Equal("GetAliases - BUILTIN", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_OpenAliasFailed() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -287,6 +294,7 @@ namespace CommonLibTest {
             Assert.Equal("OpenAlias - Administrators", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_GetMembersFailed() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -310,6 +318,7 @@ namespace CommonLibTest {
             Assert.Equal("GetMembersInAlias - Users", status.Task);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_LookupPrincipalBySid() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);
@@ -339,6 +348,7 @@ namespace CommonLibTest {
                 });
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task LocalGroupProcessor_GetLocalGroups_PreviouslyCached() {
             var mockProcessor = new Mock<LocalGroupProcessor>(new MockLdapUtils(), null);

--- a/test/unit/SPNProcessorsTest.cs
+++ b/test/unit/SPNProcessorsTest.cs
@@ -112,7 +112,11 @@ namespace CommonLibTest
             string[] servicePrincipalNames = {"MSSQLSvc/PRIMARY.TESTLAB.LOCAL:2345"};
             const string distinguishedName = "cn=policies,cn=system,DC=testlab,DC=local";
             var receivedStatus = new List<CSVComputerStatus>();
-            processor.ComputerStatusEvent += async status => { receivedStatus.Add(status); };
+            processor.ComputerStatusEvent += status => 
+            {
+                receivedStatus.Add(status); 
+                return Task.CompletedTask;
+            };
 
             var expected = new SPNPrivilege
             {

--- a/test/unit/UserRightsAssignmentProcessorTest.cs
+++ b/test/unit/UserRightsAssignmentProcessorTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading;
 using System.Threading.Tasks;
 using CommonLibTest.CollectionDefinitions;
@@ -31,6 +32,7 @@ namespace CommonLibTest
             Cache.SetCacheInstance(null);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task UserRightsAssignmentProcessor_TestWorkstation()
         {
@@ -53,6 +55,7 @@ namespace CommonLibTest
             Assert.Equal(Label.LocalGroup, rdpResult.ObjectType);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task UserRightsAssignmentProcessor_TestDC()
         {
@@ -96,6 +99,7 @@ namespace CommonLibTest
         //     Assert.Equal("Timeout", status.Status);
         // }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task UserRightsAssignmentProcessor_TestGetLocalDomainInformationFail()
         {
@@ -122,6 +126,7 @@ namespace CommonLibTest
             Assert.Equal("LSAGetMachineSID", status.Task);
         }
         
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task UserRightsAssignmentProcessor_TestGetResolvedPrincipalsWithPrivilegeFail()
         {

--- a/test/unit/UserRightsAssignmentProcessorTest.cs
+++ b/test/unit/UserRightsAssignmentProcessorTest.cs
@@ -113,8 +113,9 @@ namespace CommonLibTest
             var processor = mockProcessor.Object;
             var machineDomainSid = $"{Consts.MockDomainSid}-1001";
             var receivedStatus = new List<CSVComputerStatus>();
-            processor.ComputerStatusEvent += async status =>  {
+            processor.ComputerStatusEvent += status => {
                 receivedStatus.Add(status);
+                return Task.CompletedTask;
             };
             var results = await processor.GetUserRightsAssignments("win10.testlab.local", machineDomainSid, "testlab.local", false)
                 .ToArrayAsync();
@@ -136,8 +137,9 @@ namespace CommonLibTest
             var processor = mockProcessor.Object;
             var machineDomainSid = $"{Consts.MockDomainSid}-1001";
             var receivedStatus = new List<CSVComputerStatus>();
-            processor.ComputerStatusEvent += async status =>  {
+            processor.ComputerStatusEvent += status => {
                 receivedStatus.Add(status);
+                return Task.CompletedTask;
             };
             var results = await processor.GetUserRightsAssignments("win10.testlab.local", machineDomainSid, "testlab.local", false)
                 .ToArrayAsync();

--- a/test/unit/WebClientServiceProcessorTest.cs
+++ b/test/unit/WebClientServiceProcessorTest.cs
@@ -26,7 +26,7 @@ namespace CommonLibTest {
         public void Dispose() {
         }
     
-        [WindowsOnlyFact]
+        [Fact]
         public async Task WebClientServiceProcessorTest_TestPathExists()
         {
             var processor = new WebClientServiceProcessor();


### PR DESCRIPTION
## Description

Resolve compile time warnings for clean build output.

## Motivation and Context

[BED-7491](https://specterops.atlassian.net/browse/BED-7491)

## How Has This Been Tested?

Ran `dotnet build` succeeded with no errors/warnings
<img width="870" height="193" alt="image" src="https://github.com/user-attachments/assets/fd58aa8c-834a-4c17-a39a-5a20dcf817b6" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-7491]: https://specterops.atlassian.net/browse/BED-7491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed null-check in test mock utilities to prevent null reference issues.
  * Removed unused test variables.

* **Tests**
  * Added Windows platform restrictions to many Windows-specific tests for clearer gating.
  * Converted one previously Windows-only test to run on all platforms.

* **Refactoring**
  * Enabled nullable reference annotations across multiple modules to improve code safety.
  * Adjusted test lambdas for clearer async/task semantics.

* **Chores**
  * Updated package packaging metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->