### PR TITLE
fix: Alter ConverDomainSidToDomainNameFromLdap - BED-6095

### DIFF
--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -412,14 +412,14 @@ namespace SharpHoundCommonLib {
 
             result = await Query(new LdapQueryParameters {
                 DomainName = domain.Name,
-                Attributes = new[] { LDAPProperties.DistinguishedName },
+                Attributes = new[] { LDAPProperties.DistinguishedName, LDAPProperties.Name },
                 GlobalCatalog = true,
                 LDAPFilter = new LdapFilter().AddFilter("(objectclass=trusteddomain)", true)
                     .AddFilter($"(securityidentifier={Helpers.ConvertSidToHexSid(domainSid)})", true).GetFilter()
             }).DefaultIfEmpty(LdapResult<IDirectoryObject>.Fail()).FirstOrDefaultAsync();
 
-            if (result.IsSuccess && result.Value.TryGetDistinguishedName(out distinguishedName)) {
-                return (true, Helpers.DistinguishedNameToDomain(distinguishedName));
+            if (result.IsSuccess && result.Value.TryGetProperty(LDAPProperties.Name, out var domainName)) {
+                return (true, domainName.ToUpper());
             }
 
             result = await Query(new LdapQueryParameters {

--- a/test/unit/WebClientServiceProcessorTest.cs
+++ b/test/unit/WebClientServiceProcessorTest.cs
@@ -26,7 +26,7 @@ namespace CommonLibTest {
         public void Dispose() {
         }
     
-        [Fact]
+        [WindowsOnlyFact]
         public async Task WebClientServiceProcessorTest_TestPathExists()
         {
             var processor = new WebClientServiceProcessor();


### PR DESCRIPTION
## Description

This fix alters ConverDomainSidToDomainNameFromLdap. In a cross forest scenario, this resolution step could be used. In its current form, it may resolve to the first DC in the item, ignoring the CN for the other forest. This is due to the functionality of DistinguishedNameToDomain, which returns the first DC. To correct this, this change is made to pull the name using LDAP, and return that instead without resolving using DistinguishedNameToDomain.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves BED-6095

## How Has This Been Tested?

This has been tested by running direct LDAP queries, as well as creating a build and running collection with this version.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Chore (a change that does not modify the application functionality)
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LDAP domain name resolution to return normalized domain names and increase reliability of directory lookups.

* **Tests**
  * Adjusted a unit test to run only on Windows, ensuring platform-specific validation executes in appropriate environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->