### PR TITLE
Collect AIACAs with empty CACert BED-7513

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -472,7 +472,7 @@ namespace SharpHoundCommonLib.Processors {
             var props = GetCommonProps(entry);
 
             // Certificate
-            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate)) {
+            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate) && HasBytes(rawCertificate)) {
                 var cert = new ParsedCertificate(rawCertificate);
                 props.Add("certthumbprint", cert.Thumbprint);
                 props.Add("certname", cert.Name);
@@ -509,12 +509,12 @@ namespace SharpHoundCommonLib.Processors {
 
             return props;
         }
-        
-        private static bool HasBytes(byte[] data) {
-            return data.Length > 0
-                   && !(data.Length == 1 && data[0] == 0x00);
-        }
 
+        /// <summary>
+        /// Returns the properties associated with the EnterpriseCA
+        /// </summary>
+        /// <param name="entry"></param>
+        /// <returns>Returns a dictionary with the common properties and the caname, hostname, and flags properties of the EnterpriseCA</returns>
         public static Dictionary<string, object> ReadEnterpriseCAProperties(IDirectoryObject entry) {
             var props = GetCommonProps(entry);
             if (entry.TryGetLongProperty("flags", out var flags))
@@ -523,7 +523,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("dnshostname", entry.GetProperty(LDAPProperties.DNSHostName));
 
             // Certificate
-            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate)) {
+            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate) && HasBytes(rawCertificate)) {
                 var cert = new ParsedCertificate(rawCertificate);
                 props.Add("certthumbprint", cert.Thumbprint);
                 props.Add("certname", cert.Name);
@@ -936,6 +936,11 @@ namespace SharpHoundCommonLib.Processors {
             {
                 return "Unknown";
             }
+        }
+        
+        private static bool HasBytes(byte[] data) {
+            return data.Length > 0
+                   && !(data.Length == 1 && data[0] == 0x00);
         }
 
         [DllImport("Advapi32", SetLastError = false)]

--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -498,7 +498,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("hascrosscertificatepair", hasCrossCertificatePair);
 
             // Certificate
-            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate)) {
+            if (entry.TryGetByteProperty(LDAPProperties.CACertificate, out var rawCertificate) && HasBytes(rawCertificate)) {
                 var cert = new ParsedCertificate(rawCertificate);
                 props.Add("certthumbprint", cert.Thumbprint);
                 props.Add("certname", cert.Name);
@@ -508,6 +508,11 @@ namespace SharpHoundCommonLib.Processors {
             }
 
             return props;
+        }
+        
+        private static bool HasBytes(byte[] data) {
+            return data.Length > 0
+                   && !(data.Length == 1 && data[0] == 0x00);
         }
 
         public static Dictionary<string, object> ReadEnterpriseCAProperties(IDirectoryObject entry) {

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -667,12 +667,16 @@ namespace CommonLibTest
             Assert.Equal(2, testDumpSMSAPassword.Length);
             Assert.Equal(expected, testDumpSMSAPassword);
         }
-
+        
         [Fact]
-        public void LDAPPropertyProcessor_ReadRootCAProperties()
-        {
+        public void LDAPPropertyProcessor_ReadRootCAProperties() {
+            var ecdsa = ECDsa.Create();
+            var req = new CertificateRequest("cn=foobar", ecdsa, HashAlgorithmName.SHA256);
+            var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(5));
+
+            var bytes = cert.Export(X509ContentType.Cert, "abc");
             var mock = new MockDirectoryObject(
-                "CN\u003dDUMPSTER-DC01-CA,CN\u003dCERTIFICATION AUTHORITIES,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
                 new Dictionary<string, object>
                 {
                     {"description", null},
@@ -680,6 +684,7 @@ namespace CommonLibTest
                     {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
                     {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
                     {"whencreated", 1683986131},
+                    {LDAPProperties.CACertificate, bytes}
                 }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
 
             var test = LdapPropertyProcessor.ReadRootCAProperties(mock);
@@ -689,6 +694,40 @@ namespace CommonLibTest
             Assert.DoesNotContain("domain", keys);
             Assert.DoesNotContain("name", keys);
             Assert.DoesNotContain("domainsid", keys);
+
+            //CA Properties
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("certthumbprint", keys);
+            Assert.Contains("certname", keys);
+            Assert.Contains("certchain", keys);
+            Assert.Contains("hasbasicconstraints", keys);
+            Assert.Contains("basicconstraintpathlength", keys);
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyCertBytes))]
+        public void LDAPPropertyProcessor_ReadRootCAProperties_NoCACertificate(byte[] CACertBytes) {
+            var mock = new MockDirectoryObject(
+                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                    {LDAPProperties.CACertificate, CACertBytes}
+                }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
+
+            var test = LdapPropertyProcessor.ReadRootCAProperties(mock);
+            var keys = test.Keys;
+
+            //These are cert derived properties
+            Assert.DoesNotContain("certthumbprint", keys);
+            Assert.DoesNotContain("certname", keys);
+            Assert.DoesNotContain("certchain", keys);
+            Assert.DoesNotContain("hasbasicconstraints", keys);
+            Assert.DoesNotContain("basicconstraintpathlength", keys);
 
             Assert.Contains("whencreated", keys);
         }
@@ -721,13 +760,17 @@ namespace CommonLibTest
             Assert.DoesNotContain("name", keys);
             Assert.DoesNotContain("domainsid", keys);
 
+            //CA Properties
             Assert.Contains("whencreated", keys);
-            Assert.Contains("crosscertificatepair", keys);
             Assert.Contains("certthumbprint", keys);
             Assert.Contains("certname", keys);
             Assert.Contains("certchain", keys);
             Assert.Contains("hasbasicconstraints", keys);
-            Assert.Contains("basicconstraintpathlength", keys);
+            Assert.Contains("basicconstraintpathlength", keys);;
+            
+            //AIA CA Properties
+            Assert.Contains("crosscertificatepair", keys);
+            Assert.Contains("hascrosscertificatepair", keys);
         }
 
         [Theory]
@@ -759,6 +802,80 @@ namespace CommonLibTest
             Assert.Contains("whencreated", keys);
             Assert.Contains("crosscertificatepair", keys);
             Assert.Contains("hascrosscertificatepair", keys);
+        }
+        
+        [Fact]
+        public void LDAPPropertyProcessor_ReadEnterpriseCAProperties() {
+            var ecdsa = ECDsa.Create();
+            var req = new CertificateRequest("cn=foobar", ecdsa, HashAlgorithmName.SHA256);
+            var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(5));
+
+            var bytes = cert.Export(X509ContentType.Cert, "abc");
+            var mock = new MockDirectoryObject(
+                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                    {LDAPProperties.CACertificate, bytes},
+                    {"flags", 1}
+                }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
+
+            var test = LdapPropertyProcessor.ReadEnterpriseCAProperties(mock);
+            var keys = test.Keys;
+
+            //These are not common properties
+            Assert.DoesNotContain("domain", keys);
+            Assert.DoesNotContain("name", keys);
+            Assert.DoesNotContain("domainsid", keys);
+
+            //CA properties
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("certthumbprint", keys);
+            Assert.Contains("certname", keys);
+            Assert.Contains("certchain", keys);
+            Assert.Contains("hasbasicconstraints", keys);
+            Assert.Contains("basicconstraintpathlength", keys);
+            
+            //Enterprise CA Properties
+            Assert.Contains("flags", keys);
+            Assert.Contains("caname", keys);
+            Assert.Contains("dnshostname", keys);
+        }
+
+        [Theory]
+        [MemberData(nameof(EmptyCertBytes))]
+        public void LDAPPropertyProcessor_ReadEnterpriseCAProperties_NoCACertificate(byte[] CACertBytes) {
+            var mock = new MockDirectoryObject(
+                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                    {LDAPProperties.CACertificate, CACertBytes},
+                    {"flags", 1}
+                }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
+
+            var test = LdapPropertyProcessor.ReadEnterpriseCAProperties(mock);
+            var keys = test.Keys;
+
+            //These are cert derived properties
+            Assert.DoesNotContain("certthumbprint", keys);
+            Assert.DoesNotContain("certname", keys);
+            Assert.DoesNotContain("certchain", keys);
+            Assert.DoesNotContain("hasbasicconstraints", keys);
+            Assert.DoesNotContain("basicconstraintpathlength", keys);
+
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("flags", keys);
+            Assert.Contains("caname", keys);
+            Assert.Contains("dnshostname", keys);
         }
         
         public static IEnumerable<object[]> EmptyCertBytes =>
@@ -1072,41 +1189,6 @@ namespace CommonLibTest
             var hasGuid = props.TryGetValue("guid", out var guidActual);
             Assert.True(hasGuid);
             Assert.Equal(guidExpected.ToString(), guidActual);
-        }
-        
-        [Fact]
-        public void LDAPPropertyProcessor_ReadACAProperties() {
-            var ecdsa = ECDsa.Create();
-            var req = new CertificateRequest("cn=foobar", ecdsa, HashAlgorithmName.SHA256);
-            var cert = req.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(5));
-
-            var bytes = cert.Export(X509ContentType.Cert, "abc");
-            var mock = new MockDirectoryObject(
-                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
-                new Dictionary<string, object>
-                {
-                    {"description", null},
-                    {"domain", "DUMPSTER.FIRE"},
-                    {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
-                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
-                    {"whencreated", 1683986131},
-                    {LDAPProperties.CACertificate, bytes}
-                }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
-
-            var test = LdapPropertyProcessor.ReadRootCAProperties(mock);
-            var keys = test.Keys;
-
-            //These are not common properties
-            Assert.DoesNotContain("domain", keys);
-            Assert.DoesNotContain("name", keys);
-            Assert.DoesNotContain("domainsid", keys);
-
-            Assert.Contains("whencreated", keys);
-            Assert.Contains("certthumbprint", keys);
-            Assert.Contains("certname", keys);
-            Assert.Contains("certchain", keys);
-            Assert.Contains("hasbasicconstraints", keys);
-            Assert.Contains("basicconstraintpathlength", keys);
         }
 
         [Theory]

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -730,6 +730,45 @@ namespace CommonLibTest
             Assert.Contains("basicconstraintpathlength", keys);
         }
 
+        [Theory]
+        [MemberData(nameof(EmptyCertBytes))]
+        public void LDAPPropertyProcessor_ReadAIACAProperties_NoCACertificate(byte[] CACertBytes) {
+            var mock = new MockDirectoryObject(
+                "CN\u003dDUMPSTER-DC01-CA,CN\u003dAIA,CN\u003dPUBLIC KEY SERVICES,CN\u003dSERVICES,CN\u003dCONFIGURATION,DC\u003dDUMPSTER,DC\u003dFIRE",
+                new Dictionary<string, object>
+                {
+                    {"description", null},
+                    {"domain", "DUMPSTER.FIRE"},
+                    {"name", "DUMPSTER-DC01-CA@DUMPSTER.FIRE"},
+                    {"domainsid", "S-1-5-21-2697957641-2271029196-387917394"},
+                    {"whencreated", 1683986131},
+                    {"hascrosscertificatepair", true},
+                    {LDAPProperties.CACertificate, CACertBytes}
+                }, "","2F9F3630-F46A-49BF-B186-6629994EBCF9");
+
+            var test = LdapPropertyProcessor.ReadAIACAProperties(mock);
+            var keys = test.Keys;
+
+            //These are cert derived properties
+            Assert.DoesNotContain("certthumbprint", keys);
+            Assert.DoesNotContain("certname", keys);
+            Assert.DoesNotContain("certchain", keys);
+            Assert.DoesNotContain("hasbasicconstraints", keys);
+            Assert.DoesNotContain("basicconstraintpathlength", keys);
+
+            Assert.Contains("whencreated", keys);
+            Assert.Contains("crosscertificatepair", keys);
+            Assert.Contains("hascrosscertificatepair", keys);
+        }
+        
+        public static IEnumerable<object[]> EmptyCertBytes =>
+            new List<object[]>
+            {
+                new object[] { null },
+                new object[] { Array.Empty<byte>() },
+                new object[] { new byte[] { 0x00 } }
+            };
+
         [Fact]
         public void LDAPPropertyProcessor_ReadNTAuthStoreProperties()
         {

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -778,7 +778,7 @@ namespace CommonLibTest
             Assert.Contains("certname", keys);
             Assert.Contains("certchain", keys);
             Assert.Contains("hasbasicconstraints", keys);
-            Assert.Contains("basicconstraintpathlength", keys);;
+            Assert.Contains("basicconstraintpathlength", keys);
             
             //AIA CA Properties
             Assert.Contains("crosscertificatepair", keys);


### PR DESCRIPTION
## Description

There was an edge case where an AD AIACA with a `{0}` value for CACertificate attribute would cause cert parsing to fail and AIACA wasn't collected. To fix we check if byte array is not empty before attempting to parse.

## Motivation and Context

[BED-7513](https://specterops.atlassian.net/browse/BED-7513)

## How Has This Been Tested?

As a domain admin, make a new CA with empty cACertificate
```
$zeroByte = [byte[]](0x00)

New-ADObject `
    -Name "SEVENKINGDOMS-CA-EMPTY-TEST" `
    -Type certificationAuthority `
    -Path "CN=AIA,CN=Public Key Services,CN=Services,CN=Configuration,DC=sevenkingdoms,DC=local" `
    -OtherAttributes @{
        cACertificate=$zeroByte
        certificateRevocationList=$zeroByte
        authorityRevocationList=$zeroByte
    }
```
Confirm that new CA object with cACertificate of {0} exists in AIA
<img width="1022" height="513" alt="image" src="https://github.com/user-attachments/assets/0cd83937-a7ab-414d-8fe6-7962ade0400f" />

Run new collection and confirm that AIACA node was created
<img width="919" height="864" alt="image" src="https://github.com/user-attachments/assets/8a5f1d64-e69a-4144-918a-da974e3c65f2" />


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [x] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-7513]: https://specterops.atlassian.net/browse/BED-7513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of LDAP CA handling by validating certificate byte content before parsing; empty or non-meaningful certificate data is now skipped to prevent parsing errors and ensure consistent property population.

* **Tests**
  * Added and expanded tests covering null/empty/single-zero-byte certificate scenarios and CA-related property assertions across Root, AIA, and Enterprise CA cases.

* **Documentation**
  * Added clarifying documentation for Enterprise CA property reader.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->