### PR TITLE
chore: SHC has a required dependency of SharpHoundRPC

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,14 @@
 <Project>
+    <PropertyGroup>
+        <TargetFramework>net472</TargetFramework>
+        <OutputType>library</OutputType>
+        <LangVersion>default</LangVersion>
+        <Authors>Rohan Vazarkar</Authors>
+        <Company>SpecterOps</Company>
+        <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+        <RepositoryUrl>https://github.com/SpecterOps/SharpHoundCommon</RepositoryUrl>
+        <Version>4.6.1</Version>
+    </PropertyGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>CommonLibTest</_Parameter1>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <Company>SpecterOps</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/SpecterOps/SharpHoundCommon</RepositoryUrl>
-        <Version>4.6.1</Version>
+        <Version>4.6.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/CommonLib/README.md
+++ b/src/CommonLib/README.md
@@ -1,0 +1,46 @@
+# SharpHoundCommon
+
+SharpHoundCommon provides the high-level shared components used to build AD enumeration workflows. It includes initialization, caching, LDAP helpers, host and service processors, and registry and user-rights collection logic used by SharpHound collectors.
+
+## When to use this package
+
+Use `SharpHoundCommon` if you are building a collector or integration that needs higher-level enumeration behavior. This is the package most consumers should start with.
+
+## Requirements
+
+- .NET Framework 4.7.2
+- Windows and Active Directory oriented workloads
+
+## Install
+
+```powershell
+dotnet add package SharpHoundCommon
+```
+
+## Getting started
+
+```csharp
+using SharpHoundCommonLib;
+
+CommonLib.InitializeCommonLib();
+```
+
+You may optionally provide an `ILogger` and a pre-created `Cache` instance to `CommonLib.InitializeCommonLib(...)`.
+
+## Included capabilities
+
+- Shared initialization and cache management via `CommonLib` and `Cache`
+- LDAP querying and identity resolution via `LdapUtils`
+- Host availability, SMB, and LDAP service checks via `ComputerAvailability`, `SmbProcessor`, and `DCLdapProcessor`
+- Registry collection orchestration via `RegistryProcessor`
+- User rights, SPN, and certificate-related processing helpers
+
+## Relationship to SharpHoundRPC
+
+`SharpHoundCommon` depends on `SharpHoundRPC` and is intended to be the higher-level entry point. Most consumers should not reference `SharpHoundRPC` directly unless they need its lower-level SAM, LSA, NetAPI, or registry APIs.
+
+## Source and support
+
+- Source: https://github.com/SpecterOps/SharpHoundCommon
+- Issues: https://github.com/SpecterOps/SharpHoundCommon/issues
+- License: GPL-3.0-only

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -23,12 +23,9 @@
         <Reference Include="System.Net.Http" />
     </ItemGroup>
     <ItemGroup>
-        <Folder Include="Properties" />
+        <ProjectReference Include="..\SharpHoundRPC\SharpHoundRPC.csproj" />
     </ItemGroup>
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\SharpHoundRPC\SharpHoundRPC.csproj" />
     </ItemGroup>
 </Project>

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -1,15 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
-        <OutputType>library</OutputType>
         <PackageId>SharpHoundCommon</PackageId>
-        <LangVersion>default</LangVersion>
-        <Authors>Rohan Vazarkar</Authors>
-        <Company>SpecterOps</Company>
         <PackageDescription>Common library for C# BloodHound enumeration tasks</PackageDescription>
-        <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-        <RepositoryUrl>https://github.com/BloodHoundAD/SharpHoundCommon</RepositoryUrl>
-        <Version>4.6.0</Version>
         <AssemblyName>SharpHoundCommonLib</AssemblyName>
         <RootNamespace>SharpHoundCommonLib</RootNamespace>
     </PropertyGroup>
@@ -21,6 +13,7 @@
         <PackageReference Include="AntiXSS" Version="4.3.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+        <PackageReference Include="SharpHoundRPC" Version="$(Version)" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.DirectoryServices" />

--- a/src/CommonLib/SharpHoundCommonLib.csproj
+++ b/src/CommonLib/SharpHoundCommonLib.csproj
@@ -2,8 +2,10 @@
     <PropertyGroup>
         <PackageId>SharpHoundCommon</PackageId>
         <PackageDescription>Common library for C# BloodHound enumeration tasks</PackageDescription>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <AssemblyName>SharpHoundCommonLib</AssemblyName>
         <RootNamespace>SharpHoundCommonLib</RootNamespace>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     </PropertyGroup>
     <PropertyGroup>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
@@ -13,7 +15,6 @@
         <PackageReference Include="AntiXSS" Version="4.3.0" />
         <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
-        <PackageReference Include="SharpHoundRPC" Version="$(Version)" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.DirectoryServices" />
@@ -25,25 +26,9 @@
         <Folder Include="Properties" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\SharpHoundRPC\SharpHoundRPC.csproj" PrivateAssets="All" />
+        <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>
-    <PropertyGroup>
-        <TargetsForTfmSpecificBuildOutput>
-            $(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    </PropertyGroup>
-    <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
-        <ItemGroup>
-            <!-- Filter out unnecessary files -->
-            <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
-        </ItemGroup>
-
-        <!-- Print batches for debug purposes -->
-        <Message Text="Batch for .nupkg: ReferenceCopyLocalPaths = @(_ReferenceCopyLocalPaths), ReferenceCopyLocalPaths.DestinationSubDirectory = %(_ReferenceCopyLocalPaths.DestinationSubDirectory) Filename = %(_ReferenceCopyLocalPaths.Filename) Extension = %(_ReferenceCopyLocalPaths.Extension)" Importance="High" Condition="'@(_ReferenceCopyLocalPaths)' != ''" />
-
-        <ItemGroup>
-            <!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
-            <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)" />
-        </ItemGroup>
-    </Target>
+    <ItemGroup>
+        <ProjectReference Include="..\SharpHoundRPC\SharpHoundRPC.csproj" />
+    </ItemGroup>
 </Project>

--- a/src/SharpHoundRPC/README.md
+++ b/src/SharpHoundRPC/README.md
@@ -1,0 +1,33 @@
+# SharpHoundRPC
+
+SharpHoundRPC exposes low-level Windows RPC, Win32, and remote collection helpers used by SharpHoundCommon and SharpHound collectors. It wraps SAM, LSA, NetAPI, and remote registry operations behind C# interfaces and result types.
+
+## When to use this package
+
+Use `SharpHoundRPC` directly only if you need low-level RPC or interop access. If you want higher-level enumeration workflows, install `SharpHoundCommon` instead.
+
+## Requirements
+
+- .NET Framework 4.7.2
+- Windows-focused functionality
+- Appropriate privileges, network reachability, and RPC availability on target systems
+
+## Install
+
+```powershell
+dotnet add package SharpHoundRPC
+```
+
+## Included capabilities
+
+- SAM access through `ISAMServer`, `ISAMDomain`, `SAMServerAccessor`, and related wrappers
+- LSA policy access via `LSAPolicy` for SID lookup and privilege enumeration
+- NetAPI helpers for sessions, workstation information, and domain controller discovery
+- Remote registry strategies using WMI or Remote Registry
+- Shared `Result<T>` and related helper types for error handling
+
+## Source and support
+
+- Source: https://github.com/SpecterOps/SharpHoundCommon
+- Issues: https://github.com/SpecterOps/SharpHoundCommon/issues
+- License: GPL-3.0-only

--- a/src/SharpHoundRPC/SharpHoundRPC.csproj
+++ b/src/SharpHoundRPC/SharpHoundRPC.csproj
@@ -14,12 +14,9 @@
         <PackageReference Include="System.ValueTuple" Version="4.5.0"/>
     </ItemGroup>
     <ItemGroup>
-        <Folder Include="Properties"/>
+        <Reference Include="System.Management" />
     </ItemGroup>
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="System.Management" />
     </ItemGroup>
 </Project>

--- a/src/SharpHoundRPC/SharpHoundRPC.csproj
+++ b/src/SharpHoundRPC/SharpHoundRPC.csproj
@@ -1,14 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
-        <OutputType>library</OutputType>
         <PackageId>SharpHoundRPC</PackageId>
-        <LangVersion>default</LangVersion>
-        <Authors>Rohan Vazarkar</Authors>
-        <Company>SpecterOps</Company>
         <PackageDescription>SAM/LSA Wrapper for C# BloodHound tasks</PackageDescription>
-        <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
-        <Version>4.6.0</Version>
         <AssemblyName>SharpHoundRPC</AssemblyName>
         <RootNamespace>SharpHoundRPC</RootNamespace>
     </PropertyGroup>

--- a/src/SharpHoundRPC/SharpHoundRPC.csproj
+++ b/src/SharpHoundRPC/SharpHoundRPC.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <PackageId>SharpHoundRPC</PackageId>
         <PackageDescription>SAM/LSA Wrapper for C# BloodHound tasks</PackageDescription>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <AssemblyName>SharpHoundRPC</AssemblyName>
         <RootNamespace>SharpHoundRPC</RootNamespace>
     </PropertyGroup>
@@ -14,6 +15,9 @@
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Properties"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
         <Reference Include="System.Management" />


### PR DESCRIPTION
## Description

Both CommonLib and RPC use shared Build.Props version property.
Add readmes to nuget packages.
Nuget manages RPC dependency isntead of manually copying built files from RPC to CommonLib.

## Motivation and Context

[BED-3959](https://specterops.atlassian.net/browse/BED-3959)

## How Has This Been Tested?

Ran `dotnet pack` and validated output.
Build and tested sharphound with new common package.

## Screenshots (if appropriate):
<img width="1871" height="575" alt="image" src="https://github.com/user-attachments/assets/bdf8c657-04bb-4398-ae23-7e768a9632f8" />
<img width="1871" height="575" alt="image" src="https://github.com/user-attachments/assets/a82a3cc5-da0d-449a-8728-7b26d7d86a77" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Chore (a change that does not modify the application functionality)
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] Documentation updates are needed, and have been made accordingly.
-   [ ] I have added and/or updated tests to cover my changes.
-   [x] All new and existing tests passed.
-   [ ] My changes include a database migration.


[BED-3959]: https://specterops.atlassian.net/browse/BED-3959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ