### PR TITLE
feat: Apply blanket minimum timeout bound to 1s - BED-7153

### DIFF
--- a/src/CommonLib/AdaptiveTimeout.cs
+++ b/src/CommonLib/AdaptiveTimeout.cs
@@ -14,10 +14,12 @@ public sealed class AdaptiveTimeout : IDisposable {
     private readonly ConcurrentQueue<DateTime> _latestSuccessTimestamps;
     private readonly ILogger _log;
     private readonly TimeSpan _maxTimeout;
+    private readonly TimeSpan _minTimeout;
     private readonly bool _useAdaptiveTimeout;
     private readonly int _minSamplesForAdaptiveTimeout;
     private readonly bool _throwIfExcessiveTimeouts;
     private int _timeSpikeDecay;
+    private readonly TimeSpan _defaultMinTimeout = TimeSpan.FromSeconds(1);
     private const int TimeSpikePenalty = 2;
     private const int TimeSpikeForgiveness = 1;
     private const int TimeSpikeThreshold = 3;
@@ -37,6 +39,7 @@ public sealed class AdaptiveTimeout : IDisposable {
         if (log == null)
             throw new ArgumentNullException(nameof(log));
 
+        _minTimeout = _defaultMinTimeout;
         _sampler = new ExecutionTimeSampler(log, sampleCount, logFrequency);
         _latestSuccessTimestamps = new ConcurrentQueue<DateTime>();
         _log = log;
@@ -44,6 +47,16 @@ public sealed class AdaptiveTimeout : IDisposable {
         _minSamplesForAdaptiveTimeout = minSamplesForAdaptiveTimeout;
         _useAdaptiveTimeout = useAdaptiveTimeout;
         _throwIfExcessiveTimeouts = throwIfExcessiveTimeouts;
+    }
+
+    public AdaptiveTimeout(TimeSpan maxTimeout, TimeSpan minTimeout, ILogger log, int sampleCount = 100, int logFrequency = 1000, int minSamplesForAdaptiveTimeout = 30, bool useAdaptiveTimeout = true, bool throwIfExcessiveTimeouts = false)
+            : this(maxTimeout, log, sampleCount, logFrequency, minSamplesForAdaptiveTimeout, useAdaptiveTimeout, throwIfExcessiveTimeouts) {
+        if (minTimeout < TimeSpan.Zero)
+            throw new ArgumentException("minTimeout must be non-negative", nameof(minTimeout));
+        if (minTimeout >= maxTimeout)
+            throw new ArgumentException("minTimeout must be less than maxTimeout", nameof(minTimeout));
+
+        _minTimeout = minTimeout;
     }
 
     public void ClearSamples() {
@@ -214,11 +227,11 @@ public sealed class AdaptiveTimeout : IDisposable {
         _sampler.Dispose();
     }
 
-    // Within 5 standard deviations will have a conservative lower bound of catching 96% of executions (1 - 1/5^2),
+    // Within 7 standard deviations will have a conservative lower bound of catching 98% of executions (1 - 1/7^2),
     // regardless of sample shape
     // so long as those samples are independent and identically distributed
     // (and if they're not, our TimeSpikeSafetyValve should provide us with some adaptability)
-    // But the effective collection rate is probably closer to 98+%
+    // But the effective collection rate is probably closer to 99+%
     // (in part because we don't need to filter out "too fast" outliers)
     // But we'll cap at configured maximum timeout
     // https://modelassist.epixanalytics.com/space/EA/26574957/Tchebysheffs+Rule
@@ -231,6 +244,7 @@ public sealed class AdaptiveTimeout : IDisposable {
             var stdDev = _sampler.StandardDeviation();
             var adaptiveTimeoutMs = _sampler.Average() + (stdDev * StdDevMultiplier);
             var cappedTimeoutMS = Math.Min(adaptiveTimeoutMs, _maxTimeout.TotalMilliseconds);
+            cappedTimeoutMS = Math.Max(cappedTimeoutMS, _minTimeout.TotalMilliseconds);
             return TimeSpan.FromMilliseconds(cappedTimeoutMS);
         }
         catch (Exception ex) {

--- a/src/CommonLib/Processors/LocalGroupProcessor.cs
+++ b/src/CommonLib/Processors/LocalGroupProcessor.cs
@@ -36,7 +36,8 @@ namespace SharpHoundCommonLib.Processors
             _openDomainAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.OpenDomain)));
             _getAliasesAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMDomain.GetAliases)));
             _openAliasAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMDomain.OpenAlias)));
-            _getMembersAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMAlias.GetMembers)));
+            // Disabling adaptive timeout for GetMembers as it can be very chatty and we don't want timeouts to cause us to miss groups entirely. We can re-enable adaptive timeouts here in the future if we find a good way to handle timeouts without losing entire groups
+            _getMembersAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMAlias.GetMembers)), useAdaptiveTimeout: false);
             _lookupPrincipalBySidAdaptiveTimeout = new AdaptiveTimeout(maxTimeout: TimeSpan.FromMinutes(2), Logging.LogProvider.CreateLogger(nameof(ISAMServer.LookupPrincipalBySid)));
         }
 

--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -18,7 +18,8 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_NotEnoughSamplesAsync() {
         var maxTimeout = TimeSpan.FromSeconds(1);
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3);
+        var minTimeout = TimeSpan.Zero;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3);
 
         await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
 
@@ -29,7 +30,8 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_AdaptiveDisabled() {
         var maxTimeout = TimeSpan.FromSeconds(1);
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3, false);
+        var minTimeout = TimeSpan.Zero;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3, false);
 
         await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
         await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
@@ -42,7 +44,8 @@ public class AdaptiveTimeoutTest {
     [Fact]
     public async Task AdaptiveTimeout_GetAdaptiveTimeout() {
         var maxTimeout = TimeSpan.FromSeconds(1);
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3);
+        var minTimeout = TimeSpan.Zero;
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 10, 1000, 3);
 
         await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(40));
         await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
@@ -56,8 +59,9 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_TimeSpikeSafetyValve() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromSeconds(1);
+        var minTimeout = TimeSpan.Zero;
         var numSamples = 30;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 10);
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 10);
 
         for (int i = 0; i < numSamples; i++)
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(10)));
@@ -75,8 +79,9 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_TimeSpikeSafetyValve_IgnoreHiccup() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromSeconds(1);
+        var minTimeout = TimeSpan.Zero;
         var numSamples = 5;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2);
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2);
 
         // Prepare our successful samples
         for (int i = 0; i < numSamples; i++)
@@ -103,8 +108,9 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_ThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromMilliseconds(500);
+        var minTimeout = TimeSpan.Zero;
         var numSamples = 5;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: true);
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: true);
 
         for (int i = 0; i < numSamples; i++)
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
@@ -121,8 +127,9 @@ public class AdaptiveTimeoutTest {
     public async Task AdaptiveTimeout_GetAdaptiveTimeout_DoNotThrowWhenExcessiveTimeouts() {
         var tasks = new List<Task>();
         var maxTimeout = TimeSpan.FromMilliseconds(500);
+        var minTimeout = TimeSpan.Zero;
         var numSamples = 5;
-        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: false);
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), numSamples, 1000, 2, throwIfExcessiveTimeouts: false);
 
         for (int i = 0; i < numSamples; i++)
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask));
@@ -133,6 +140,19 @@ public class AdaptiveTimeoutTest {
             tasks.Add(adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(1000)));
 
         await Task.WhenAll(tasks);
+    }
+
+    [Fact]
+    public async Task AdaptiveTimeout_GetAdaptiveTimeout_MinTimeout() {
+        var maxTimeout = TimeSpan.FromSeconds(1);
+        var minTimeout = TimeSpan.FromSeconds(0.5);
+        var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 1, 1000, 1);
+
+        await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
+
+        var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
+        Assert.Equal(minTimeout, adaptiveTimeoutResult);
+        Assert.True(adaptiveTimeoutResult < maxTimeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Add minimum timeout floor for adaptive timeouts, apply a 1 second blanket floor to all current uses, with the option being configurable.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-7153

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable minimum timeout enforcement to prevent excessively short timeout values (default: 1 second).
  * Enhanced timeout management with new configuration options for custom minimum timeout thresholds.

* **Improvements**
  * Improved reliability by enforcing lower bounds on adaptive timeout calculations, ensuring more predictable system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->