### PR TITLE
chore: update specterops nuget source to shcommon-nuget BED-8241

### DIFF
--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,6 +45,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
+          sleet recreate
 #          sleet push ./pkgs
 
       #the prune command deletes older -dev package versions to avoid clutter

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,7 +45,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
+          sleet recreate
           sleet push ./pkgs
+          sleet validate
 
       #the prune command deletes older -dev package versions to avoid clutter
       #it deletes any versions of the $packageIds with "-dev" that are older than the last $maxDevVersions

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,7 +45,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
-          sleet recreate
+          sleet recreate --force
 #          sleet push ./pkgs
 
       #the prune command deletes older -dev package versions to avoid clutter

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,10 +45,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
-          sleet push ./pkgs
+#          sleet push ./pkgs
 
       #the prune command deletes older -dev package versions to avoid clutter
-      #it deletes any versions of the $packageIds with "-dev" that are older than the first $maxDevVersions
+      #it deletes any versions of the $packageIds with "-dev" that are older than the last $maxDevVersions
       #set $dryRun to true for debugging without deleting any packages
       - name: Prune old -dev packages
         env:

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,8 +45,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
-          sleet recreate --force
-#          sleet push ./pkgs
+          sleet push ./pkgs
 
       #the prune command deletes older -dev package versions to avoid clutter
       #it deletes any versions of the $packageIds with "-dev" that are older than the last $maxDevVersions

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -3,8 +3,7 @@ name: Publish Dev Package
 on:
   push:
     branches:
-      - "lfalslev/bed-8241"
-      #- "v4"
+      - "v4"
 
 jobs:
   update-dev-package:
@@ -56,7 +55,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         shell: pwsh
         run: |
-          $dryRun = $true
+          $dryRun = $false
           $packageIndexUrl = 'https://s3.amazonaws.com/shcommon-nuget/sleet.packageindex.json'
           $packageIds = @('SharpHoundCommon', 'SharpHoundRPC')
           $maxDevVersions = 5

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -3,7 +3,8 @@ name: Publish Dev Package
 on:
   push:
     branches:
-      - "v4"
+      - "lfalslev/bed-8241"
+      #- "v4"
 
 jobs:
   update-dev-package:
@@ -55,8 +56,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         shell: pwsh
         run: |
-          $dryRun = $false
-          $packageIndexUrl = 'https://s3.amazonaws.com/bloodhound-ad/sleet.packageindex.json'
+          $dryRun = $true
+          $packageIndexUrl = 'https://s3.amazonaws.com/shcommon-nuget/sleet.packageindex.json'
           $packageIds = @('SharpHoundCommon', 'SharpHoundRPC')
           $maxDevVersions = 5
           

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -45,9 +45,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run: |
           dotnet tool install -g sleet
-          sleet recreate
           sleet push ./pkgs
-          sleet validate
 
       #the prune command deletes older -dev package versions to avoid clutter
       #it deletes any versions of the $packageIds with "-dev" that are older than the last $maxDevVersions

--- a/sleet.json
+++ b/sleet.json
@@ -3,9 +3,9 @@
     {
       "name": "feed",
       "type": "s3",
-      "path": "https://s3.amazonaws.com/bloodhound-ad",
+      "path": "https://s3.amazonaws.com/shcommon-nuget",
       "region": "us-east-1",
-      "bucketName": "bloodhound-ad"
+      "bucketName": "shcommon-nuget"
     }
   ]
 }


### PR DESCRIPTION
## Description
Old bloodhound-ad s3 bucket has been replaced with new shcommon-nuget bucket for the specterops nuget feed. This updates sleet config and github workflows to use new the new feed.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: [BED-8241](https://specterops.atlassian.net/browse/BED-8241)

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->
Ran `sleet validate` and tested publishing and pruning -dev packages to feed. 

## Screenshots (if appropriate):
<img width="443" height="344" alt="image" src="https://github.com/user-attachments/assets/843c2a14-9bf1-4b9c-a8fc-58e268111657" />
<img width="1070" height="878" alt="Screenshot_2026-05-08_09-55-13" src="https://github.com/user-attachments/assets/e00da791-558c-4365-ad61-bbe26da7fb51" />

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-8241]: https://specterops.atlassian.net/browse/BED-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package publishing workflow to point at an alternate NuGet package source.
  * Updated package feed configuration to use the new S3 package bucket.
  * Clarified package cleanup behavior to prune older dev-package versions relative to the most recent releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->