### PR TITLE
fix: AntiXssLibrary missing dependency BED-7686

### DIFF
--- a/RPCTest/RPCTest.csproj
+++ b/RPCTest/RPCTest.csproj
@@ -5,6 +5,8 @@
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <!-- Suppress cross-targeting warning when referencing net472 projects in net8.0 tests -->
+        <NoWarn>$(NoWarn);NU1702</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -18,7 +18,7 @@
         <DebugType>full</DebugType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="AntiXSS" Version="4.3.0" PrivateAssets="All"/>
+        <PackageReference Include="AntiXSS" Version="4.3.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/test/unit/CommonLibTest.csproj
+++ b/test/unit/CommonLibTest.csproj
@@ -6,8 +6,8 @@
         <CollectCoverage>true</CollectCoverage>
         <CoverletOutput>..\..\docfx\coverage\</CoverletOutput>
         <CoverletOutputFormat>OpenCover</CoverletOutputFormat>
-        <!-- Suppress cross-targeting warning when referencing net472 SharpHound projects in net8.0 tests -->
-        <NoWarn>$(NoWarn);NU1702</NoWarn> 
+        <!-- Suppress cross-targeting warning when referencing net472 projects/packages in net8.0 tests -->
+        <NoWarn>$(NoWarn);NU1702;NU1701</NoWarn> 
     </PropertyGroup>
 
     <!-- Project references -->

--- a/test/unit/RegistryProcessorTests.cs
+++ b/test/unit/RegistryProcessorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
 using Microsoft.Extensions.Logging;
@@ -74,6 +75,7 @@ namespace CommonLibTest
             }
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task RegistryProcessor_ReadRegistrySettings_FirstStrategySuccessful() {
             const uint minClientSecValue = 536870912;
@@ -106,6 +108,7 @@ namespace CommonLibTest
             VerifyCompStatusLog(task, TargetName, CSVComputerStatus.StatusSuccess);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task RegistryProcessor_ReadRegistrySettings_SecondStrategySuccessful() {
             const string failureReason = "No such host is known.";
@@ -166,6 +169,7 @@ namespace CommonLibTest
             Assert.Empty(_receivedCompStatuses);
         }
 
+        [SupportedOSPlatform("windows")]
         [WindowsOnlyFact]
         public async Task RegistryProcessor_ReadRegistrySettings_SetsAllValues() {
             var allowedServers = new[] {"server"};


### PR DESCRIPTION
## Description

Remove private assets attribute from AntiXSS package ref to allow transitive restore from SH/SHE.
Suppress NU17012/NU1702 in test projects.

## Motivation and Context

[BED-7686](https://specterops.atlassian.net/browse/BED-7686)

## How Has This Been Tested?

Ran tests. Built project and ran in lab.

## Screenshots (if appropriate):
Before:
<img width="958" height="436" alt="image" src="https://github.com/user-attachments/assets/65dd39d9-c588-4f02-ab37-d719554819db" />
After:
<img width="958" height="294" alt="image" src="https://github.com/user-attachments/assets/bd3707e7-64cf-498c-a516-40ff0e928240" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project build configuration to properly handle cross-framework compatibility warnings.
  * Modified dependency packaging behavior for improved transitive dependency handling.

* **Tests**
  * Added platform-specific targeting annotations to registry processor tests to ensure they run on compatible operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[BED-7686]: https://specterops.atlassian.net/browse/BED-7686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ