### PR TITLE
chore: bump version to 4.7.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore -p:BuildDocFx=false
 
       - name: Test
         run: dotnet test --no-build

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Pack
         run: |
           mkdir pkgs
-          dotnet pack --no-restore -c Release -p:PackageVersion=${{ steps.version.outputs.dev_version }} -o ./pkgs
+          dotnet pack --no-restore -c Release -p:BuildDocFx=false -p:PackageVersion=${{ steps.version.outputs.result }} -o ./pkgs
 
       - name: Publish to SpecterOps Packages
         env:

--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Pack
         run: |
           mkdir pkgs
-          dotnet pack --no-restore -c Release -p:BuildDocFx=false -p:PackageVersion=${{ steps.version.outputs.result }} -o ./pkgs
+          dotnet pack --no-restore -c Release -p:BuildDocFx=false -p:PackageVersion=${{ steps.version.outputs.dev_version }} -o ./pkgs
 
       - name: Publish to SpecterOps Packages
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Pack
         run: |
           mkdir pkgs
-          dotnet pack --no-restore -c Release -p:PackageVersion=${{ steps.version.outputs.result }} -o ./pkgs
+          dotnet pack --no-restore -c Release -p:BuildDocFx=false -p:PackageVersion=${{ steps.version.outputs.result }} -o ./pkgs
 
         #      - name: Prep Packages
         #        run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/BloodHoundAD/index.json"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <Company>SpecterOps</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/SpecterOps/SharpHoundCommon</RepositoryUrl>
-        <Version>4.6.2</Version>
+        <Version>4.7.0</Version>
     </PropertyGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Description
Bump version for SH 2.14.0

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

This PR addresses: [BED-9000](https://specterops.atlassian.net/browse/BED-9000)

## How Has This Been Tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.*
-->

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a change that does not modify the application functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!-- Please make sure you have completed all following checks. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have met the contributing prerequisites
  - Assigned myself to this PR
  - Added the appropriate labels
  - Associated an issue: https://github.com/SpecterOps/BloodHound/issues/672
  - Read the Contributing guide: https://github.com/SpecterOps/BloodHound/wiki/Contributing
- [x] I have ensured that related documentation is up-to-date
  - Open API docs
  - Code comments
- [x] I have followed proper test practices
  - Added/updated tests to cover my changes
  - All new and existing tests passed


[BED-9000]: https://specterops.atlassian.net/browse/BED-9000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application package version from **4.6.2** to **4.7.0**.
* **Build & Release**
  * Updated build and packaging pipelines to **disable DocFX documentation generation** during `dotnet build`/`dotnet pack`.
  * Kept development package packing aligned with the versioning output produced by the workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->