### PR TITLE
fix: AdaptiveTimeout MinTimeout test needs to be more resource-aware for github runners - BED-7153

### DIFF
--- a/test/unit/AdaptiveTimeoutTest.cs
+++ b/test/unit/AdaptiveTimeoutTest.cs
@@ -148,11 +148,10 @@ public class AdaptiveTimeoutTest {
         var minTimeout = TimeSpan.FromSeconds(0.5);
         var adaptiveTimeout = new AdaptiveTimeout(maxTimeout, minTimeout, new TestLogger(_testOutputHelper, Microsoft.Extensions.Logging.LogLevel.Trace), 1, 1000, 1);
 
-        await adaptiveTimeout.ExecuteWithTimeout(async (_) => await Task.Delay(50));
+        await adaptiveTimeout.ExecuteWithTimeout((_) => Task.CompletedTask);
 
         var adaptiveTimeoutResult = adaptiveTimeout.GetAdaptiveTimeout();
         Assert.Equal(minTimeout, adaptiveTimeoutResult);
-        Assert.True(adaptiveTimeoutResult < maxTimeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Description
Github runners are too efficient with concurrency resources for `Task.Delay()` code in parallelized tests to be particularly timely.

## Motivation and Context
https://specterops.atlassian.net/browse/BED-7153

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated adaptive timeout test logic to improve test reliability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->