### PR TITLE
fix: GetLocalGroups RPC response time too variant for adaptive timeouts

### DIFF
--- a/src/CommonLib/Processors/LocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/LocalGroupProcessor.cs
@@ -23,7 +23,6 @@ namespace SharpHoundCommonLib.Processors
         private readonly AdaptiveTimeout _openDomainAdaptiveTimeout;
         private readonly AdaptiveTimeout _getAliasesAdaptiveTimeout;
         private readonly AdaptiveTimeout _openAliasAdaptiveTimeout;
-        private readonly AdaptiveTimeout _getMembersAdaptiveTimeout;
         private readonly AdaptiveTimeout _lookupPrincipalBySidAdaptiveTimeout;
 
         public LocalGroupProcessor(ILdapUtils utils, ILogger log = null) {
@@ -36,7 +35,6 @@ namespace SharpHoundCommonLib.Processors
             _openDomainAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.OpenDomain)));
             _getAliasesAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMDomain.GetAliases)));
             _openAliasAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMDomain.OpenAlias)));
-            _getMembersAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMAlias.GetMembers)));
             _lookupPrincipalBySidAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.LookupPrincipalBySid)));
         }
 
@@ -214,7 +212,7 @@ namespace SharpHoundCommonLib.Processors
                     
                     var localGroup = openAliasResult.Value;
                     //Call GetMembersInAlias to get raw group members
-                    var getMembersResult = await _getMembersAdaptiveTimeout.ExecuteRPCWithTimeout((_) => localGroup.GetMembers());
+                    var getMembersResult = await Timeout.ExecuteRPCWithTimeout(TimeSpan.FromMinutes(2), (_) => localGroup.GetMembers());
                     if (getMembersResult.IsFailed)
                     {
                         _log.LogTrace("Failed to get members in alias {Alias} with RID {Rid} in domain {Domain} on computer {ComputerName}: {Error}", alias.Name, alias.Rid, domainResult.Name, computerName, openAliasResult.Error);


### PR DESCRIPTION
## Description

GetLocalGroups for RPC is too inconsistent in payload and response time to extract much value from adaptive timeout logic, and is causing data loss besides.  Switching to static timeouts.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-7153

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized timeout handling for group member operations to use fixed timeouts, improving consistency in error handling flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->