### PR TITLE
fix: AllowedToDelegate Edge not getting created when user has msDS-AllowedToDelegateTo values BED-7625

### DIFF
--- a/src/CommonLib/Processors/LdapPropertyProcessor.cs
+++ b/src/CommonLib/Processors/LdapPropertyProcessor.cs
@@ -271,8 +271,7 @@ namespace SharpHoundCommonLib.Processors {
                 userProps.UnconstrainedDelegation = uacFlags.HasFlag(UacFlags.TrustedForDelegation);
                 
                 var comps = new List<TypedPrincipal>();
-                if (uacFlags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
-                    entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
+                if (entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
                     props.Add("allowedtodelegate", delegates);
 
                     foreach (var d in delegates) {
@@ -390,8 +389,7 @@ namespace SharpHoundCommonLib.Processors {
             props.Add("admincount", ac != 0);
 
             var comps = new List<TypedPrincipal>();
-            if (flags.HasFlag(UacFlags.TrustedToAuthForDelegation) &&
-                entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
+            if (entry.TryGetArrayProperty(LDAPProperties.AllowedToDelegateTo, out var delegates)) {
                 props.Add("allowedtodelegate", delegates);
 
                 foreach (var d in delegates) {

--- a/test/unit/LdapPropertyTests.cs
+++ b/test/unit/LdapPropertyTests.cs
@@ -1448,7 +1448,7 @@ namespace CommonLibTest
                 new Dictionary<string, object>
                 {
                     {"description", "Test"},
-                    {"useraccountcontrol", 0x1000000.ToString()},
+                    {"useraccountcontrol", 0x200.ToString()},
                     {LDAPProperties.LastLogon, "132673011142753043"},
                     {LDAPProperties.LastLogonTimestamp, "132670318095676525"},
                     {"homedirectory", @"\\win10\testdir"},
@@ -1507,7 +1507,7 @@ namespace CommonLibTest
                 new Dictionary<string, object>
                 {
                     {"description", "Test"},
-                    {"useraccountcontrol", 0x1001000.ToString()},
+                    {"useraccountcontrol", 0x1000.ToString()},
                     {"lastlogon", "132673011142753043"},
                     {"lastlogontimestamp", "132670318095676525"},
                     {"operatingsystem", "Windows 10 Enterprise"},


### PR DESCRIPTION
## Description
Removed the `TrustedToAuthForDelegation` flag check from both `ReadUserProperties` and `ReadComputerProperties`, so `AllowedToDelegate` edges are emitted whenever `msDS-AllowedToDelegateTo` is populated.
Updated tests to allow UAC flag check for `TrustedToAuthForDelegation` to be false.

## Motivation and Context
If a user or computer has `msDS-AllowedToDelegateTo` populated, it doesn’t matter if `TrustedForDelegation` or `TrustedToAuthForDelegation`  is true or false, there should be an AllowedToDelegate edge drawn from the user/computer to the destination computer

This PR addresses: [BED-7625](https://specterops.atlassian.net/browse/BED-7625)

## How Has This Been Tested?
Tested in GOAD lab
Testing Instructions on ticket https://specterops.atlassian.net/browse/BED-7625

## Screenshots (if appropriate):
<img width="2427" height="1293" alt="image" src="https://github.com/user-attachments/assets/ec908760-e3c6-4307-8b92-ca12dc0bcb19" />


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a change that does not modify the application functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-7625]: https://specterops.atlassian.net/browse/BED-7625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ