### PR TITLE
fix: publish the dev build as a patch - BED-7858

### DIFF
--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -23,8 +23,11 @@ jobs:
         shell: pwsh
         run: |
           $base_version = dotnet msbuild Directory.Build.props --getProperty:Version
+          $parts = $base_version.Split('.')
+          $parts[2] = [int]$parts[2] + 1
+          $next_version = $parts -join '.'
           $date_stamp = Get-Date -Format 'yyyyMMddHHmm'
-          "dev_version=$base_version-dev.$date_stamp" >> $env:GITHUB_OUTPUT
+          "dev_version=$next_version-dev.$date_stamp" >> $env:GITHUB_OUTPUT
 
       - name: Restore dependencies
         run: dotnet restore


### PR DESCRIPTION
## Description

This change alters the build to publish the dev package as an increment to the current stable version.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: BED-7858

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dev package versioning logic to increment the patch version number with a date stamp appended to development releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->