### PR TITLE
fix: change PrincipalContext and DirectoryEntry calls to properly respect the LDAP configuration set

### DIFF
--- a/src/CommonLib/ConnectionPoolManager.cs
+++ b/src/CommonLib/ConnectionPoolManager.cs
@@ -139,7 +139,7 @@ namespace SharpHoundCommonLib {
             if (Cache.GetDomainSidMapping(domainName, out var domainSid)) return (true, domainSid);
 
             try {
-                var entry = new DirectoryEntry($"LDAP://{domainName}").ToDirectoryObject();
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://{domainName}", _ldapConfig);
                 if (entry.TryGetSecurityIdentifier(out var sid)) {
                     Cache.AddDomainSidMapping(domainName, sid);
                     return (true, sid);

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -16,6 +16,10 @@ namespace SharpHoundCommonLib {
         private static readonly HashSet<string> Users = new() { "805306368", "805306370" };
 
         private static readonly Regex SPNRegex = new(@".*\/.*", RegexOptions.Compiled);
+
+        // Splits a DN on commas that are not escaped (i.e. not preceded by a backslash).
+        // Plain Split(',') would break on OU/CN values that contain \, (e.g. "OU=Sales\, West").
+        private static readonly Regex UnescapedCommaRegex = new(@"(?<!\\),", RegexOptions.Compiled);
         private static readonly DateTime EpochDiff = new(1970, 1, 1);
 
         private static readonly string[] FilteredSids = {
@@ -133,7 +137,7 @@ namespace SharpHoundCommonLib {
             // component correctly skips leading DC= RDNs on deleted-object tombstones and any
             // over-split pieces from escaped commas in CN/OU values — DC= values are DNS labels
             // and never contain commas themselves.
-            var rdns = distinguishedName.Split(',');
+            var rdns = UnescapedCommaRegex.Split(distinguishedName);
             var dcValues = new List<string>();
             for (var i = rdns.Length - 1; i >= 0; i--) {
                 var rdn = rdns[i].Trim();

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -15,7 +15,6 @@ namespace SharpHoundCommonLib {
         private static readonly HashSet<string> Computers = new() { "805306369" };
         private static readonly HashSet<string> Users = new() { "805306368", "805306370" };
 
-        private static readonly Regex DCReplaceRegex = new("DC=", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex SPNRegex = new(@".*\/.*", RegexOptions.Compiled);
         private static readonly DateTime EpochDiff = new(1970, 1, 1);
 
@@ -129,21 +128,22 @@ namespace SharpHoundCommonLib {
         /// <param name="distinguishedName">Distinguished Name to extract domain from</param>
         /// <returns>String representing the domain name of this object</returns>
         public static string DistinguishedNameToDomain(string distinguishedName) {
-            int idx;
-            if (distinguishedName.ToUpper().Contains("DELETED OBJECTS")) {
-                idx = distinguishedName.IndexOf("DC=", 3, StringComparison.Ordinal);
-            }
-            else {
-                idx = distinguishedName.IndexOf("DC=",
-                    StringComparison.CurrentCultureIgnoreCase);
+            // Split on commas and collect only the trailing DC= RDNs (which always form the
+            // DNS domain suffix in AD DNs). Walking backward and stopping at the first non-DC=
+            // component correctly skips leading DC= RDNs on deleted-object tombstones and any
+            // over-split pieces from escaped commas in CN/OU values — DC= values are DNS labels
+            // and never contain commas themselves.
+            var rdns = distinguishedName.Split(',');
+            var dcValues = new List<string>();
+            for (var i = rdns.Length - 1; i >= 0; i--) {
+                var rdn = rdns[i].Trim();
+                if (!rdn.StartsWith("DC=", StringComparison.OrdinalIgnoreCase)) break;
+                dcValues.Add(rdn.Substring(3));
             }
 
-            if (idx < 0)
-                return null;
-
-            var temp = distinguishedName.Substring(idx);
-            temp = DCReplaceRegex.Replace(temp, "").Replace(",", ".").ToUpper();
-            return temp;
+            if (dcValues.Count == 0) return null;
+            dcValues.Reverse();
+            return string.Join(".", dcValues).ToUpper();
         }
 
         /// <summary>

--- a/src/CommonLib/Helpers.cs
+++ b/src/CommonLib/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.DirectoryServices;
 using System.Globalization;
 using System.Linq;
 using System.Security.Principal;
@@ -54,6 +55,71 @@ namespace SharpHoundCommonLib {
             }
 
             return "";
+        }
+        
+        internal static IDirectoryObject CreateDirectoryEntry(string path, LdapConfig config) {
+            // Build AuthenticationTypes flags from LdapConfig.
+            // AuthenticationTypes.Secure requests SSPI (Negotiate) and is the safe default.
+            var authType = AuthenticationTypes.Secure;
+
+            if (config.ForceSSL) {
+                authType |= AuthenticationTypes.SecureSocketsLayer;
+            }
+
+            // Mirror the connection pool's logic: signing and sealing are mutually exclusive with
+            // SSL (the transport already provides integrity) and are skipped when DisableSigning is set.
+            if (!config.DisableSigning && !config.ForceSSL) {
+                authType |= AuthenticationTypes.Signing | AuthenticationTypes.Sealing;
+            }
+
+            // If a specific server is configured, insert it into the ADSI path so that this
+            // call targets the same DC as the connection pool rather than relying on DNS discovery.
+            //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com/<SID=...>"
+            //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/DC=domain,DC=com"
+            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/RootDSE"
+            // Note: DisableCertVerification cannot be honoured here — there is no ADSI API for it.
+            var serverTarget = config.GetServerTarget();
+            if (serverTarget != null) {
+                const string ldapPrefix = "LDAP://";
+                var serverPrefix = $"{ldapPrefix}{serverTarget}/";
+
+                // Guard: if the path already begins with "LDAP://<serverTarget>/" the server has
+                // already been injected (e.g. the caller constructed the path from a previous
+                // result).  Injecting again would corrupt the path, so leave it unchanged.
+                if (!path.StartsWith(serverPrefix, StringComparison.OrdinalIgnoreCase)) {
+                    var afterPrefix = path.Substring(ldapPrefix.Length);
+
+                    // Detect domain-shortcut targets: the component before the first '/' contains no '='
+                    // so it is a plain domain name (e.g. "domain.com", "domain") rather than an
+                    // already-valid DN ("DC=domain,DC=com") or an ADSI special moniker ("<SID=...>").
+                    var slashIndex = afterPrefix.IndexOf('/');
+                    var firstComponent = slashIndex >= 0 ? afterPrefix.Substring(0, slashIndex) : afterPrefix;
+                    var suffix = slashIndex >= 0 ? afterPrefix.Substring(slashIndex) : string.Empty;
+
+                    if (!firstComponent.Contains('=')) {
+                        // RootDSE is a special ADSI moniker – when the caller passes a path like
+                        // "LDAP://domain.com/RootDSE" (used by GetNamingContextPath) the domain
+                        // portion is only there for server selection.  We must NOT convert it to
+                        // a DN component; instead just point at the server's RootDSE directly.
+                        if (suffix.Equals("/RootDSE", StringComparison.OrdinalIgnoreCase)) {
+                            path = $"{ldapPrefix}{serverTarget}/RootDSE";
+                        } else {
+                            // "domain.com" → "DC=domain,DC=com"; single-label "domain" → "DC=domain"
+                            var dn = string.Join(",", firstComponent.Split('.').Select(part => $"DC={part}"));
+                            path = $"{ldapPrefix}{serverTarget}/{dn}{suffix}";
+                        }
+                    } else {
+                        path = $"{ldapPrefix}{serverTarget}/{afterPrefix}";
+                    }
+                }
+            }
+
+            if (config.Username != null) {
+                return new DirectoryEntry(path, config.Username, config.Password, authType)
+                    .ToDirectoryObject();
+            }
+
+            return new DirectoryEntry(path) { AuthenticationType = authType }.ToDirectoryObject();
         }
 
         /// <summary>

--- a/src/CommonLib/LdapConfig.cs
+++ b/src/CommonLib/LdapConfig.cs
@@ -42,7 +42,7 @@ namespace SharpHoundCommonLib
         /// </summary>
         public string GetServerTarget()
         {
-            if (Server == null) return null;
+            if (string.IsNullOrWhiteSpace(Server)) return null;
             var port = GetPort(ForceSSL);
             var isDefaultPort = port == (ForceSSL ? 636 : 389);
             return isDefaultPort ? Server : $"{Server}:{port}";

--- a/src/CommonLib/LdapConfig.cs
+++ b/src/CommonLib/LdapConfig.cs
@@ -65,5 +65,40 @@ namespace SharpHoundCommonLib
             }
             return sb.ToString();
         }
+
+        public string GetConfigWarnings() {
+            var builder = new StringBuilder();
+            var hasWarning = false;
+            if (!string.IsNullOrWhiteSpace(Server)) {
+                hasWarning = true;
+                builder.AppendLine("-------------LDAP CONFIG WARNINGS-------------");
+                builder.AppendLine($"-Explicit Server has been set to {Server}, this can degrade cross domain lookups");
+            }
+
+            if (ForceSSL && DisableCertVerification) {
+                if (!hasWarning) {
+                    builder.AppendLine("-------------LDAP CONFIG WARNINGS-------------");
+                }
+
+                hasWarning = true;
+                builder.AppendLine("-Not all calls are able to respect DisableCertVerification, lookups may fail");
+            }
+
+            if (DisableSigning) {
+                if (!hasWarning) {
+                    builder.AppendLine("-------------LDAP CONFIG WARNINGS-------------");
+                }
+
+                hasWarning = true;
+                builder.AppendLine("-Signing is disabled, regular LDAP traffic will be in plaintext");
+            }
+
+            if (hasWarning) {
+                builder.AppendLine("----------------------------------------------");
+                return builder.ToString();
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/src/CommonLib/LdapConfig.cs
+++ b/src/CommonLib/LdapConfig.cs
@@ -35,6 +35,19 @@ namespace SharpHoundCommonLib
             return ssl ? 3269 : 3268;
         }
 
+        /// <summary>
+        /// Returns the server-target string used in ADSI paths and <see cref="System.DirectoryServices.AccountManagement.PrincipalContext"/> bindings:
+        /// <c>"server"</c> when the port is the protocol default, or <c>"server:port"</c> when a
+        /// non-default port is configured. Returns <c>null</c> when <see cref="Server"/> is not set.
+        /// </summary>
+        public string GetServerTarget()
+        {
+            if (Server == null) return null;
+            var port = GetPort(ForceSSL);
+            var isDefaultPort = port == (ForceSSL ? 636 : 389);
+            return isDefaultPort ? Server : $"{Server}:{port}";
+        }
+
         public override string ToString() {
             var sb = new StringBuilder();
             sb.AppendLine($"Server: {Server}");

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -1164,7 +1164,7 @@ namespace SharpHoundCommonLib {
             // call targets the same DC as the connection pool rather than relying on DNS discovery.
             //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com/<SID=...>"
             //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/DC=domain,DC=com"
-            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/DC=domain/RootDSE"
+            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/RootDSE"
             // Note: DisableCertVerification cannot be honoured here — there is no ADSI API for it.
             var serverTarget = _ldapConfig.GetServerTarget();
             if (serverTarget != null) {
@@ -1185,9 +1185,17 @@ namespace SharpHoundCommonLib {
                     var suffix = slashIndex >= 0 ? afterPrefix.Substring(slashIndex) : string.Empty;
 
                     if (!firstComponent.Contains('=')) {
-                        // "domain.com" → "DC=domain,DC=com"; single-label "domain" → "DC=domain"
-                        var dn = string.Join(",", firstComponent.Split('.').Select(part => $"DC={part}"));
-                        path = $"{ldapPrefix}{serverTarget}/{dn}{suffix}";
+                        // RootDSE is a special ADSI moniker – when the caller passes a path like
+                        // "LDAP://domain.com/RootDSE" (used by GetNamingContextPath) the domain
+                        // portion is only there for server selection.  We must NOT convert it to
+                        // a DN component; instead just point at the server's RootDSE directly.
+                        if (suffix.Equals("/RootDSE", StringComparison.OrdinalIgnoreCase)) {
+                            path = $"{ldapPrefix}{serverTarget}/RootDSE";
+                        } else {
+                            // "domain.com" → "DC=domain,DC=com"; single-label "domain" → "DC=domain"
+                            var dn = string.Join(",", firstComponent.Split('.').Select(part => $"DC={part}"));
+                            path = $"{ldapPrefix}{serverTarget}/{dn}{suffix}";
+                        }
                     } else {
                         path = $"{ldapPrefix}{serverTarget}/{afterPrefix}";
                     }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -1146,11 +1146,40 @@ namespace SharpHoundCommonLib {
         }
 
         private IDirectoryObject CreateDirectoryEntry(string path) {
-            if (_ldapConfig.Username != null) {
-                return new DirectoryEntry(path, _ldapConfig.Username, _ldapConfig.Password).ToDirectoryObject();
+            // Build AuthenticationTypes flags from LdapConfig.
+            // AuthenticationTypes.Secure requests SSPI (Negotiate) and is the safe default.
+            var authType = AuthenticationTypes.Secure;
+
+            if (_ldapConfig.ForceSSL) {
+                authType |= AuthenticationTypes.SecureSocketsLayer;
             }
 
-            return new DirectoryEntry(path).ToDirectoryObject();
+            // Mirror the connection pool's logic: signing and sealing are mutually exclusive with
+            // SSL (the transport already provides integrity) and are skipped when DisableSigning is set.
+            if (!_ldapConfig.DisableSigning && !_ldapConfig.ForceSSL) {
+                authType |= AuthenticationTypes.Signing | AuthenticationTypes.Sealing;
+            }
+
+            // If a specific server is configured, insert it into the ADSI path so that this
+            // call targets the same DC as the connection pool rather than relying on DNS discovery.
+            //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com:389/<SID=...>"
+            //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/domain.com"
+            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/domain/RootDSE"
+            // Note: DisableCertVerification cannot be honoured here — there is no ADSI API for it.
+            if (_ldapConfig.Server != null) {
+                const string ldapPrefix = "LDAP://";
+                var port = _ldapConfig.GetPort(_ldapConfig.ForceSSL);
+                var isDefaultPort = port == (_ldapConfig.ForceSSL ? 636 : 389);
+                var serverTarget = isDefaultPort ? _ldapConfig.Server : $"{_ldapConfig.Server}:{port}";
+                path = $"{ldapPrefix}{serverTarget}/{path.Substring(ldapPrefix.Length)}";
+            }
+
+            if (_ldapConfig.Username != null) {
+                return new DirectoryEntry(path, _ldapConfig.Username, _ldapConfig.Password, authType)
+                    .ToDirectoryObject();
+            }
+
+            return new DirectoryEntry(path) { AuthenticationType = authType }.ToDirectoryObject();
         }
 
         public void Dispose() {

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -185,7 +185,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                using (var ctx = new PrincipalContext(ContextType.Domain)) {
+                using (var ctx = CreatePrincipalContext(_ldapConfig, tempDomain)) {
                     // Blocking External Call
                     var principal = Principal.FindByIdentity(ctx, IdentityType.Sid, sid);
                     if (principal != null) {
@@ -234,7 +234,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                using (var ctx = new PrincipalContext(ContextType.Domain)) {
+                using (var ctx = CreatePrincipalContext(_ldapConfig, domain)) {
                     // Blocking External Call
                     var principal = Principal.FindByIdentity(ctx, IdentityType.Guid, guid);
                     if (principal != null) {
@@ -374,7 +374,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                using (var ctx = new PrincipalContext(ContextType.Domain)) {
+                using (var ctx = CreatePrincipalContext(_ldapConfig)) {
                     // Blocking External Call
                     var principal = Principal.FindByIdentity(ctx, IdentityType.Sid, sid);
                     if (principal != null) {
@@ -951,7 +951,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                using (var ctx = new PrincipalContext(ContextType.Domain)) {
+                using (var ctx = CreatePrincipalContext(_ldapConfig, domain)) {
                     // Blocking External Call
                     var lookupPrincipal =
                         Principal.FindByIdentity(ctx, IdentityType.DistinguishedName, distinguishedName);
@@ -1180,6 +1180,82 @@ namespace SharpHoundCommonLib {
             }
 
             return new DirectoryEntry(path) { AuthenticationType = authType }.ToDirectoryObject();
+        }
+
+        /// <summary>
+        /// Computes the <c>contextName</c> and <see cref="ContextOptions"/> that should be passed
+        /// to a <see cref="PrincipalContext"/> for a given <see cref="LdapConfig"/>.
+        ///
+        /// <para>
+        /// Separated from <see cref="CreatePrincipalContext"/> so that the parameter-building logic
+        /// can be unit-tested without constructing a real <see cref="PrincipalContext"/> (which
+        /// would require a live directory connection).
+        /// </para>
+        ///
+        /// <para>
+        /// When <see cref="LdapConfig.Server"/> is set, the server hostname is returned as
+        /// <c>contextName</c> so that <see cref="PrincipalContext"/> binds to that specific DC
+        /// rather than relying on domain-level DNS discovery. Non-standard ports are expressed as
+        /// <c>host:port</c>. Otherwise <paramref name="domainName"/> is returned as-is (null = let
+        /// the runtime discover the current domain).
+        /// </para>
+        ///
+        /// <para>
+        /// Signing and sealing are disabled when SSL is active, mirroring the mutual-exclusion rule
+        /// applied by <see cref="LdapConnectionPool.CreateBaseConnection"/>.
+        /// </para>
+        /// </summary>
+        internal static (string ContextName, ContextOptions Options) BuildPrincipalContextParameters(
+            LdapConfig config, string domainName = null) {
+            var options = ContextOptions.Negotiate;
+
+            if (config.ForceSSL) {
+                options |= ContextOptions.SecureSocketLayer;
+            }
+
+            // Signing and sealing are mutually exclusive with SSL (the transport provides integrity).
+            if (!config.DisableSigning && !config.ForceSSL) {
+                options |= ContextOptions.Signing | ContextOptions.Sealing;
+            }
+
+            string contextName;
+            if (config.Server != null) {
+                var port = config.GetPort(config.ForceSSL);
+                var isDefaultPort = port == (config.ForceSSL ? 636 : 389);
+                contextName = isDefaultPort ? config.Server : $"{config.Server}:{port}";
+            } else {
+                contextName = domainName; // null = let the runtime discover the current domain
+            }
+
+            return (contextName, options);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="PrincipalContext"/> that targets the same DC as the connection pool
+        /// and applies the same SSL / signing / credential settings from <paramref name="config"/>.
+        ///
+        /// <para>
+        /// <see cref="ContextType.Domain"/> is always used. When <see cref="LdapConfig.Server"/> is
+        /// set, the server hostname is passed as the <c>name</c> argument so the runtime binds to
+        /// that specific DC rather than performing domain-level DNS discovery.
+        /// </para>
+        ///
+        /// <para>Note: <see cref="LdapConfig.DisableCertVerification"/> cannot be applied here —
+        /// <see cref="PrincipalContext"/> exposes no API for it.</para>
+        ///
+        /// <para>This is intentionally <c>static</c> so that Moq's Castle.DynamicProxy does not
+        /// encounter <see cref="PrincipalContext"/> in an instance-method signature when building
+        /// test proxies against <see cref="LdapUtils"/> on non-Windows runtimes.</para>
+        /// </summary>
+        private static PrincipalContext CreatePrincipalContext(LdapConfig config, string domainName = null) {
+            var (contextName, options) = BuildPrincipalContextParameters(config, domainName);
+
+            if (config.Username != null) {
+                return new PrincipalContext(ContextType.Domain, contextName, null, options,
+                    config.Username, config.Password);
+            }
+
+            return new PrincipalContext(ContextType.Domain, contextName, null, options);
         }
 
         public void Dispose() {

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -1162,16 +1162,36 @@ namespace SharpHoundCommonLib {
 
             // If a specific server is configured, insert it into the ADSI path so that this
             // call targets the same DC as the connection pool rather than relying on DNS discovery.
-            //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com:389/<SID=...>"
-            //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/domain.com"
-            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/domain/RootDSE"
+            //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com/<SID=...>"
+            //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/DC=domain,DC=com"
+            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/DC=domain/RootDSE"
             // Note: DisableCertVerification cannot be honoured here — there is no ADSI API for it.
-            if (_ldapConfig.Server != null) {
+            var serverTarget = _ldapConfig.GetServerTarget();
+            if (serverTarget != null) {
                 const string ldapPrefix = "LDAP://";
-                var port = _ldapConfig.GetPort(_ldapConfig.ForceSSL);
-                var isDefaultPort = port == (_ldapConfig.ForceSSL ? 636 : 389);
-                var serverTarget = isDefaultPort ? _ldapConfig.Server : $"{_ldapConfig.Server}:{port}";
-                path = $"{ldapPrefix}{serverTarget}/{path.Substring(ldapPrefix.Length)}";
+                var serverPrefix = $"{ldapPrefix}{serverTarget}/";
+
+                // Guard: if the path already begins with "LDAP://<serverTarget>/" the server has
+                // already been injected (e.g. the caller constructed the path from a previous
+                // result).  Injecting again would corrupt the path, so leave it unchanged.
+                if (!path.StartsWith(serverPrefix, StringComparison.OrdinalIgnoreCase)) {
+                    var afterPrefix = path.Substring(ldapPrefix.Length);
+
+                    // Detect domain-shortcut targets: the component before the first '/' contains no '='
+                    // so it is a plain domain name (e.g. "domain.com", "domain") rather than an
+                    // already-valid DN ("DC=domain,DC=com") or an ADSI special moniker ("<SID=...>").
+                    var slashIndex = afterPrefix.IndexOf('/');
+                    var firstComponent = slashIndex >= 0 ? afterPrefix.Substring(0, slashIndex) : afterPrefix;
+                    var suffix = slashIndex >= 0 ? afterPrefix.Substring(slashIndex) : string.Empty;
+
+                    if (!firstComponent.Contains('=')) {
+                        // "domain.com" → "DC=domain,DC=com"; single-label "domain" → "DC=domain"
+                        var dn = string.Join(",", firstComponent.Split('.').Select(part => $"DC={part}"));
+                        path = $"{ldapPrefix}{serverTarget}/{dn}{suffix}";
+                    } else {
+                        path = $"{ldapPrefix}{serverTarget}/{afterPrefix}";
+                    }
+                }
             }
 
             if (_ldapConfig.Username != null) {
@@ -1218,14 +1238,9 @@ namespace SharpHoundCommonLib {
                 options |= ContextOptions.Signing | ContextOptions.Sealing;
             }
 
-            string contextName;
-            if (config.Server != null) {
-                var port = config.GetPort(config.ForceSSL);
-                var isDefaultPort = port == (config.ForceSSL ? 636 : 389);
-                contextName = isDefaultPort ? config.Server : $"{config.Server}:{port}";
-            } else {
-                contextName = domainName; // null = let the runtime discover the current domain
-            }
+            // GetServerTarget() returns null when Server is not set, so the ?? falls through to
+            // domainName — which itself may be null, meaning "let the runtime discover the domain".
+            var contextName = config.GetServerTarget() ?? domainName;
 
             return (contextName, options);
         }

--- a/src/CommonLib/LdapUtils.cs
+++ b/src/CommonLib/LdapUtils.cs
@@ -174,7 +174,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                var entry = CreateDirectoryEntry($"LDAP://<SID={sid}>");
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://<SID={sid}>", _ldapConfig);
                 if (entry.GetLabel(out type)) {
                     Cache.AddType(sid, type);
                     return (true, type);
@@ -223,7 +223,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                var entry = CreateDirectoryEntry($"LDAP://<GUID={guid}>");
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://<GUID={guid}>", _ldapConfig);
                 if (entry.GetLabel(out type)) {
                     Cache.AddType(guid, type);
                     return (true, type);
@@ -358,7 +358,7 @@ namespace SharpHoundCommonLib {
             }
 
             try {
-                var entry = CreateDirectoryEntry($"LDAP://<SID={domainSid}>");
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://<SID={domainSid}>", _ldapConfig);
                 if (entry.TryGetDistinguishedName(out var dn)) {
                     Cache.AddDomainSidMapping(domainSid, Helpers.DistinguishedNameToDomain(dn));
                     return (true, Helpers.DistinguishedNameToDomain(dn));
@@ -440,7 +440,7 @@ namespace SharpHoundCommonLib {
             if (Cache.GetDomainSidMapping(domainName, out var domainSid)) return (true, domainSid);
 
             try {
-                var entry = CreateDirectoryEntry($"LDAP://{domainName}");
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://{domainName}", _ldapConfig);
                 //Force load objectsid into the object cache
                 if (entry.TryGetSecurityIdentifier(out var sid)) {
                     Cache.AddDomainSidMapping(domainName, sid);
@@ -1096,7 +1096,7 @@ namespace SharpHoundCommonLib {
             };
 
             try {
-                var entry = CreateDirectoryEntry($"LDAP://{domain}/RootDSE");
+                var entry = Helpers.CreateDirectoryEntry($"LDAP://{domain}/RootDSE", _ldapConfig);
                 if (entry.TryGetProperty(property, out var searchBase)) {
                     return (true, searchBase);
                 }
@@ -1143,71 +1143,6 @@ namespace SharpHoundCommonLib {
             
             // Metrics
             LdapMetrics.ResetInFlight();
-        }
-
-        private IDirectoryObject CreateDirectoryEntry(string path) {
-            // Build AuthenticationTypes flags from LdapConfig.
-            // AuthenticationTypes.Secure requests SSPI (Negotiate) and is the safe default.
-            var authType = AuthenticationTypes.Secure;
-
-            if (_ldapConfig.ForceSSL) {
-                authType |= AuthenticationTypes.SecureSocketsLayer;
-            }
-
-            // Mirror the connection pool's logic: signing and sealing are mutually exclusive with
-            // SSL (the transport already provides integrity) and are skipped when DisableSigning is set.
-            if (!_ldapConfig.DisableSigning && !_ldapConfig.ForceSSL) {
-                authType |= AuthenticationTypes.Signing | AuthenticationTypes.Sealing;
-            }
-
-            // If a specific server is configured, insert it into the ADSI path so that this
-            // call targets the same DC as the connection pool rather than relying on DNS discovery.
-            //   "LDAP://<SID=...>"       → "LDAP://dc01.corp.com/<SID=...>"
-            //   "LDAP://domain.com"      → "LDAP://dc01.corp.com/DC=domain,DC=com"
-            //   "LDAP://domain/RootDSE"  → "LDAP://dc01.corp.com/RootDSE"
-            // Note: DisableCertVerification cannot be honoured here — there is no ADSI API for it.
-            var serverTarget = _ldapConfig.GetServerTarget();
-            if (serverTarget != null) {
-                const string ldapPrefix = "LDAP://";
-                var serverPrefix = $"{ldapPrefix}{serverTarget}/";
-
-                // Guard: if the path already begins with "LDAP://<serverTarget>/" the server has
-                // already been injected (e.g. the caller constructed the path from a previous
-                // result).  Injecting again would corrupt the path, so leave it unchanged.
-                if (!path.StartsWith(serverPrefix, StringComparison.OrdinalIgnoreCase)) {
-                    var afterPrefix = path.Substring(ldapPrefix.Length);
-
-                    // Detect domain-shortcut targets: the component before the first '/' contains no '='
-                    // so it is a plain domain name (e.g. "domain.com", "domain") rather than an
-                    // already-valid DN ("DC=domain,DC=com") or an ADSI special moniker ("<SID=...>").
-                    var slashIndex = afterPrefix.IndexOf('/');
-                    var firstComponent = slashIndex >= 0 ? afterPrefix.Substring(0, slashIndex) : afterPrefix;
-                    var suffix = slashIndex >= 0 ? afterPrefix.Substring(slashIndex) : string.Empty;
-
-                    if (!firstComponent.Contains('=')) {
-                        // RootDSE is a special ADSI moniker – when the caller passes a path like
-                        // "LDAP://domain.com/RootDSE" (used by GetNamingContextPath) the domain
-                        // portion is only there for server selection.  We must NOT convert it to
-                        // a DN component; instead just point at the server's RootDSE directly.
-                        if (suffix.Equals("/RootDSE", StringComparison.OrdinalIgnoreCase)) {
-                            path = $"{ldapPrefix}{serverTarget}/RootDSE";
-                        } else {
-                            // "domain.com" → "DC=domain,DC=com"; single-label "domain" → "DC=domain"
-                            var dn = string.Join(",", firstComponent.Split('.').Select(part => $"DC={part}"));
-                            path = $"{ldapPrefix}{serverTarget}/{dn}{suffix}";
-                        }
-                    } else {
-                        path = $"{ldapPrefix}{serverTarget}/{afterPrefix}";
-                    }
-                }
-            }
-
-            if (_ldapConfig.Username != null) {
-                return new DirectoryEntry(path, _ldapConfig.Username, _ldapConfig.Password, authType)
-                    .ToDirectoryObject();
-            }
-
-            return new DirectoryEntry(path) { AuthenticationType = authType }.ToDirectoryObject();
         }
 
         /// <summary>

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -259,6 +259,15 @@ namespace CommonLibTest {
         }
 
         [Fact]
+        public void DistinguishedNameToDomain_EscapedCommaInOUValueFollowedByDCEquals_ReturnsCorrectDomain() {
+            // The fragment after the escaped comma starts with "DC=" which would cause a naive
+            // Split(',') to misidentify it as a domain component.  The unescaped-comma split
+            // must keep the whole OU value together so only the true trailing DC= RDNs are used.
+            var result = Helpers.DistinguishedNameToDomain(@"CN=User,OU=Dept\, DC=Proxy,DC=corp,DC=com");
+            Assert.Equal("CORP.COM", result);
+        }
+
+        [Fact]
         public void DistinguishedNameToDomain_DomainOnlyDN_ReturnsCorrectDomain() {
             // A DN that consists solely of DC= components (e.g. as stored in RootDSE).
             var result = Helpers.DistinguishedNameToDomain("DC=corp,DC=com");

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -235,6 +235,37 @@ namespace CommonLibTest {
         }
 
         [Fact]
+        public void DistinguishedNameToDomain_CNValueStartsWithDCEquals_ReturnsTrailingDCComponents() {
+            // A naive IndexOf("DC=") would hit the "DC=" inside the CN value and return
+            // the wrong domain.  The correct result uses only the trailing DC= RDNs.
+            var result = Helpers.DistinguishedNameToDomain("CN=DC=proxy,CN=Users,DC=corp,DC=com");
+            Assert.Equal("CORP.COM", result);
+        }
+
+        [Fact]
+        public void DistinguishedNameToDomain_DeletedDNSZoneWithLeadingDCRdn_ReturnsCorrectDomain() {
+            // Deleted DNS zone objects have a DC= attribute type on the first RDN.
+            // That leading DC= must not be included in the domain result.
+            var result = Helpers.DistinguishedNameToDomain(
+                @"DC=_msdcs.corp.com\0ADEL:guid,CN=Deleted Objects,DC=corp,DC=com");
+            Assert.Equal("CORP.COM", result);
+        }
+
+        [Fact]
+        public void DistinguishedNameToDomain_EscapedCommaInCN_ReturnsCorrectDomain() {
+            // The escaped comma inside the CN value must not be used as an RDN separator.
+            var result = Helpers.DistinguishedNameToDomain(@"CN=Smith\, John,OU=Sales,DC=corp,DC=com");
+            Assert.Equal("CORP.COM", result);
+        }
+
+        [Fact]
+        public void DistinguishedNameToDomain_DomainOnlyDN_ReturnsCorrectDomain() {
+            // A DN that consists solely of DC= components (e.g. as stored in RootDSE).
+            var result = Helpers.DistinguishedNameToDomain("DC=corp,DC=com");
+            Assert.Equal("CORP.COM", result);
+        }
+
+        [Fact]
         public void ConvertTimestampToUnixEpoch_ValidTimestamp() {
             var d = DateTime.Parse("2025-04-07T00:00:00.0000000-07:00");
             var result =

--- a/test/unit/CommonLibHelperTests.cs
+++ b/test/unit/CommonLibHelperTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
@@ -26,53 +27,52 @@ namespace CommonLibTest {
 
         [Fact]
         public void SplitGPLinkProperty_ValidPropFilterEnabled_ExpectedResult() {
-            var isPropFilterEnabled = false;
-            //TODO: Ari, proper test string?
-            var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123; SIP:foouser@example.co.uk; smtp:foouser@sub1.example.co.uk; smtp:foouser@sub2.example.co.uk; SMTP:foouser@example.co.uk][]";
+            // Filter is ON (filterDisabled = true): an enabled link (status 0) must pass through.
+            const string testGPLinkProperty =
+                "[LDAP://CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local;0]";
 
-            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, isPropFilterEnabled);
+            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, filterDisabled: true).ToList();
 
-            foreach (var parsedGPLink in res)
-                Assert.Equal("cn=foouser (blah)123", parsedGPLink.DistinguishedName);
-            // TODO: issue here with test data? Assert.Equal("1", parsedGPLink.Status);
+            Assert.Single(res);
+            Assert.Equal("CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local",
+                res[0].DistinguishedName);
+            Assert.Equal("0", res[0].Status);
         }
 
         [Fact]
         public void SplitGPLinkProperty_ValidPropFilterDisabled_ExpectedResult() {
-            var isPropFilterEnabled = false;
-            //TODO: Ari, proper test string?
-            var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123; SIP:foouser@example.co.uk; smtp:foouser@sub1.example.co.uk; smtp:foouser@sub2.example.co.uk; SMTP:foouser@example.co.uk][]";
+            // Filter is OFF (filterDisabled = false): a disabled link (status 1) must still come through.
+            const string testGPLinkProperty =
+                "[LDAP://CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local;1]";
 
-            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, isPropFilterEnabled);
+            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, filterDisabled: false).ToList();
 
-            foreach (var parsedGPLink in res)
-                Assert.Equal("cn=foouser (blah)123", parsedGPLink.DistinguishedName);
-            // TODO: issue here with test data? Assert.Equal("1", parsedGPLink.Status);
+            Assert.Single(res);
+            Assert.Equal("CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local",
+                res[0].DistinguishedName);
+            Assert.Equal("1", res[0].Status);
         }
 
-        /// 
         [Fact]
-        public void SplitGPLinkProperty_PropWithUnsupportedDelimiter_FilterEnabled_ExpectedResult() {
-            var isPropFilterEnabled = true;
-            //TODO: Ari, proper test string?
-            var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123; DC=somedomainName; SIP:foouser@example.co.uk; smtp:foouser@sub1.example.co.uk; smtp:foouser@sub2.example.co.uk; SMTP:foouser@example.co.uk][]";
+        public void SplitGPLinkProperty_MixedStatuses_FilterEnabled_OnlyEnabledLinksReturned() {
+            // Filter is ON: a multi-link property containing both enabled (status 0) and disabled
+            // (status 1) links must yield only the enabled one.
+            const string testGPLinkProperty =
+                "[LDAP://CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local;0]" +
+                "[LDAP://CN={C52F168C-CD05-4487-B405-564934DA8EFF},CN=Policies,CN=System,DC=testlab,DC=local;1]";
 
-            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, isPropFilterEnabled);
+            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, filterDisabled: true).ToList();
 
-            foreach (var parsedGPLink in res)
-                Assert.Equal("cn=foouser (blah)123", parsedGPLink.DistinguishedName);
-            // TODO: issue here with test data? Assert.Equal("1", parsedGPLink.Status);
+            Assert.Single(res);
+            Assert.Equal("CN={94DD0260-38B5-497E-8876-10E7A96E80D0},CN=Policies,CN=System,DC=testlab,DC=local",
+                res[0].DistinguishedName);
+            Assert.Equal("0", res[0].Status);
         }
 
         [Fact]
         public void SplitGPLinkProperty_InValidPropFilterDisabled_ExpectedResult() {
-            var isPropFilterEnabled = false;
-            //TODO: Ari, proper test string?
-            var testGPLinkProperty = "/*obviously wrong data*/";
-            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, isPropFilterEnabled);
+            const string testGPLinkProperty = "/*obviously wrong data*/";
+            var res = Helpers.SplitGPLinkProperty(testGPLinkProperty, filterDisabled: false);
             Assert.Empty(res);
         }
 

--- a/test/unit/CommonLibTest.csproj
+++ b/test/unit/CommonLibTest.csproj
@@ -25,6 +25,7 @@
         <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
+        <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
         <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
         <PackageReference Include="Xbehave" Version="2.4.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/unit/GPOLocalGroupProcessorTest.cs
+++ b/test/unit/GPOLocalGroupProcessorTest.cs
@@ -147,7 +147,7 @@ namespace CommonLibTest {
 
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
             var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;2;]";
+                "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somedomain;0][LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=someotherdomain;2]";
             var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, "DC=Testlab,DC=Local");
 
             Assert.Single(result.AffectedComputers);
@@ -234,7 +234,7 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
                         y.Attributes.Contains(LDAPProperties.Flags) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somedomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.SearchBase.Equals("CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somedomain", StringComparison.OrdinalIgnoreCase) &&
                         y.DomainName.Equals("somedomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result0.ToAsyncEnumerable);
@@ -245,7 +245,7 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
                         y.Attributes.Contains(LDAPProperties.Flags) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.SearchBase.Equals("CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=someotherdomain", StringComparison.OrdinalIgnoreCase) &&
                         y.DomainName.Equals("someotherdomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result1.ToAsyncEnumerable);
@@ -256,7 +256,7 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
                         y.Attributes.Contains(LDAPProperties.Flags) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.SearchBase.Equals("CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somethirddomain", StringComparison.OrdinalIgnoreCase) &&
                         y.DomainName.Equals("somethirddomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result2.ToAsyncEnumerable);
@@ -267,16 +267,16 @@ namespace CommonLibTest {
                         y.SearchScope.Equals(SearchScope.Base) &&
                         y.Attributes.Contains(LDAPProperties.GPCFileSYSPath) &&
                         y.Attributes.Contains(LDAPProperties.Flags) &&
-                        y.SearchBase.Equals("cn=foouser (blah)123/dc=somefourthdomain", StringComparison.OrdinalIgnoreCase) &&
+                        y.SearchBase.Equals("CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somefourthdomain", StringComparison.OrdinalIgnoreCase) &&
                         y.DomainName.Equals("somefourthdomain", StringComparison.OrdinalIgnoreCase)),
                     It.IsAny<CancellationToken>()))
                 .Returns(result3.ToAsyncEnumerable);
-            
+
             var processor = new GPOLocalGroupProcessor(mockLDAPUtils.Object);
-            var testGPLinkProperty0 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;]";
-            var testGPLinkProperty1 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;0;]";
-            var testGPLinkProperty2 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somethirddomain;0;]";
-            var testGPLinkProperty3 = "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somefourthdomain;0;]";
+            var testGPLinkProperty0 = "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somedomain;0]";
+            var testGPLinkProperty1 = "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=someotherdomain;0]";
+            var testGPLinkProperty2 = "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somethirddomain;0]";
+            var testGPLinkProperty3 = "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somefourthdomain;0]";
             
             // Act
             var act0 = await processor.ReadGPOLocalGroups(testGPLinkProperty0, "DC=Testlab,DC=Local");
@@ -330,7 +330,7 @@ namespace CommonLibTest {
             
 
             var testGPLinkProperty =
-                "[LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=somedomain;0;][LDAP:/o=foo/ou=foo Group (ABC123)/cn=foouser (blah)123/dc=someotherdomain;2;]";
+                "[LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=somedomain;0][LDAP://CN={ECAD920E-8EB1-4E31-A80E-DD36367F81F4},CN=Policies,CN=System,DC=someotherdomain;2]";
             var result = await processor.ReadGPOLocalGroups(testGPLinkProperty, null);
             
             //mockLDAPUtils.VerifyAll();

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -260,13 +260,19 @@ namespace CommonLibTest {
         // ---------------------------------------------------------------------------
 
         /// <summary>
-        /// Invokes the private CreateDirectoryEntry method via reflection.
+        /// Invokes the static CreateDirectoryEntry method via reflection.
         /// DirectoryEntry does not connect to the server until properties are accessed,
         /// so the call succeeds even with a fake path.
         /// </summary>
         private static IDirectoryObject InvokeCreateDirectoryEntry(LdapUtils utils, string path) {
-            return TestPrivateMethod.InstanceMethod<IDirectoryObject>(utils, "CreateDirectoryEntry",
-                new object[] { path });
+            // Extract the LdapConfig from the LdapUtils instance via reflection.
+            var configField = typeof(LdapUtils).GetField("_ldapConfig",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(configField);
+            var config = (LdapConfig)configField.GetValue(utils);
+
+            return TestPrivateMethod.StaticMethod<IDirectoryObject>(typeof(LdapUtils),
+                "CreateDirectoryEntry", new object[] { path, config });
         }
 
         /// <summary>

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.DirectoryServices;
+using System.DirectoryServices.AccountManagement;
 using System.DirectoryServices.ActiveDirectory;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -431,6 +432,102 @@ namespace CommonLibTest {
 
             Assert.Equal("testuser", entry.Username);
             Assert.Equal("LDAP://domain.com", entry.Path);
+        }
+
+        #endregion
+
+        #region BuildPrincipalContextParameters Tests
+
+        // ---------------------------------------------------------------------------
+        // contextName – no server configured
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void BuildPrincipalContextParameters_NoServer_NoDomain_ContextNameIsNull() {
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(new LdapConfig());
+            Assert.Null(contextName);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_NoServer_DomainProvided_ContextNameIsDomain() {
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(new LdapConfig(), "testlab.local");
+            Assert.Equal("testlab.local", contextName);
+        }
+
+        // ---------------------------------------------------------------------------
+        // contextName – server configured
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ServerSet_DefaultPort_ContextNameIsServerOnly() {
+            var config = new LdapConfig { Server = "dc01.corp.com" };
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(config);
+            Assert.Equal("dc01.corp.com", contextName);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ServerSet_CustomPort_ContextNameIncludesPort() {
+            var config = new LdapConfig { Server = "dc01.corp.com", Port = 3636 };
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(config);
+            Assert.Equal("dc01.corp.com:3636", contextName);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ServerSet_DomainIgnoredWhenServerPresent() {
+            // The domain name should be ignored when a server is explicitly configured.
+            var config = new LdapConfig { Server = "dc01.corp.com" };
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(config, "testlab.local");
+            Assert.Equal("dc01.corp.com", contextName);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ServerSet_ForceSSL_DefaultSSLPort_ContextNameIsServerOnly() {
+            var config = new LdapConfig { Server = "dc01.corp.com", ForceSSL = true };
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(config);
+            Assert.Equal("dc01.corp.com", contextName);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ServerSet_ForceSSL_CustomSSLPort_ContextNameIncludesPort() {
+            var config = new LdapConfig { Server = "dc01.corp.com", ForceSSL = true, SSLPort = 1636 };
+            var (contextName, _) = LdapUtils.BuildPrincipalContextParameters(config);
+            Assert.Equal("dc01.corp.com:1636", contextName);
+        }
+
+        // ---------------------------------------------------------------------------
+        // ContextOptions – mirroring connection pool's mutual-exclusion rule
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void BuildPrincipalContextParameters_Default_HasNegotiateSigningAndSealing() {
+            var (_, options) = LdapUtils.BuildPrincipalContextParameters(new LdapConfig());
+            var expected = ContextOptions.Negotiate | ContextOptions.Signing | ContextOptions.Sealing;
+            Assert.Equal(expected, options);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ForceSSL_HasNegotiateAndSSLOnly_NoSigningOrSealing() {
+            var config = new LdapConfig { ForceSSL = true };
+            var (_, options) = LdapUtils.BuildPrincipalContextParameters(config);
+            var expected = ContextOptions.Negotiate | ContextOptions.SecureSocketLayer;
+            Assert.Equal(expected, options);
+            Assert.Equal((ContextOptions)0, options & ContextOptions.Signing);
+            Assert.Equal((ContextOptions)0, options & ContextOptions.Sealing);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_DisableSigning_HasNegotiateOnly() {
+            var config = new LdapConfig { DisableSigning = true };
+            var (_, options) = LdapUtils.BuildPrincipalContextParameters(config);
+            Assert.Equal(ContextOptions.Negotiate, options);
+        }
+
+        [Fact]
+        public void BuildPrincipalContextParameters_ForceSSLAndDisableSigning_HasNegotiateAndSSLOnly() {
+            var config = new LdapConfig { ForceSSL = true, DisableSigning = true };
+            var (_, options) = LdapUtils.BuildPrincipalContextParameters(config);
+            var expected = ContextOptions.Negotiate | ContextOptions.SecureSocketLayer;
+            Assert.Equal(expected, options);
         }
 
         #endregion

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -307,7 +307,7 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com/domain.com", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com", entry.Path);
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com:3636/domain.com", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com:3636/DC=domain,DC=com", entry.Path);
         }
 
         [Fact]
@@ -329,7 +329,7 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com/domain.com", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com", entry.Path);
         }
 
         [Fact]
@@ -340,7 +340,7 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com:1636/domain.com", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com:1636/DC=domain,DC=com", entry.Path);
         }
 
         [Fact]
@@ -362,7 +362,78 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com/RootDSE");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com/domain.com/RootDSE", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com/RootDSE", entry.Path);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Path construction – domain-shortcut edge cases
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_SingleLabelDomain_ConvertedToSingleDCPart() {
+            // A domain name with no dots (e.g. a NetBIOS-style name) should become "DC=<name>".
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://corp");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/DC=corp", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_ExistingDNPath_ServerInjectedWithoutConversion() {
+            // When the path already carries a proper DN (contains '=') it must be forwarded
+            // verbatim after the server – no DC= conversion should be applied.
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://DC=domain,DC=com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com", entry.Path);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Path construction – double injection guard
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_PathAlreadyHasServer_NotInjectedAgain() {
+            // If the path already begins with LDAP://<server>/ the server must not be
+            // prepended a second time.
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://dc01.corp.com/DC=domain,DC=com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_CustomPort_PathAlreadyHasServerWithPort_NotInjectedAgain() {
+            // Same guard when the path already carries the server with a non-default port.
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com", Port = 3636 });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://dc01.corp.com:3636/DC=domain,DC=com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com:3636/DC=domain,DC=com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_PathAlreadyHasServerWithRootDSE_NotInjectedAgain() {
+            // The guard must fire even when the path component after the server is not a DN
+            // (e.g. the special "RootDSE" target used by GetNamingContextPath).
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://dc01.corp.com/RootDSE");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/RootDSE", entry.Path);
         }
 
         // ---------------------------------------------------------------------------
@@ -432,6 +503,7 @@ namespace CommonLibTest {
 
             Assert.Equal("testuser", entry.Username);
             Assert.Equal("LDAP://domain.com", entry.Path);
+            Assert.Equal(AuthenticationTypes.Secure | AuthenticationTypes.Signing | AuthenticationTypes.Sealing, entry.AuthenticationType);
         }
 
         #endregion

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.DirectoryServices;
 using System.DirectoryServices.ActiveDirectory;
+using System.Reflection;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using CommonLibTest.Facades;
@@ -249,6 +251,189 @@ namespace CommonLibTest {
             Assert.Equal("TESTLAB.LOCAL", result.Domain);
             Assert.False(result.Deleted);
         }
+
+        #region CreateDirectoryEntry Tests
+
+        // ---------------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Invokes the private CreateDirectoryEntry method via reflection.
+        /// DirectoryEntry does not connect to the server until properties are accessed,
+        /// so the call succeeds even with a fake path.
+        /// </summary>
+        private static IDirectoryObject InvokeCreateDirectoryEntry(LdapUtils utils, string path) {
+            return TestPrivateMethod.InstanceMethod<IDirectoryObject>(utils, "CreateDirectoryEntry",
+                new object[] { path });
+        }
+
+        /// <summary>
+        /// Extracts the underlying DirectoryEntry from its DirectoryEntryWrapper so that
+        /// Path and AuthenticationType can be inspected without triggering a network call.
+        /// </summary>
+        private static DirectoryEntry ExtractDirectoryEntry(IDirectoryObject directoryObject) {
+            var entryField = directoryObject.GetType()
+                .GetField("_entry", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(entryField);
+            return (DirectoryEntry)entryField.GetValue(directoryObject);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Path construction – no server configured
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_NoServer_PathIsUnchanged() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig());
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://domain.com", entry.Path);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Path construction – server configured
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_DefaultPort_InjectsServerWithoutPort() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/domain.com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_CustomPort_InjectsServerWithPort() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com", Port = 3636 });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com:3636/domain.com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_ForceSSL_DefaultSSLPort_InjectsServerWithoutPort() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com", ForceSSL = true });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/domain.com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_ForceSSL_CustomSSLPort_InjectsServerWithPort() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com", ForceSSL = true, SSLPort = 1636 });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com:1636/domain.com", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_SIDPath_InjectsServerBeforeSIDMoniiker() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://<SID=S-1-5-21-123>");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/<SID=S-1-5-21-123>", entry.Path);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ServerSet_RootDSEPath_InjectsServerBeforeSuffix() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Server = "dc01.corp.com" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com/RootDSE");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("LDAP://dc01.corp.com/domain.com/RootDSE", entry.Path);
+        }
+
+        // ---------------------------------------------------------------------------
+        // AuthenticationTypes – matching connection pool logic
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_Default_HasSecureSigningAndSealing() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig()); // ForceSSL=false, DisableSigning=false
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            var expected = AuthenticationTypes.Secure | AuthenticationTypes.Signing | AuthenticationTypes.Sealing;
+            Assert.Equal(expected, entry.AuthenticationType);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ForceSSL_HasSecureSSLOnly_NoSigningOrSealing() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { ForceSSL = true });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            var expected = AuthenticationTypes.Secure | AuthenticationTypes.SecureSocketsLayer;
+            Assert.Equal(expected, entry.AuthenticationType);
+            Assert.Equal(AuthenticationTypes.None, entry.AuthenticationType & AuthenticationTypes.Signing);
+            Assert.Equal(AuthenticationTypes.None, entry.AuthenticationType & AuthenticationTypes.Sealing);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_DisableSigning_HasSecureOnly() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { DisableSigning = true });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal(AuthenticationTypes.Secure, entry.AuthenticationType);
+        }
+
+        [Fact]
+        public void CreateDirectoryEntry_ForceSSLAndDisableSigning_HasSecureSSLOnly() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { ForceSSL = true, DisableSigning = true });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            var expected = AuthenticationTypes.Secure | AuthenticationTypes.SecureSocketsLayer;
+            Assert.Equal(expected, entry.AuthenticationType);
+        }
+
+        // ---------------------------------------------------------------------------
+        // Credentials
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void CreateDirectoryEntry_WithCredentials_UsernameAndPasswordApplied() {
+            var utils = new LdapUtils();
+            utils.SetLdapConfig(new LdapConfig { Username = "testuser", Password = "testpass" });
+
+            var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com");
+            var entry = ExtractDirectoryEntry(result);
+
+            Assert.Equal("testuser", entry.Username);
+            Assert.Equal("LDAP://domain.com", entry.Path);
+        }
+
+        #endregion
 
         [Fact]
         public async Task Test_ResolveHostToSid_BlankHost() {

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -362,7 +362,7 @@ namespace CommonLibTest {
             var result = InvokeCreateDirectoryEntry(utils, "LDAP://domain.com/RootDSE");
             var entry = ExtractDirectoryEntry(result);
 
-            Assert.Equal("LDAP://dc01.corp.com/DC=domain,DC=com/RootDSE", entry.Path);
+            Assert.Equal("LDAP://dc01.corp.com/RootDSE", entry.Path);
         }
 
         // ---------------------------------------------------------------------------

--- a/test/unit/LDAPUtilsTest.cs
+++ b/test/unit/LDAPUtilsTest.cs
@@ -271,7 +271,7 @@ namespace CommonLibTest {
             Assert.NotNull(configField);
             var config = (LdapConfig)configField.GetValue(utils);
 
-            return TestPrivateMethod.StaticMethod<IDirectoryObject>(typeof(LdapUtils),
+            return TestPrivateMethod.StaticMethod<IDirectoryObject>(typeof(Helpers),
                 "CreateDirectoryEntry", new object[] { path, config });
         }
 


### PR DESCRIPTION
## Description
PrincipalContext and DirectoryEntry calls all support the majority of our configuration options in the LDAPConfig, they just needed to be wired correctly. Also fixes some edge cases in DistinguishedNameToDomain.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: [GitHub issue or Jira ticket number]

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [ ] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * More consistent LDAP server targeting and port handling (including non-default ports).
  * Improved SSL vs signing/sealing option composition to avoid conflicting security settings.
  * More reliable application of credentials when establishing directory connections.
  * Revised distinguished-name → domain extraction for more accurate domain resolution.
  * Added utilities to compute directory/context binding parameters and server targets.

* **Tests**
  * Added extensive unit tests covering path rewriting, auth flag combinations, domain parsing, and credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->